### PR TITLE
fix: made json_like_output inline to avoid collisions

### DIFF
--- a/include/async_mqtt/util/json_like_out.hpp
+++ b/include/async_mqtt/util/json_like_out.hpp
@@ -63,7 +63,7 @@ inline std::ostream& operator<<(std::ostream& o, json_like_out_t const& v) {
     return o;
 }
 
-json_like_out_t inline json_like_out(buffer const& buf) {
+inline json_like_out_t json_like_out(buffer const& buf) {
     return json_like_out_t{buf};
 }
 

--- a/include/async_mqtt/util/json_like_out.hpp
+++ b/include/async_mqtt/util/json_like_out.hpp
@@ -63,7 +63,7 @@ inline std::ostream& operator<<(std::ostream& o, json_like_out_t const& v) {
     return o;
 }
 
-json_like_out_t json_like_out(buffer const& buf) {
+json_like_out_t inline json_like_out(buffer const& buf) {
     return json_like_out_t{buf};
 }
 


### PR DESCRIPTION
I found that `json_like_output` function collides with itself when trying to include `all.hpp` into multiple source files.
So, I made it `inline`.