### PR TITLE
Removed certificate interval for broker.

### DIFF
--- a/test/system/st_broker.conf
+++ b/test/system/st_broker.conf
@@ -20,12 +20,6 @@ iocs=1
 # min(4 or Num of vCPU)
 threads_per_ioc=1
 
-# Reload interval for the certificate and private key files (hours)
-# When configured the broker will perform  automatic loading of
-# cert/key update. If not set or set to 0 (default), then no
-# reloading is performed.
-# certificate_reload_interval=24
-
 # Configuration for TCP
 [tcp]
 port=1883

--- a/tool/broker.conf
+++ b/tool/broker.conf
@@ -19,12 +19,6 @@ iocs=0
 # min(4 or Num of vCPU)
 threads_per_ioc=0
 
-# Reload interval for the certificate and private key files (hours)
-# When configured the broker will perform  automatic loading of
-# cert/key update. If not set or set to 0 (default), then no
-# reloading is performed.
-# certificate_reload_interval=24
-
 # Configuration for TCP
 [tcp]
 port=1883

--- a/tool/broker.cpp
+++ b/tool/broker.cpp
@@ -631,11 +631,6 @@ int main(int argc, char *argv[]) {
                 "Field to be used from certificate for authenticating clients"
             )
             (
-                "certificate_reload_interval",
-                boost::program_options::value<unsigned int>()->default_value(0),
-                "Reload interval for the certificate and private key files (hours)\n 0 - Disabled"
-            )
-            (
                 "auth_file",
                 boost::program_options::value<std::string>(),
                 "Authentication file"


### PR DESCRIPTION
It is no longer required because for each accept, ssl::context is newly created. So if certificate and key are updated, then it reflects from the next accept.

NOTE: Even if timer is used, accepting certificate is not updated. It reflects from the next accept. So this fix has no disadvantage.