### PR TITLE
Fixed bench.

### DIFF
--- a/docker/conf/bench.conf
+++ b/docker/conf/bench.conf
@@ -1,10 +1,18 @@
+## mode settings
+# [single|send|recv] single is default.
+# single: measure RTT by single bench process
+# recv  : only receive publish packet and measure RTT
+# send  : only publish packet that contains timestamp
+mode=single
+
 ## connection settings
 
-# hostname or IP address of the target broker
-host=localhost
-
-# MQTT typical port is 1883. MQTTS typical port is 8883
-port=1883
+# mqtt broker's hostname:port to connect. when you set this option  multiple times,
+# then connect round robin for each client.
+# Note for each 'target=' has one target. You cannot write target=host1:1883 host2:1883,
+# user multiple times target=host:port notation
+target=localhost:1883
+#target 127.0.0.1:1883 # 2nd target
 
 # mqtt, mqtts, ws, or wss
 protocol=mqtt


### PR DESCRIPTION
When using send/recv mode with pub_idle_count != 0, bench was stuck. This PR fix the issue.
Log message became easier to understand.