### PR TITLE
Fixed multiple close problem.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 4.0.0
+### breaking changes
+- Fixed multiple close problem. In order to do that endpoint become shared_ptr based design. #98, #100, #101, #102
+### other updates
+- Refined documents. #97
+- Added TLS async_shutdown timeout. #99
+
 ## 3.0.0
 ### breaking changes
 - Fixed inconsistent function names. #84, #89

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 # http://www.boost.org/LICENSE_1_0.txt)
 
 cmake_minimum_required (VERSION 3.13.0)
-project(async_mqtt_iface VERSION 3.0.0)
+project(async_mqtt_iface VERSION 4.0.0)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -107,7 +107,7 @@ if(DOXYGEN_FOUND)
         COMMAND ${CMAKE_COMMAND} -E echo "FILE_PATTERNS          = *.hpp" >> ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
         COMMAND ${CMAKE_COMMAND} -E echo "OUTPUT_DIRECTORY       = doc" >> ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
         COMMAND ${CMAKE_COMMAND} -E echo "PROJECT_NAME           = async_mqtt" >> ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
-        COMMAND ${CMAKE_COMMAND} -E echo "PROJECT_NUMBER         = 3.0.0" >> ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
+        COMMAND ${CMAKE_COMMAND} -E echo "PROJECT_NUMBER         = 4.0.0" >> ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
         COMMAND ${CMAKE_COMMAND} -E echo "RECURSIVE              = YES" >> ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
         COMMAND ${CMAKE_COMMAND} -E echo "PREDEFINED             = _DOXYGEN_ ASYNC_MQTT_USE_TLS ASYNC_MQTT_USE_WS" >> ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
         COMMAND ${CMAKE_COMMAND} -E echo "INPUT                  = ${CMAKE_CURRENT_SOURCE_DIR}/include/async_mqtt" >> ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Asynchronous MQTT communication library.
 
-Version 3.0.0 [![Actions Status](https://github.com/redboltz/async_mqtt/workflows/CI/badge.svg)](https://github.com/redboltz/async_mqtt/actions)[![codecov](https://codecov.io/gh/redboltz/async_mqtt/branch/main/graph/badge.svg)](https://codecov.io/gh/redboltz/async_mqtt)
+Version 4.0.0 [![Actions Status](https://github.com/redboltz/async_mqtt/workflows/CI/badge.svg)](https://github.com/redboltz/async_mqtt/actions)[![codecov](https://codecov.io/gh/redboltz/async_mqtt/branch/main/graph/badge.svg)](https://codecov.io/gh/redboltz/async_mqtt)
 
 This is Boost.Asio oriented asynchronous MQTT communication library. You can use async_mqtt to develop not only your MQTT client application but also your server (e.g. broker).
 Based on https://github.com/redboltz/mqtt_cpp experience, there are many improvements. See overview.

--- a/example/ep_future_mqtt_client.cpp
+++ b/example/ep_future_mqtt_client.cpp
@@ -24,10 +24,10 @@ int main(int argc, char* argv[]) {
     as::io_context ioc;
     as::ip::tcp::socket resolve_sock{ioc};
     as::ip::tcp::resolver res{resolve_sock.get_executor()};
-    am::endpoint<am::role::client, am::protocol::mqtt> amep {
+    auto amep = am::endpoint<am::role::client, am::protocol::mqtt>::create(
         am::protocol_version::v3_1_1,
         ioc.get_executor()
-    };
+    );
 
     // async_mqtt thread
     auto guard = as::make_work_guard(ioc.get_executor());
@@ -56,7 +56,7 @@ int main(int argc, char* argv[]) {
         auto eps = f_res.get();
 
         auto f_con = as::async_connect(
-            amep.next_layer(),
+            amep->next_layer(),
             eps,
             as::use_future
         );
@@ -65,7 +65,7 @@ int main(int argc, char* argv[]) {
 
         // Send MQTT CONNECT
         {
-            auto fut = amep.send(
+            auto fut = amep->send(
                 am::v3_1_1::connect_packet{
                     true,   // clean_session
                     0x1234, // keep_alive
@@ -85,7 +85,7 @@ int main(int argc, char* argv[]) {
 
         // Recv MQTT CONNACK
         {
-            auto fut = amep.recv(as::use_future);
+            auto fut = amep->recv(as::use_future);
             auto pv = fut.get(); // get am::packet_variant
             if (pv) {
                 pv.visit(
@@ -112,9 +112,9 @@ int main(int argc, char* argv[]) {
 
         // Send MQTT SUBSCRIBE
         {
-            auto fut_id = amep.acquire_unique_packet_id(as::use_future);
+            auto fut_id = amep->acquire_unique_packet_id(as::use_future);
             auto pid = fut_id.get();
-            auto fut = amep.send(
+            auto fut = amep->send(
                 am::v3_1_1::subscribe_packet{
                     *pid,
                     { {am::allocate_buffer("topic1"), am::qos::at_most_once} }
@@ -130,7 +130,7 @@ int main(int argc, char* argv[]) {
 
         // Recv MQTT SUBACK
         {
-            auto fut = amep.recv(as::use_future);
+            auto fut = amep->recv(as::use_future);
             auto pv = fut.get();
             if (pv) {
                 pv.visit(
@@ -160,9 +160,9 @@ int main(int argc, char* argv[]) {
 
         // Send MQTT PUBLISH
         {
-            auto fut_id = amep.acquire_unique_packet_id(as::use_future);
+            auto fut_id = amep->acquire_unique_packet_id(as::use_future);
             auto pid = fut_id.get();
-            auto fut = amep.send(
+            auto fut = amep->send(
                 am::v3_1_1::publish_packet{
                     *pid,
                     am::allocate_buffer("topic1"),
@@ -181,7 +181,7 @@ int main(int argc, char* argv[]) {
         // Recv MQTT PUBLISH and PUBACK (order depends on broker)
         {
             for (std::size_t count = 0; count != 2; ++count) {
-                auto fut =  amep.recv(as::use_future);
+                auto fut =  amep->recv(as::use_future);
                 auto pv = fut.get();
                 if (pv) {
                     pv.visit(
@@ -218,7 +218,7 @@ int main(int argc, char* argv[]) {
         }
         {
             std::cout << "close" << std::endl;
-            auto fut = amep.close(as::use_future);
+            auto fut = amep->close(as::use_future);
             fut.get();
         }
     }

--- a/example/ep_slcoro_mqtt_client.cpp
+++ b/example/ep_slcoro_mqtt_client.cpp
@@ -24,7 +24,7 @@ struct app {
     ):res_{exe},
       host_{std::move(host)},
       port_{std::move(port)},
-      amep_{am::protocol_version::v3_1_1, exe}
+      amep_{am::endpoint<am::role::client, am::protocol::mqtt>::create(am::protocol_version::v3_1_1, exe)}
     {
         impl_();
     }
@@ -73,7 +73,7 @@ private:
 
                 // Underlying TCP connect
                 yield as::async_connect(
-                    app_.amep_.next_layer(),
+                    app_.amep_->next_layer(),
                     *eps,
                     *this
                 );
@@ -85,7 +85,7 @@ private:
                 if (ec) return;
 
                 // Send MQTT CONNECT
-                yield app_.amep_.send(
+                yield app_.amep_->send(
                     am::v3_1_1::connect_packet{
                         true,   // clean_session
                         0x1234, // keep_alive
@@ -102,7 +102,7 @@ private:
                 }
 
                 // Recv MQTT CONNACK
-                yield app_.amep_.recv(*this);
+                yield app_.amep_->recv(*this);
                 if (pv) {
                     pv.visit(
                         am::overload {
@@ -125,9 +125,9 @@ private:
                 }
 
                 // Send MQTT SUBSCRIBE
-                yield app_.amep_.send(
+                yield app_.amep_->send(
                     am::v3_1_1::subscribe_packet{
-                        *app_.amep_.acquire_unique_packet_id(),
+                        *app_.amep_->acquire_unique_packet_id(),
                         { {am::allocate_buffer("topic1"), am::qos::at_most_once} }
                     },
                     *this
@@ -137,7 +137,7 @@ private:
                     return;
                 }
                 // Recv MQTT SUBACK
-                yield app_.amep_.recv(*this);
+                yield app_.amep_->recv(*this);
                 if (pv) {
                     pv.visit(
                         am::overload {
@@ -163,9 +163,9 @@ private:
                     return;
                 }
                 // Send MQTT PUBLISH
-                yield app_.amep_.send(
+                yield app_.amep_->send(
                     am::v3_1_1::publish_packet{
-                        *app_.amep_.acquire_unique_packet_id(),
+                        *app_.amep_->acquire_unique_packet_id(),
                         am::allocate_buffer("topic1"),
                         am::allocate_buffer("payload1"),
                         am::qos::at_least_once
@@ -178,7 +178,7 @@ private:
                 }
                 // Recv MQTT PUBLISH and PUBACK (order depends on broker)
                 for (app_.count_ = 0; app_.count_ != 2; ++app_.count_) {
-                    yield app_.amep_.recv(*this);
+                    yield app_.amep_->recv(*this);
                     if (pv) {
                         pv.visit(
                             am::overload {
@@ -212,7 +212,7 @@ private:
                     }
                 }
                 std::cout << "close" << std::endl;
-                yield app_.amep_.close(*this);
+                yield app_.amep_->close(*this);
             }
         }
 
@@ -224,7 +224,7 @@ private:
     as::ip::tcp::resolver res_;
     std::string_view host_;
     std::string_view port_;
-    am::endpoint<am::role::client, am::protocol::mqtt> amep_;
+    std::shared_ptr<am::endpoint<am::role::client, am::protocol::mqtt>> amep_;
     std::size_t count_ = 0;
     impl impl_{*this};
 };

--- a/example/ep_slcoro_mqtts_client.cpp
+++ b/example/ep_slcoro_mqtts_client.cpp
@@ -24,7 +24,11 @@ struct app {
     ):res_{exe},
       host_{std::move(host)},
       port_{std::move(port)},
-      amep_{am::protocol_version::v3_1_1, exe, ctx_}
+      amep_{
+          am::endpoint<am::role::client, am::protocol::mqtts>::create(
+              am::protocol_version::v3_1_1, exe, ctx_
+          )
+      }
     {
         ctx_.set_verify_mode(am::tls::verify_none);
         impl_();
@@ -74,7 +78,7 @@ private:
 
                 // Underlying TCP connect
                 yield as::async_connect(
-                    app_.amep_.lowest_layer(),
+                    app_.amep_->lowest_layer(),
                     *eps,
                     *this
                 );
@@ -86,7 +90,7 @@ private:
                 if (ec) return;
 
                 // Underlying TLS handshake
-                yield app_.amep_.next_layer().async_handshake(
+                yield app_.amep_->next_layer().async_handshake(
                     am::tls::stream_base::client,
                     *this
                 );
@@ -96,7 +100,7 @@ private:
                     << std::endl;
 
                 // Send MQTT CONNECT
-                yield app_.amep_.send(
+                yield app_.amep_->send(
                     am::v3_1_1::connect_packet{
                         true,   // clean_session
                         0x1234, // keep_alive
@@ -113,7 +117,7 @@ private:
                 }
 
                 // Recv MQTT CONNACK
-                yield app_.amep_.recv(*this);
+                yield app_.amep_->recv(*this);
                 if (pv) {
                     pv.visit(
                         am::overload {
@@ -136,9 +140,9 @@ private:
                 }
 
                 // Send MQTT SUBSCRIBE
-                yield app_.amep_.send(
+                yield app_.amep_->send(
                     am::v3_1_1::subscribe_packet{
-                        *app_.amep_.acquire_unique_packet_id(),
+                        *app_.amep_->acquire_unique_packet_id(),
                         { {am::allocate_buffer("topic1"), am::qos::at_most_once} }
                     },
                     *this
@@ -148,7 +152,7 @@ private:
                     return;
                 }
                 // Recv MQTT SUBACK
-                yield app_.amep_.recv(*this);
+                yield app_.amep_->recv(*this);
                 if (pv) {
                     pv.visit(
                         am::overload {
@@ -174,9 +178,9 @@ private:
                     return;
                 }
                 // Send MQTT PUBLISH
-                yield app_.amep_.send(
+                yield app_.amep_->send(
                     am::v3_1_1::publish_packet{
-                        *app_.amep_.acquire_unique_packet_id(),
+                        *app_.amep_->acquire_unique_packet_id(),
                         am::allocate_buffer("topic1"),
                         am::allocate_buffer("payload1"),
                         am::qos::at_least_once
@@ -189,7 +193,7 @@ private:
                 }
                 // Recv MQTT PUBLISH and PUBACK (order depends on broker)
                 for (app_.count_ = 0; app_.count_ != 2; ++app_.count_) {
-                    yield app_.amep_.recv(*this);
+                    yield app_.amep_->recv(*this);
                     if (pv) {
                         pv.visit(
                             am::overload {
@@ -223,7 +227,7 @@ private:
                     }
                 }
                 std::cout << "close" << std::endl;
-                yield app_.amep_.close(*this);
+                yield app_.amep_->close(*this);
             }
         }
 
@@ -236,7 +240,7 @@ private:
     std::string_view host_;
     std::string_view port_;
     am::tls::context ctx_{am::tls::context::tlsv12};
-    am::endpoint<am::role::client, am::protocol::mqtts> amep_;
+    std::shared_ptr<am::endpoint<am::role::client, am::protocol::mqtts>> amep_;
     std::size_t count_ = 0;
     impl impl_{*this};
 };

--- a/include/async_mqtt/util/ioc_queue.hpp
+++ b/include/async_mqtt/util/ioc_queue.hpp
@@ -46,10 +46,16 @@ public:
         return queue_.stopped();
     }
 
-    void poll_one() {
+    std::size_t poll_one() {
         working_ = false;
         if (queue_.stopped()) queue_.restart();
-        queue_.poll_one();
+        return queue_.poll_one();
+    }
+
+    std::size_t poll() {
+        working_ = false;
+        if (queue_.stopped()) queue_.restart();
+        return queue_.poll();
     }
 
 private:

--- a/include/async_mqtt/util/make_shared_helper.hpp
+++ b/include/async_mqtt/util/make_shared_helper.hpp
@@ -1,0 +1,37 @@
+// Copyright Takatoshi Kondo 2022
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(ASYNC_MQTT_UTIL_MAKE_SHARED_HELPER_HPP)
+#define ASYNC_MQTT_UTIL_MAKE_SHARED_HELPER_HPP
+
+#include <memory>
+
+namespace async_mqtt {
+
+template <typename T>
+class make_shared_helper {
+    friend T;
+    struct target : public T {
+        template<typename... Args>
+        target(Args&&... args)
+            :T{std::forward<Args>(args)...}
+        {}
+    };
+
+    template <typename... Args>
+    static std::shared_ptr<T> make_shared(Args&&... args) {
+        return std::make_shared<target>(std::forward<Args>(args)...);
+    }
+
+    template<typename Alloc, typename... Args>
+    static std::shared_ptr<T> allocate_shared(Alloc const& alloc, Args&&... args) {
+        return std::allocate_shared<target>(alloc, std::forward<Args>(args)...);
+    }
+};
+
+} // namespace async_mqtt
+
+#endif // ASYNC_MQTT_UTIL_MAKE_SHARED_HELPER_HPP

--- a/test/system/st_auth.cpp
+++ b/test/system/st_auth.cpp
@@ -21,7 +21,7 @@ BOOST_AUTO_TEST_CASE(fail_plain) {
     broker_runner br;
     as::io_context ioc;
     using ep_t = am::endpoint<am::role::client, am::protocol::mqtt>;
-    auto amep = ep_t(
+    auto amep = ep_t::create(
         am::protocol_version::v3_1_1,
         ioc.get_executor()
     );
@@ -71,7 +71,7 @@ BOOST_AUTO_TEST_CASE(fail_plain) {
         }
     };
 
-    tc t{amep, "127.0.0.1", 1883};
+    tc t{*amep, "127.0.0.1", 1883};
     t();
     ioc.run();
     BOOST_TEST(t.finish());
@@ -81,7 +81,7 @@ BOOST_AUTO_TEST_CASE(success_digest) {
     broker_runner br;
     as::io_context ioc;
     using ep_t = am::endpoint<am::role::client, am::protocol::mqtt>;
-    auto amep = ep_t(
+    auto amep = ep_t::create(
         am::protocol_version::v3_1_1,
         ioc.get_executor()
     );
@@ -131,7 +131,7 @@ BOOST_AUTO_TEST_CASE(success_digest) {
         }
     };
 
-    tc t{amep, "127.0.0.1", 1883};
+    tc t{*amep, "127.0.0.1", 1883};
     t();
     ioc.run();
     BOOST_TEST(t.finish());
@@ -141,7 +141,7 @@ BOOST_AUTO_TEST_CASE(fail_digest) {
     broker_runner br;
     as::io_context ioc;
     using ep_t = am::endpoint<am::role::client, am::protocol::mqtt>;
-    auto amep = ep_t(
+    auto amep = ep_t::create(
         am::protocol_version::v3_1_1,
         ioc.get_executor()
     );
@@ -191,7 +191,7 @@ BOOST_AUTO_TEST_CASE(fail_digest) {
         }
     };
 
-    tc t{amep, "127.0.0.1", 1883};
+    tc t{*amep, "127.0.0.1", 1883};
     t();
     ioc.run();
     BOOST_TEST(t.finish());
@@ -201,7 +201,7 @@ BOOST_AUTO_TEST_CASE(send_auth) {
     broker_runner br;
     as::io_context ioc;
     using ep_t = am::endpoint<am::role::client, am::protocol::mqtt>;
-    auto amep = ep_t(
+    auto amep = ep_t::create(
         am::protocol_version::v5,
         ioc.get_executor()
     );
@@ -258,7 +258,7 @@ BOOST_AUTO_TEST_CASE(send_auth) {
         }
     };
 
-    tc t{amep, "127.0.0.1", 1883};
+    tc t{*amep, "127.0.0.1", 1883};
     t();
     ioc.run();
     BOOST_TEST(t.finish());

--- a/test/system/st_conflict_cid.cpp
+++ b/test/system/st_conflict_cid.cpp
@@ -21,11 +21,11 @@ BOOST_AUTO_TEST_CASE(v311_cs1to1) {
     broker_runner br;
     as::io_context ioc;
     using ep_t = am::endpoint<am::role::client, am::protocol::mqtt>;
-    auto amep1 = ep_t(
+    auto amep1 = ep_t::create(
         am::protocol_version::v3_1_1,
         ioc.get_executor()
     );
-    auto amep2 = ep_t(
+    auto amep2 = ep_t::create(
         am::protocol_version::v3_1_1,
         ioc.get_executor()
     );
@@ -108,7 +108,7 @@ BOOST_AUTO_TEST_CASE(v311_cs1to1) {
         }
     };
 
-    tc t{{amep1, amep2}, "127.0.0.1", 1883};
+    tc t{{*amep1, *amep2}, "127.0.0.1", 1883};
     t();
     ioc.run();
     BOOST_TEST(t.finish());
@@ -118,11 +118,11 @@ BOOST_AUTO_TEST_CASE(v311_cs0to1) {
     broker_runner br;
     as::io_context ioc;
     using ep_t = am::endpoint<am::role::client, am::protocol::mqtt>;
-    auto amep1 = ep_t(
+    auto amep1 = ep_t::create(
         am::protocol_version::v3_1_1,
         ioc.get_executor()
     );
-    auto amep2 = ep_t(
+    auto amep2 = ep_t::create(
         am::protocol_version::v3_1_1,
         ioc.get_executor()
     );
@@ -205,7 +205,7 @@ BOOST_AUTO_TEST_CASE(v311_cs0to1) {
         }
     };
 
-    tc t{{amep1, amep2}, "127.0.0.1", 1883};
+    tc t{{*amep1, *amep2}, "127.0.0.1", 1883};
     t();
     ioc.run();
     BOOST_TEST(t.finish());
@@ -215,11 +215,11 @@ BOOST_AUTO_TEST_CASE(v311_cs0to0) {
     broker_runner br;
     as::io_context ioc;
     using ep_t = am::endpoint<am::role::client, am::protocol::mqtt>;
-    auto amep1 = ep_t(
+    auto amep1 = ep_t::create(
         am::protocol_version::v3_1_1,
         ioc.get_executor()
     );
-    auto amep2 = ep_t(
+    auto amep2 = ep_t::create(
         am::protocol_version::v3_1_1,
         ioc.get_executor()
     );
@@ -302,7 +302,7 @@ BOOST_AUTO_TEST_CASE(v311_cs0to0) {
         }
     };
 
-    tc t{{amep1, amep2}, "127.0.0.1", 1883};
+    tc t{{*amep1, *amep2}, "127.0.0.1", 1883};
     t();
     ioc.run();
     BOOST_TEST(t.finish());
@@ -312,11 +312,11 @@ BOOST_AUTO_TEST_CASE(v311_cs0offto1) {
     broker_runner br;
     as::io_context ioc;
     using ep_t = am::endpoint<am::role::client, am::protocol::mqtt>;
-    auto amep1 = ep_t(
+    auto amep1 = ep_t::create(
         am::protocol_version::v3_1_1,
         ioc.get_executor()
     );
-    auto amep2 = ep_t(
+    auto amep2 = ep_t::create(
         am::protocol_version::v3_1_1,
         ioc.get_executor()
     );
@@ -400,7 +400,7 @@ BOOST_AUTO_TEST_CASE(v311_cs0offto1) {
         }
     };
 
-    tc t{{amep1, amep2}, "127.0.0.1", 1883};
+    tc t{{*amep1, *amep2}, "127.0.0.1", 1883};
     t();
     ioc.run();
     BOOST_TEST(t.finish());

--- a/test/system/st_gencid.cpp
+++ b/test/system/st_gencid.cpp
@@ -21,7 +21,7 @@ BOOST_AUTO_TEST_CASE(v311_cs1) {
     broker_runner br;
     as::io_context ioc;
     using ep_t = am::endpoint<am::role::client, am::protocol::mqtt>;
-    auto amep = ep_t(
+    auto amep = ep_t::create(
         am::protocol_version::v3_1_1,
         ioc.get_executor()
     );
@@ -70,7 +70,7 @@ BOOST_AUTO_TEST_CASE(v311_cs1) {
         }
     };
 
-    tc t{amep, "127.0.0.1", 1883};
+    tc t{*amep, "127.0.0.1", 1883};
     t();
     ioc.run();
     BOOST_TEST(t.finish());
@@ -80,7 +80,7 @@ BOOST_AUTO_TEST_CASE(v311_cs0) {
     broker_runner br;
     as::io_context ioc;
     using ep_t = am::endpoint<am::role::client, am::protocol::mqtt>;
-    auto amep = ep_t(
+    auto amep = ep_t::create(
         am::protocol_version::v3_1_1,
         ioc.get_executor()
     );
@@ -130,7 +130,7 @@ BOOST_AUTO_TEST_CASE(v311_cs0) {
         }
     };
 
-    tc t{amep, "127.0.0.1", 1883};
+    tc t{*amep, "127.0.0.1", 1883};
     t();
     ioc.run();
     BOOST_TEST(t.finish());
@@ -140,7 +140,7 @@ BOOST_AUTO_TEST_CASE(v5_cs1) {
     broker_runner br;
     as::io_context ioc;
     using ep_t = am::endpoint<am::role::client, am::protocol::mqtt>;
-    auto amep = ep_t(
+    auto amep = ep_t::create(
         am::protocol_version::v5,
         ioc.get_executor()
     );
@@ -203,7 +203,7 @@ BOOST_AUTO_TEST_CASE(v5_cs1) {
         }
     };
 
-    tc t{amep, "127.0.0.1", 1883};
+    tc t{*amep, "127.0.0.1", 1883};
     t();
     ioc.run();
     BOOST_TEST(t.finish());
@@ -215,7 +215,7 @@ BOOST_AUTO_TEST_CASE(v5_cs0) {
     broker_runner br;
     as::io_context ioc;
     using ep_t = am::endpoint<am::role::client, am::protocol::mqtt>;
-    auto amep = ep_t(
+    auto amep = ep_t::create(
         am::protocol_version::v5,
         ioc.get_executor()
     );
@@ -307,7 +307,7 @@ BOOST_AUTO_TEST_CASE(v5_cs0) {
         }
     };
 
-    tc t{amep, "127.0.0.1", 1883};
+    tc t{*amep, "127.0.0.1", 1883};
     t();
     ioc.run();
     BOOST_TEST(t.finish());

--- a/test/system/st_inflight.cpp
+++ b/test/system/st_inflight.cpp
@@ -18,7 +18,7 @@ BOOST_AUTO_TEST_CASE(v311_to_broker) {
     broker_runner br;
     as::io_context ioc;
     using ep_t = am::endpoint<am::role::client, am::protocol::mqtt>;
-    auto amep = ep_t(
+    auto amep = ep_t::create(
         am::protocol_version::v3_1_1,
         ioc.get_executor()
     );
@@ -167,7 +167,7 @@ BOOST_AUTO_TEST_CASE(v311_to_broker) {
         }
     };
 
-    tc t{amep, "127.0.0.1", 1883};
+    tc t{*amep, "127.0.0.1", 1883};
     t();
     ioc.run();
     BOOST_TEST(t.finish());
@@ -177,7 +177,7 @@ BOOST_AUTO_TEST_CASE(v5_to_broker) {
     broker_runner br;
     as::io_context ioc;
     using ep_t = am::endpoint<am::role::client, am::protocol::mqtt>;
-    auto amep = ep_t(
+    auto amep = ep_t::create(
         am::protocol_version::v5,
         ioc.get_executor()
     );
@@ -329,7 +329,7 @@ BOOST_AUTO_TEST_CASE(v5_to_broker) {
         }
     };
 
-    tc t{amep, "127.0.0.1", 1883};
+    tc t{*amep, "127.0.0.1", 1883};
     t();
     ioc.run();
     BOOST_TEST(t.finish());
@@ -339,11 +339,11 @@ BOOST_AUTO_TEST_CASE(v311_from_broker) {
     broker_runner br;
     as::io_context ioc;
     using ep_t = am::endpoint<am::role::client, am::protocol::mqtt>;
-    auto amep_pub = ep_t(
+    auto amep_pub = ep_t::create(
         am::protocol_version::v3_1_1,
         ioc.get_executor()
     );
-    auto amep_sub = ep_t(
+    auto amep_sub = ep_t::create(
         am::protocol_version::v3_1_1,
         ioc.get_executor()
     );
@@ -518,7 +518,7 @@ BOOST_AUTO_TEST_CASE(v311_from_broker) {
         }
     };
 
-    tc t{{amep_pub, amep_sub}, "127.0.0.1", 1883};
+    tc t{{*amep_pub, *amep_sub}, "127.0.0.1", 1883};
     t();
     ioc.run();
     BOOST_TEST(t.finish());
@@ -528,11 +528,11 @@ BOOST_AUTO_TEST_CASE(v5_from_broker) {
     broker_runner br;
     as::io_context ioc;
     using ep_t = am::endpoint<am::role::client, am::protocol::mqtt>;
-    auto amep_pub = ep_t(
+    auto amep_pub = ep_t::create(
         am::protocol_version::v5,
         ioc.get_executor()
     );
-    auto amep_sub = ep_t(
+    auto amep_sub = ep_t::create(
         am::protocol_version::v5,
         ioc.get_executor()
     );
@@ -708,7 +708,7 @@ BOOST_AUTO_TEST_CASE(v5_from_broker) {
         }
     };
 
-    tc t{{amep_pub, amep_sub}, "127.0.0.1", 1883};
+    tc t{{*amep_pub, *amep_sub}, "127.0.0.1", 1883};
     t();
     ioc.run();
     BOOST_TEST(t.finish());
@@ -718,11 +718,11 @@ BOOST_AUTO_TEST_CASE(v5_from_broker_mei) {
     broker_runner br;
     as::io_context ioc;
     using ep_t = am::endpoint<am::role::client, am::protocol::mqtt>;
-    auto amep_pub = ep_t(
+    auto amep_pub = ep_t::create(
         am::protocol_version::v5,
         ioc.get_executor()
     );
-    auto amep_sub = ep_t(
+    auto amep_sub = ep_t::create(
         am::protocol_version::v5,
         ioc.get_executor()
     );
@@ -887,7 +887,7 @@ BOOST_AUTO_TEST_CASE(v5_from_broker_mei) {
         }
     };
 
-    tc t{{amep_pub, amep_sub}, "127.0.0.1", 1883};
+    tc t{{*amep_pub, *amep_sub}, "127.0.0.1", 1883};
     t();
     ioc.run();
     BOOST_TEST(t.finish());

--- a/test/system/st_invalid.cpp
+++ b/test/system/st_invalid.cpp
@@ -23,7 +23,7 @@ BOOST_AUTO_TEST_CASE(remaining_length) {
     broker_runner br;
     as::io_context ioc;
     using ep_t = am::endpoint<am::role::client, am::protocol::mqtt>;
-    auto amep = ep_t(
+    auto amep = ep_t::create(
         am::protocol_version::v3_1_1,
         ioc.get_executor()
     );
@@ -56,7 +56,7 @@ BOOST_AUTO_TEST_CASE(remaining_length) {
         }
     };
 
-    tc t{amep, "127.0.0.1", 1883};
+    tc t{*amep, "127.0.0.1", 1883};
     t();
     ioc.run();
     BOOST_TEST(t.finish());

--- a/test/system/st_keep_alive.cpp
+++ b/test/system/st_keep_alive.cpp
@@ -21,7 +21,7 @@ BOOST_AUTO_TEST_CASE(v311_timeout) {
     broker_runner br;
     as::io_context ioc;
     using ep_t = am::endpoint<am::role::client, am::protocol::mqtt>;
-    auto amep = ep_t(
+    auto amep = ep_t::create(
         am::protocol_version::v3_1_1,
         ioc.get_executor()
     );
@@ -63,7 +63,7 @@ BOOST_AUTO_TEST_CASE(v311_timeout) {
         }
     };
 
-    tc t{amep, "127.0.0.1", 1883};
+    tc t{*amep, "127.0.0.1", 1883};
     t();
     ioc.run();
     BOOST_TEST(t.finish());
@@ -73,7 +73,7 @@ BOOST_AUTO_TEST_CASE(v5_timeout) {
     broker_runner br;
     as::io_context ioc;
     using ep_t = am::endpoint<am::role::client, am::protocol::mqtt>;
-    auto amep = ep_t(
+    auto amep = ep_t::create(
         am::protocol_version::v5,
         ioc.get_executor()
     );
@@ -118,7 +118,7 @@ BOOST_AUTO_TEST_CASE(v5_timeout) {
         }
     };
 
-    tc t{amep, "127.0.0.1", 1883};
+    tc t{*amep, "127.0.0.1", 1883};
     t();
     ioc.run();
     BOOST_TEST(t.finish());

--- a/test/system/st_offline.cpp
+++ b/test/system/st_offline.cpp
@@ -21,7 +21,7 @@ BOOST_AUTO_TEST_CASE(v311_cs1_sp0) {
     broker_runner br;
     as::io_context ioc;
     using ep_t = am::endpoint<am::role::client, am::protocol::mqtt>;
-    auto amep = ep_t(
+    auto amep = ep_t::create(
         am::protocol_version::v3_1_1,
         ioc.get_executor()
     );
@@ -130,7 +130,7 @@ BOOST_AUTO_TEST_CASE(v311_cs1_sp0) {
         }
     };
 
-    tc t{amep, "127.0.0.1", 1883};
+    tc t{*amep, "127.0.0.1", 1883};
     t();
     ioc.run();
     BOOST_TEST(t.finish());
@@ -140,7 +140,7 @@ BOOST_AUTO_TEST_CASE(v311_cs0_sp0) {
     broker_runner br;
     as::io_context ioc;
     using ep_t = am::endpoint<am::role::client, am::protocol::mqtt>;
-    auto amep = ep_t(
+    auto amep = ep_t::create(
         am::protocol_version::v3_1_1,
         ioc.get_executor()
     );
@@ -250,7 +250,7 @@ BOOST_AUTO_TEST_CASE(v311_cs0_sp0) {
         }
     };
 
-    tc t{amep, "127.0.0.1", 1883};
+    tc t{*amep, "127.0.0.1", 1883};
     t();
     ioc.run();
     BOOST_TEST(t.finish());
@@ -260,7 +260,7 @@ BOOST_AUTO_TEST_CASE(v311_cs0_sp1) {
     broker_runner br;
     as::io_context ioc;
     using ep_t = am::endpoint<am::role::client, am::protocol::mqtt>;
-    auto amep = ep_t(
+    auto amep = ep_t::create(
         am::protocol_version::v3_1_1,
         ioc.get_executor()
     );
@@ -383,7 +383,7 @@ BOOST_AUTO_TEST_CASE(v311_cs0_sp1) {
         }
     };
 
-    tc t{amep, "127.0.0.1", 1883};
+    tc t{*amep, "127.0.0.1", 1883};
     t();
     ioc.run();
     BOOST_TEST(t.finish());
@@ -393,11 +393,11 @@ BOOST_AUTO_TEST_CASE(v311_cs0_sp1_from_broker) {
     broker_runner br;
     as::io_context ioc;
     using ep_t = am::endpoint<am::role::client, am::protocol::mqtt>;
-    auto amep_pub = ep_t(
+    auto amep_pub = ep_t::create(
         am::protocol_version::v3_1_1,
         ioc.get_executor()
     );
-    auto amep_sub = ep_t(
+    auto amep_sub = ep_t::create(
         am::protocol_version::v3_1_1,
         ioc.get_executor()
     );
@@ -591,7 +591,7 @@ BOOST_AUTO_TEST_CASE(v311_cs0_sp1_from_broker) {
         }
     };
 
-    tc t{{amep_pub, amep_sub}, "127.0.0.1", 1883};
+    tc t{{*amep_pub, *amep_sub}, "127.0.0.1", 1883};
     t();
     ioc.run();
     BOOST_TEST(t.finish());
@@ -601,11 +601,11 @@ BOOST_AUTO_TEST_CASE(v5_cs0_sp1_from_broker_mei) {
     broker_runner br;
     as::io_context ioc;
     using ep_t = am::endpoint<am::role::client, am::protocol::mqtt>;
-    auto amep_pub = ep_t(
+    auto amep_pub = ep_t::create(
         am::protocol_version::v5,
         ioc.get_executor()
     );
-    auto amep_sub = ep_t(
+    auto amep_sub = ep_t::create(
         am::protocol_version::v5,
         ioc.get_executor()
     );
@@ -795,7 +795,7 @@ BOOST_AUTO_TEST_CASE(v5_cs0_sp1_from_broker_mei) {
         }
     };
 
-    tc t{{amep_pub, amep_sub}, "127.0.0.1", 1883};
+    tc t{{*amep_pub, *amep_sub}, "127.0.0.1", 1883};
     t();
     ioc.run();
     BOOST_TEST(t.finish());

--- a/test/system/st_pub.cpp
+++ b/test/system/st_pub.cpp
@@ -21,7 +21,7 @@ BOOST_AUTO_TEST_CASE(v311_pub_to_broker) {
     broker_runner br;
     as::io_context ioc;
     using ep_t = am::endpoint<am::role::client, am::protocol::mqtt>;
-    auto amep = ep_t(
+    auto amep = ep_t::create(
         am::protocol_version::v3_1_1,
         ioc.get_executor()
     );
@@ -110,7 +110,7 @@ BOOST_AUTO_TEST_CASE(v311_pub_to_broker) {
         ep_t::packet_id_t pid;
     };
 
-    tc t{amep, "127.0.0.1", 1883};
+    tc t{*amep, "127.0.0.1", 1883};
     t();
     ioc.run();
     BOOST_TEST(t.finish());
@@ -120,7 +120,7 @@ BOOST_AUTO_TEST_CASE(v5_pub_to_broker) {
     broker_runner br;
     as::io_context ioc;
     using ep_t = am::endpoint<am::role::client, am::protocol::mqtt>;
-    auto amep = ep_t(
+    auto amep = ep_t::create(
         am::protocol_version::v5,
         ioc.get_executor()
     );
@@ -210,7 +210,7 @@ BOOST_AUTO_TEST_CASE(v5_pub_to_broker) {
         ep_t::packet_id_t pid;
     };
 
-    tc t{amep, "127.0.0.1", 1883};
+    tc t{*amep, "127.0.0.1", 1883};
     t();
     ioc.run();
     BOOST_TEST(t.finish());
@@ -220,11 +220,11 @@ BOOST_AUTO_TEST_CASE(v311_from_broker) {
     broker_runner br;
     as::io_context ioc;
     using ep_t = am::endpoint<am::role::client, am::protocol::mqtt>;
-    auto amep_pub = ep_t(
+    auto amep_pub = ep_t::create(
         am::protocol_version::v3_1_1,
         ioc.get_executor()
     );
-    auto amep_sub = ep_t(
+    auto amep_sub = ep_t::create(
         am::protocol_version::v3_1_1,
         ioc.get_executor()
     );
@@ -395,7 +395,7 @@ BOOST_AUTO_TEST_CASE(v311_from_broker) {
         }
     };
 
-    tc t{{amep_pub, amep_sub}, "127.0.0.1", 1883};
+    tc t{{*amep_pub, *amep_sub}, "127.0.0.1", 1883};
     t();
     ioc.run();
     BOOST_TEST(t.finish());
@@ -405,11 +405,11 @@ BOOST_AUTO_TEST_CASE(v5_from_broker) {
     broker_runner br;
     as::io_context ioc;
     using ep_t = am::endpoint<am::role::client, am::protocol::mqtt>;
-    auto amep_pub = ep_t(
+    auto amep_pub = ep_t::create(
         am::protocol_version::v5,
         ioc.get_executor()
     );
-    auto amep_sub = ep_t(
+    auto amep_sub = ep_t::create(
         am::protocol_version::v5,
         ioc.get_executor()
     );
@@ -580,7 +580,7 @@ BOOST_AUTO_TEST_CASE(v5_from_broker) {
         }
     };
 
-    tc t{{amep_pub, amep_sub}, "127.0.0.1", 1883};
+    tc t{{*amep_pub, *amep_sub}, "127.0.0.1", 1883};
     t();
     ioc.run();
     BOOST_TEST(t.finish());

--- a/test/system/st_reqres.cpp
+++ b/test/system/st_reqres.cpp
@@ -21,7 +21,7 @@ BOOST_AUTO_TEST_CASE(generate_reuse_renew) {
     broker_runner br;
     as::io_context ioc;
     using ep_t = am::endpoint<am::role::client, am::protocol::mqtt>;
-    auto amep = ep_t(
+    auto amep = ep_t::create(
         am::protocol_version::v5,
         ioc.get_executor()
     );
@@ -184,7 +184,7 @@ BOOST_AUTO_TEST_CASE(generate_reuse_renew) {
         am::buffer response_topic;
     };
 
-    tc t{amep, "127.0.0.1", 1883};
+    tc t{*amep, "127.0.0.1", 1883};
     t();
     ioc.run();
     BOOST_TEST(t.finish());

--- a/test/system/st_retain.cpp
+++ b/test/system/st_retain.cpp
@@ -21,11 +21,11 @@ BOOST_AUTO_TEST_CASE(v5_mei_none) {
     broker_runner br;
     as::io_context ioc;
     using ep_t = am::endpoint<am::role::client, am::protocol::mqtt>;
-    auto amep_pub = ep_t(
+    auto amep_pub = ep_t::create(
         am::protocol_version::v5,
         ioc.get_executor()
     );
-    auto amep_sub = ep_t(
+    auto amep_sub = ep_t::create(
         am::protocol_version::v5,
         ioc.get_executor()
     );
@@ -163,7 +163,7 @@ BOOST_AUTO_TEST_CASE(v5_mei_none) {
         }
     };
 
-    tc t{{amep_pub, amep_sub}, "127.0.0.1", 1883};
+    tc t{{*amep_pub, *amep_sub}, "127.0.0.1", 1883};
     t();
     ioc.run();
     BOOST_TEST(t.finish());
@@ -173,11 +173,11 @@ BOOST_AUTO_TEST_CASE(v5_mei_no_exp) {
     broker_runner br;
     as::io_context ioc;
     using ep_t = am::endpoint<am::role::client, am::protocol::mqtt>;
-    auto amep_pub = ep_t(
+    auto amep_pub = ep_t::create(
         am::protocol_version::v5,
         ioc.get_executor()
     );
-    auto amep_sub = ep_t(
+    auto amep_sub = ep_t::create(
         am::protocol_version::v5,
         ioc.get_executor()
     );
@@ -317,7 +317,7 @@ BOOST_AUTO_TEST_CASE(v5_mei_no_exp) {
         }
     };
 
-    tc t{{amep_pub, amep_sub}, "127.0.0.1", 1883};
+    tc t{{*amep_pub, *amep_sub}, "127.0.0.1", 1883};
     t();
     ioc.run();
     BOOST_TEST(t.finish());
@@ -327,11 +327,11 @@ BOOST_AUTO_TEST_CASE(v5_mei_exp) {
     broker_runner br;
     as::io_context ioc;
     using ep_t = am::endpoint<am::role::client, am::protocol::mqtt>;
-    auto amep_pub = ep_t(
+    auto amep_pub = ep_t::create(
         am::protocol_version::v5,
         ioc.get_executor()
     );
-    auto amep_sub = ep_t(
+    auto amep_sub = ep_t::create(
         am::protocol_version::v5,
         ioc.get_executor()
     );
@@ -484,7 +484,7 @@ BOOST_AUTO_TEST_CASE(v5_mei_exp) {
         }
     };
 
-    tc t{{amep_pub, amep_sub}, "127.0.0.1", 1883};
+    tc t{{*amep_pub, *amep_sub}, "127.0.0.1", 1883};
     t();
     ioc.run();
     BOOST_TEST(t.finish());
@@ -494,11 +494,11 @@ BOOST_AUTO_TEST_CASE(v5_clear) {
     broker_runner br;
     as::io_context ioc;
     using ep_t = am::endpoint<am::role::client, am::protocol::mqtt>;
-    auto amep_pub = ep_t(
+    auto amep_pub = ep_t::create(
         am::protocol_version::v5,
         ioc.get_executor()
     );
-    auto amep_sub = ep_t(
+    auto amep_sub = ep_t::create(
         am::protocol_version::v5,
         ioc.get_executor()
     );
@@ -635,7 +635,7 @@ BOOST_AUTO_TEST_CASE(v5_clear) {
         }
     };
 
-    tc t{{amep_pub, amep_sub}, "127.0.0.1", 1883};
+    tc t{{*amep_pub, *amep_sub}, "127.0.0.1", 1883};
     t();
     ioc.run();
     BOOST_TEST(t.finish());

--- a/test/system/st_shared_sub.cpp
+++ b/test/system/st_shared_sub.cpp
@@ -21,19 +21,19 @@ BOOST_AUTO_TEST_CASE(v5_from_broker) {
     broker_runner br;
     as::io_context ioc;
     using ep_t = am::endpoint<am::role::client, am::protocol::mqtt>;
-    auto amep_pub = ep_t(
+    auto amep_pub = ep_t::create(
         am::protocol_version::v5,
         ioc.get_executor()
     );
-    auto amep_sub1 = ep_t(
+    auto amep_sub1 = ep_t::create(
         am::protocol_version::v5,
         ioc.get_executor()
     );
-    auto amep_sub2 = ep_t(
+    auto amep_sub2 = ep_t::create(
         am::protocol_version::v5,
         ioc.get_executor()
     );
-    auto amep_sub3 = ep_t(
+    auto amep_sub3 = ep_t::create(
         am::protocol_version::v5,
         ioc.get_executor()
     );
@@ -320,7 +320,7 @@ BOOST_AUTO_TEST_CASE(v5_from_broker) {
         }
     };
 
-    tc t{{amep_pub, amep_sub1, amep_sub2, amep_sub3}, "127.0.0.1", 1883};
+    tc t{{*amep_pub, *amep_sub1, *amep_sub2, *amep_sub3}, "127.0.0.1", 1883};
     t();
     ioc.run();
     BOOST_TEST(t.finish());
@@ -330,19 +330,19 @@ BOOST_AUTO_TEST_CASE(v5_unsub_from_broker) {
     broker_runner br;
     as::io_context ioc;
     using ep_t = am::endpoint<am::role::client, am::protocol::mqtt>;
-    auto amep_pub = ep_t(
+    auto amep_pub = ep_t::create(
         am::protocol_version::v5,
         ioc.get_executor()
     );
-    auto amep_sub1 = ep_t(
+    auto amep_sub1 = ep_t::create(
         am::protocol_version::v5,
         ioc.get_executor()
     );
-    auto amep_sub2 = ep_t(
+    auto amep_sub2 = ep_t::create(
         am::protocol_version::v5,
         ioc.get_executor()
     );
-    auto amep_sub3 = ep_t(
+    auto amep_sub3 = ep_t::create(
         am::protocol_version::v5,
         ioc.get_executor()
     );
@@ -654,7 +654,7 @@ BOOST_AUTO_TEST_CASE(v5_unsub_from_broker) {
         }
     };
 
-    tc t{{amep_pub, amep_sub1, amep_sub2, amep_sub3}, "127.0.0.1", 1883};
+    tc t{{*amep_pub, *amep_sub1, *amep_sub2, *amep_sub3}, "127.0.0.1", 1883};
     t();
     ioc.run();
     BOOST_TEST(t.finish());

--- a/test/system/st_sub.cpp
+++ b/test/system/st_sub.cpp
@@ -21,7 +21,7 @@ BOOST_AUTO_TEST_CASE(v311_sub) {
     broker_runner br;
     as::io_context ioc;
     using ep_t = am::endpoint<am::role::client, am::protocol::mqtt>;
-    auto amep = ep_t(
+    auto amep = ep_t::create(
         am::protocol_version::v3_1_1,
         ioc.get_executor()
     );
@@ -135,7 +135,7 @@ BOOST_AUTO_TEST_CASE(v311_sub) {
         ep_t::packet_id_t pid;
     };
 
-    tc t{amep, "127.0.0.1", 1883};
+    tc t{*amep, "127.0.0.1", 1883};
     t();
     ioc.run();
     BOOST_TEST(t.finish());
@@ -145,7 +145,7 @@ BOOST_AUTO_TEST_CASE(v5_sub) {
     broker_runner br;
     as::io_context ioc;
     using ep_t = am::endpoint<am::role::client, am::protocol::mqtt>;
-    auto amep = ep_t(
+    auto amep = ep_t::create(
         am::protocol_version::v5,
         ioc.get_executor()
     );
@@ -287,7 +287,7 @@ BOOST_AUTO_TEST_CASE(v5_sub) {
         ep_t::packet_id_t pid;
     };
 
-    tc t{amep, "127.0.0.1", 1883};
+    tc t{*amep, "127.0.0.1", 1883};
     t();
     ioc.run();
     BOOST_TEST(t.finish());

--- a/test/system/st_will.cpp
+++ b/test/system/st_will.cpp
@@ -21,11 +21,11 @@ BOOST_AUTO_TEST_CASE(v311_will) {
     broker_runner br;
     as::io_context ioc;
     using ep_t = am::endpoint<am::role::client, am::protocol::mqtt>;
-    auto amep_pub = ep_t(
+    auto amep_pub = ep_t::create(
         am::protocol_version::v3_1_1,
         ioc.get_executor()
     );
-    auto amep_sub = ep_t(
+    auto amep_sub = ep_t::create(
         am::protocol_version::v3_1_1,
         ioc.get_executor()
     );
@@ -130,7 +130,7 @@ BOOST_AUTO_TEST_CASE(v311_will) {
         }
     };
 
-    tc t{{amep_pub, amep_sub}, "127.0.0.1", 1883};
+    tc t{{*amep_pub, *amep_sub}, "127.0.0.1", 1883};
     t();
     ioc.run();
     BOOST_TEST(t.finish());
@@ -140,11 +140,11 @@ BOOST_AUTO_TEST_CASE(v5_will_wd_send) {
     broker_runner br;
     as::io_context ioc;
     using ep_t = am::endpoint<am::role::client, am::protocol::mqtt>;
-    auto amep_pub = ep_t(
+    auto amep_pub = ep_t::create(
         am::protocol_version::v5,
         ioc.get_executor()
     );
-    auto amep_sub = ep_t(
+    auto amep_sub = ep_t::create(
         am::protocol_version::v5,
         ioc.get_executor()
     );
@@ -253,7 +253,7 @@ BOOST_AUTO_TEST_CASE(v5_will_wd_send) {
         }
     };
 
-    tc t{{amep_pub, amep_sub}, "127.0.0.1", 1883};
+    tc t{{*amep_pub, *amep_sub}, "127.0.0.1", 1883};
     t();
     ioc.run();
     BOOST_TEST(t.finish());
@@ -263,11 +263,11 @@ BOOST_AUTO_TEST_CASE(v5_will_wd_send_sei) {
     broker_runner br;
     as::io_context ioc;
     using ep_t = am::endpoint<am::role::client, am::protocol::mqtt>;
-    auto amep_pub = ep_t(
+    auto amep_pub = ep_t::create(
         am::protocol_version::v5,
         ioc.get_executor()
     );
-    auto amep_sub = ep_t(
+    auto amep_sub = ep_t::create(
         am::protocol_version::v5,
         ioc.get_executor()
     );
@@ -376,7 +376,7 @@ BOOST_AUTO_TEST_CASE(v5_will_wd_send_sei) {
         }
     };
 
-    tc t{{amep_pub, amep_sub}, "127.0.0.1", 1883};
+    tc t{{*amep_pub, *amep_sub}, "127.0.0.1", 1883};
     t();
     ioc.run();
     BOOST_TEST(t.finish());
@@ -386,11 +386,11 @@ BOOST_AUTO_TEST_CASE(v5_will_wd_send_sei_disconnect) {
     broker_runner br;
     as::io_context ioc;
     using ep_t = am::endpoint<am::role::client, am::protocol::mqtt>;
-    auto amep_pub = ep_t(
+    auto amep_pub = ep_t::create(
         am::protocol_version::v5,
         ioc.get_executor()
     );
-    auto amep_sub = ep_t(
+    auto amep_sub = ep_t::create(
         am::protocol_version::v5,
         ioc.get_executor()
     );
@@ -506,7 +506,7 @@ BOOST_AUTO_TEST_CASE(v5_will_wd_send_sei_disconnect) {
         }
     };
 
-    tc t{{amep_pub, amep_sub}, "127.0.0.1", 1883};
+    tc t{{*amep_pub, *amep_sub}, "127.0.0.1", 1883};
     t();
     ioc.run();
     BOOST_TEST(t.finish());
@@ -516,11 +516,11 @@ BOOST_AUTO_TEST_CASE(v5_will_wd_not_send_sei_disconnect) {
     broker_runner br;
     as::io_context ioc;
     using ep_t = am::endpoint<am::role::client, am::protocol::mqtt>;
-    auto amep_pub = ep_t(
+    auto amep_pub = ep_t::create(
         am::protocol_version::v5,
         ioc.get_executor()
     );
-    auto amep_sub = ep_t(
+    auto amep_sub = ep_t::create(
         am::protocol_version::v5,
         ioc.get_executor()
     );
@@ -648,7 +648,7 @@ BOOST_AUTO_TEST_CASE(v5_will_wd_not_send_sei_disconnect) {
         }
     };
 
-    tc t{{amep_pub, amep_sub}, "127.0.0.1", 1883};
+    tc t{{*amep_pub, *amep_sub}, "127.0.0.1", 1883};
     t();
     ioc.run();
     BOOST_TEST(t.finish());
@@ -658,11 +658,11 @@ BOOST_AUTO_TEST_CASE(v5_will_wd_not_send_mei) {
     broker_runner br;
     as::io_context ioc;
     using ep_t = am::endpoint<am::role::client, am::protocol::mqtt>;
-    auto amep_pub = ep_t(
+    auto amep_pub = ep_t::create(
         am::protocol_version::v5,
         ioc.get_executor()
     );
-    auto amep_sub = ep_t(
+    auto amep_sub = ep_t::create(
         am::protocol_version::v5,
         ioc.get_executor()
     );
@@ -789,7 +789,7 @@ BOOST_AUTO_TEST_CASE(v5_will_wd_not_send_mei) {
         }
     };
 
-    tc t{{amep_pub, amep_sub}, "127.0.0.1", 1883};
+    tc t{{*amep_pub, *amep_sub}, "127.0.0.1", 1883};
     t();
     ioc.run();
     BOOST_TEST(t.finish());

--- a/test/unit/ut_ep_con_discon.cpp
+++ b/test/unit/ut_ep_con_discon.cpp
@@ -22,7 +22,7 @@ namespace am = async_mqtt;
 namespace as = boost::asio;
 
 // packet_id is hard coded in this test case for just testing.
-// but users need to get packet_id via ep.acquire_unique_packet_id(...)
+// but users need to get packet_id via ep->acquire_unique_packet_id(...)
 // see other test cases.
 
 // v3_1_1
@@ -37,12 +37,12 @@ BOOST_AUTO_TEST_CASE(valid_client_v3_1_1) {
         }
     };
 
-    am::endpoint<async_mqtt::role::client, async_mqtt::stub_socket> ep{
+    auto ep = am::endpoint<async_mqtt::role::client, async_mqtt::stub_socket>::create(
         version,
         // for stub_socket args
         version,
         ioc
-    };
+    );
 
     auto connect = am::v3_1_1::connect_packet{
         true,   // clean_session
@@ -103,7 +103,7 @@ BOOST_AUTO_TEST_CASE(valid_client_v3_1_1) {
 
     auto close = am::make_error(am::errc::network_reset, "pseudo close");
 
-    ep.next_layer().set_recv_packets(
+    ep->next_layer().set_recv_packets(
         {
             // receive packets
             connack,
@@ -114,154 +114,154 @@ BOOST_AUTO_TEST_CASE(valid_client_v3_1_1) {
     );
 
     // send connect
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(am::packet_compare(connect, wp));
         }
     );
     {
-        auto ec = ep.send(connect, as::use_future).get();
+        auto ec = ep->send(connect, as::use_future).get();
         BOOST_TEST(!ec);
     }
 
     // recv connack
     {
-        auto pv = ep.recv(as::use_future).get();
+        auto pv = ep->recv(as::use_future).get();
         BOOST_TEST(am::packet_compare(connack, pv));
     }
 
     // register packet_id for testing
-    BOOST_TEST(ep.register_packet_id(0x1, as::use_future).get());
+    BOOST_TEST(ep->register_packet_id(0x1, as::use_future).get());
     // send valid packets
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(am::packet_compare(publish, wp));
         }
     );
     {
-        auto ec = ep.send(publish, as::use_future).get();
+        auto ec = ep->send(publish, as::use_future).get();
         BOOST_TEST(!ec);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(am::packet_compare(puback, wp));
         }
     );
     {
-        auto ec = ep.send(puback, as::use_future).get();
+        auto ec = ep->send(puback, as::use_future).get();
         BOOST_TEST(!ec);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(am::packet_compare(pubrec, wp));
         }
     );
     {
-        auto ec = ep.send(pubrec, as::use_future).get();
+        auto ec = ep->send(pubrec, as::use_future).get();
         BOOST_TEST(!ec);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(am::packet_compare(pubrel, wp));
         }
     );
     {
-        auto ec = ep.send(pubrel, as::use_future).get();
+        auto ec = ep->send(pubrel, as::use_future).get();
         BOOST_TEST(!ec);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(am::packet_compare(pubcomp, wp));
         }
     );
     {
-        auto ec = ep.send(pubcomp, as::use_future).get();
+        auto ec = ep->send(pubcomp, as::use_future).get();
         BOOST_TEST(!ec);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(am::packet_compare(subscribe, wp));
         }
     );
     {
-        auto ec = ep.send(subscribe, as::use_future).get();
+        auto ec = ep->send(subscribe, as::use_future).get();
         BOOST_TEST(!ec);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(am::packet_compare(unsubscribe, wp));
         }
     );
     {
-        auto ec = ep.send(unsubscribe, as::use_future).get();
+        auto ec = ep->send(unsubscribe, as::use_future).get();
         BOOST_TEST(!ec);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(am::packet_compare(pingreq, wp));
         }
     );
     {
-        auto ec = ep.send(pingreq, as::use_future).get();
+        auto ec = ep->send(pingreq, as::use_future).get();
         BOOST_TEST(!ec);
     }
 
 
     // send disconnect
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(am::packet_compare(disconnect, wp));
         }
     );
     {
-        auto ec = ep.send(disconnect, as::use_future).get();
+        auto ec = ep->send(disconnect, as::use_future).get();
         BOOST_TEST(!ec);
     }
 
     // recv close
     {
-        auto pv = ep.recv(as::use_future).get();
+        auto pv = ep->recv(as::use_future).get();
         BOOST_TEST(pv.get_if<am::system_error>() != nullptr);
     }
 
     // send connect
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(am::packet_compare(connect, wp));
         }
     );
     {
-        auto ec = ep.send(connect, as::use_future).get();
+        auto ec = ep->send(connect, as::use_future).get();
         BOOST_TEST(!ec);
     }
 
     // recv connack
     {
-        auto pv = ep.recv(as::use_future).get();
+        auto pv = ep->recv(as::use_future).get();
         BOOST_TEST(am::packet_compare(connack, pv));
     }
 
     // send disconnect
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(am::packet_compare(disconnect, wp));
         }
     );
     {
-        auto ec = ep.send(disconnect, as::use_future).get();
+        auto ec = ep->send(disconnect, as::use_future).get();
         BOOST_TEST(!ec);
     }
 
     // recv close
     {
-        auto pv = ep.recv(as::use_future).get();
+        auto pv = ep->recv(as::use_future).get();
         BOOST_TEST(pv.get_if<am::system_error>() != nullptr);
     }
 
@@ -279,12 +279,12 @@ BOOST_AUTO_TEST_CASE(invalid_client_v3_1_1) {
         }
     };
 
-    am::endpoint<async_mqtt::role::client, async_mqtt::stub_socket> ep{
+    auto ep = am::endpoint<async_mqtt::role::client, async_mqtt::stub_socket>::create(
         version,
         // for stub_socket args
         version,
         ioc
-    };
+    );
 
     auto connect = am::v3_1_1::connect_packet{
         true,   // clean_session
@@ -358,7 +358,7 @@ BOOST_AUTO_TEST_CASE(invalid_client_v3_1_1) {
 
     auto close = am::make_error(am::errc::network_reset, "pseudo close");
 
-    ep.next_layer().set_recv_packets(
+    ep->next_layer().set_recv_packets(
         {
             // receive packets
             connack
@@ -370,356 +370,356 @@ BOOST_AUTO_TEST_CASE(invalid_client_v3_1_1) {
     // compile error as expected
 #if defined(ASYNC_MQTT_TEST_COMPILE_ERROR)
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(connack, as::use_future).get();
+        auto ec = ep->send(connack, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(suback, as::use_future).get();
+        auto ec = ep->send(suback, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(unsuback, as::use_future).get();
+        auto ec = ep->send(unsuback, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(pingresp, as::use_future).get();
+        auto ec = ep->send(pingresp, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
 #endif // defined(ASYNC_MQTT_TEST_COMPILE_ERROR)
 
     // runtime error due to unable send packet
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(am::packet_variant(connack), as::use_future).get();
+        auto ec = ep->send(am::packet_variant(connack), as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(am::packet_variant(suback), as::use_future).get();
+        auto ec = ep->send(am::packet_variant(suback), as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(am::packet_variant(unsuback), as::use_future).get();
+        auto ec = ep->send(am::packet_variant(unsuback), as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(am::packet_variant(pingresp), as::use_future).get();
+        auto ec = ep->send(am::packet_variant(pingresp), as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
     // register packet_id for testing
-    BOOST_TEST(ep.register_packet_id(0x1, as::use_future).get());
+    BOOST_TEST(ep->register_packet_id(0x1, as::use_future).get());
     // offline publish success
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(publish, as::use_future).get();
+        auto ec = ep->send(publish, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::success);
     }
 
     // runtime error due to send before sending connect
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(puback, as::use_future).get();
+        auto ec = ep->send(puback, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(pubrec, as::use_future).get();
+        auto ec = ep->send(pubrec, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(pubrel, as::use_future).get();
+        auto ec = ep->send(pubrel, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(pubcomp, as::use_future).get();
+        auto ec = ep->send(pubcomp, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(subscribe, as::use_future).get();
+        auto ec = ep->send(subscribe, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(unsubscribe, as::use_future).get();
+        auto ec = ep->send(unsubscribe, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(pingreq, as::use_future).get();
+        auto ec = ep->send(pingreq, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
     // send connect
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(am::packet_compare(connect, wp));
         }
     );
     {
-        auto ec = ep.send(connect, as::use_future).get();
+        auto ec = ep->send(connect, as::use_future).get();
         BOOST_TEST(!ec);
     }
 
     // register packet_id for testing
-    BOOST_TEST(ep.register_packet_id(0x1, as::use_future).get());
+    BOOST_TEST(ep->register_packet_id(0x1, as::use_future).get());
     // offline publish success
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(publish, as::use_future).get();
+        auto ec = ep->send(publish, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::success);
     }
 
     // runtime error due to send before receiving connack
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(puback, as::use_future).get();
+        auto ec = ep->send(puback, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(pubrec, as::use_future).get();
+        auto ec = ep->send(pubrec, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(pubrel, as::use_future).get();
+        auto ec = ep->send(pubrel, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(pubcomp, as::use_future).get();
+        auto ec = ep->send(pubcomp, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(subscribe, as::use_future).get();
+        auto ec = ep->send(subscribe, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(unsubscribe, as::use_future).get();
+        auto ec = ep->send(unsubscribe, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(pingreq, as::use_future).get();
+        auto ec = ep->send(pingreq, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
     // recv connack
     {
-        auto pv = ep.recv(as::use_future).get();
+        auto pv = ep->recv(as::use_future).get();
         BOOST_TEST(am::packet_compare(connack, pv));
     }
 
     // offline publish success
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(publish, as::use_future).get();
+        auto ec = ep->send(publish, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::success);
     }
 
     // runtime error due to send before receiving connack with not_authorized
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(puback, as::use_future).get();
+        auto ec = ep->send(puback, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(pubrec, as::use_future).get();
+        auto ec = ep->send(pubrec, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(pubrel, as::use_future).get();
+        auto ec = ep->send(pubrel, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(pubcomp, as::use_future).get();
+        auto ec = ep->send(pubcomp, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(subscribe, as::use_future).get();
+        auto ec = ep->send(subscribe, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(unsubscribe, as::use_future).get();
+        auto ec = ep->send(unsubscribe, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(pingreq, as::use_future).get();
+        auto ec = ep->send(pingreq, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
-    ep.close(as::use_future).get();
+    ep->close(as::use_future).get();
     guard.reset();
     th.join();
 }
@@ -734,18 +734,18 @@ BOOST_AUTO_TEST_CASE(valid_server_v3_1_1) {
         }
     };
 
-    am::endpoint<async_mqtt::role::server, async_mqtt::stub_socket> ep1{
+    auto ep1 = am::endpoint<async_mqtt::role::server, async_mqtt::stub_socket>::create(
         version,
         // for stub_socket args
         version,
         ioc
-    };
-    am::endpoint<async_mqtt::role::server, async_mqtt::stub_socket> ep2{
+    );
+    auto ep2 = am::endpoint<async_mqtt::role::server, async_mqtt::stub_socket>::create(
         version,
         // for stub_socket args
         version,
         ioc
-    };
+    );
 
     auto connect = am::v3_1_1::connect_packet{
         true,   // clean_session
@@ -800,7 +800,7 @@ BOOST_AUTO_TEST_CASE(valid_server_v3_1_1) {
 
     auto close = am::make_error(am::errc::network_reset, "pseudo close");
 
-    ep1.next_layer().set_recv_packets(
+    ep1->next_layer().set_recv_packets(
         {
             // receive packets
             connect,
@@ -810,113 +810,113 @@ BOOST_AUTO_TEST_CASE(valid_server_v3_1_1) {
 
     // recv connect
     {
-        auto pv = ep1.recv(as::use_future).get();
+        auto pv = ep1->recv(as::use_future).get();
         BOOST_TEST(am::packet_compare(connect, pv));
     }
 
     // send connack
-    ep1.next_layer().set_write_packet_checker(
+    ep1->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(am::packet_compare(connack, wp));
         }
     );
     {
-        auto ec = ep1.send(connack, as::use_future).get();
+        auto ec = ep1->send(connack, as::use_future).get();
         BOOST_TEST(!ec);
     }
 
     // register packet_id for testing
-    BOOST_TEST(ep1.register_packet_id(0x1, as::use_future).get());
+    BOOST_TEST(ep1->register_packet_id(0x1, as::use_future).get());
 
     // send valid packets
-    ep1.next_layer().set_write_packet_checker(
+    ep1->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(am::packet_compare(publish, wp));
         }
     );
     {
-        auto ec = ep1.send(publish, as::use_future).get();
+        auto ec = ep1->send(publish, as::use_future).get();
         BOOST_TEST(!ec);
     }
 
-    ep1.next_layer().set_write_packet_checker(
+    ep1->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(am::packet_compare(puback, wp));
         }
     );
     {
-        auto ec = ep1.send(puback, as::use_future).get();
+        auto ec = ep1->send(puback, as::use_future).get();
         BOOST_TEST(!ec);
     }
 
-    ep1.next_layer().set_write_packet_checker(
+    ep1->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(am::packet_compare(pubrec, wp));
         }
     );
     {
-        auto ec = ep1.send(pubrec, as::use_future).get();
+        auto ec = ep1->send(pubrec, as::use_future).get();
         BOOST_TEST(!ec);
     }
 
-    ep1.next_layer().set_write_packet_checker(
+    ep1->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(am::packet_compare(pubrel, wp));
         }
     );
     {
-        auto ec = ep1.send(pubrel, as::use_future).get();
+        auto ec = ep1->send(pubrel, as::use_future).get();
         BOOST_TEST(!ec);
     }
 
-    ep1.next_layer().set_write_packet_checker(
+    ep1->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(am::packet_compare(pubcomp, wp));
         }
     );
     {
-        auto ec = ep1.send(pubcomp, as::use_future).get();
+        auto ec = ep1->send(pubcomp, as::use_future).get();
         BOOST_TEST(!ec);
     }
 
-    ep1.next_layer().set_write_packet_checker(
+    ep1->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(am::packet_compare(suback, wp));
         }
     );
     {
-        auto ec = ep1.send(suback, as::use_future).get();
+        auto ec = ep1->send(suback, as::use_future).get();
         BOOST_TEST(!ec);
     }
 
-    ep1.next_layer().set_write_packet_checker(
+    ep1->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(am::packet_compare(unsuback, wp));
         }
     );
     {
-        auto ec = ep1.send(unsuback, as::use_future).get();
+        auto ec = ep1->send(unsuback, as::use_future).get();
         BOOST_TEST(!ec);
     }
 
-    ep1.next_layer().set_write_packet_checker(
+    ep1->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(am::packet_compare(pingresp, wp));
         }
     );
     {
-        auto ec = ep1.send(pingresp, as::use_future).get();
+        auto ec = ep1->send(pingresp, as::use_future).get();
         BOOST_TEST(!ec);
     }
 
 
     // recv close
     {
-        auto pv = ep1.recv(as::use_future).get();
+        auto pv = ep1->recv(as::use_future).get();
         BOOST_TEST(pv.get_if<am::system_error>() != nullptr);
     }
 
-    ep2.next_layer().set_recv_packets(
+    ep2->next_layer().set_recv_packets(
         {
             // receive packets
             connect,
@@ -926,38 +926,38 @@ BOOST_AUTO_TEST_CASE(valid_server_v3_1_1) {
 
     // recv connect
     {
-        auto pv = ep2.recv(as::use_future).get();
+        auto pv = ep2->recv(as::use_future).get();
         BOOST_TEST(am::packet_compare(connect, pv));
     }
 
     // send connack
-    ep2.next_layer().set_write_packet_checker(
+    ep2->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(am::packet_compare(connack, wp));
         }
     );
     {
-        auto ec = ep2.send(connack, as::use_future).get();
+        auto ec = ep2->send(connack, as::use_future).get();
         BOOST_TEST(!ec);
     }
 
     // register packet_id for testing
-    BOOST_TEST(ep2.register_packet_id(0x1, as::use_future).get());
+    BOOST_TEST(ep2->register_packet_id(0x1, as::use_future).get());
 
     // send publish behalf of valid packets
-    ep2.next_layer().set_write_packet_checker(
+    ep2->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(am::packet_compare(publish, wp));
         }
     );
     {
-        auto ec = ep2.send(publish, as::use_future).get();
+        auto ec = ep2->send(publish, as::use_future).get();
         BOOST_TEST(!ec);
     }
 
     // recv close
     {
-        auto pv = ep2.recv(as::use_future).get();
+        auto pv = ep2->recv(as::use_future).get();
         BOOST_TEST(pv.get_if<am::system_error>() != nullptr);
     }
 
@@ -975,12 +975,12 @@ BOOST_AUTO_TEST_CASE(invalid_server_v3_1_1) {
         }
     };
 
-    am::endpoint<async_mqtt::role::server, async_mqtt::stub_socket> ep{
+    auto ep = am::endpoint<async_mqtt::role::server, async_mqtt::stub_socket>::create(
         version,
         // for stub_socket args
         version,
         ioc
-    };
+    );
 
     auto connect = am::v3_1_1::connect_packet{
         true,   // clean_session
@@ -1054,7 +1054,7 @@ BOOST_AUTO_TEST_CASE(invalid_server_v3_1_1) {
 
     auto close = am::make_error(am::errc::network_reset, "pseudo close");
 
-    ep.next_layer().set_recv_packets(
+    ep->next_layer().set_recv_packets(
         {
             // receive packets
             connect,
@@ -1066,354 +1066,354 @@ BOOST_AUTO_TEST_CASE(invalid_server_v3_1_1) {
     // compile error as expected
 #if defined(ASYNC_MQTT_TEST_COMPILE_ERROR)
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(connect, as::use_future).get();
+        auto ec = ep->send(connect, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(subscribe, as::use_future).get();
+        auto ec = ep->send(subscribe, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(unsubscribe, as::use_future).get();
+        auto ec = ep->send(unsubscribe, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(pingreq, as::use_future).get();
+        auto ec = ep->send(pingreq, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
 #endif // defined(ASYNC_MQTT_TEST_COMPILE_ERROR)
 
     // runtime error due to unable send packet
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(am::packet_variant(connect), as::use_future).get();
+        auto ec = ep->send(am::packet_variant(connect), as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(am::packet_variant(subscribe), as::use_future).get();
+        auto ec = ep->send(am::packet_variant(subscribe), as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(am::packet_variant(unsubscribe), as::use_future).get();
+        auto ec = ep->send(am::packet_variant(unsubscribe), as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(am::packet_variant(pingreq), as::use_future).get();
+        auto ec = ep->send(am::packet_variant(pingreq), as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
     // register packet_id for testing
-    BOOST_TEST(ep.register_packet_id(0x1, as::use_future).get());
+    BOOST_TEST(ep->register_packet_id(0x1, as::use_future).get());
     // offline publish success
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(publish, as::use_future).get();
+        auto ec = ep->send(publish, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::success);
     }
 
     // runtime error due to send before receiving connect
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(puback, as::use_future).get();
+        auto ec = ep->send(puback, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(pubrec, as::use_future).get();
+        auto ec = ep->send(pubrec, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(pubrel, as::use_future).get();
+        auto ec = ep->send(pubrel, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(pubcomp, as::use_future).get();
+        auto ec = ep->send(pubcomp, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(suback, as::use_future).get();
+        auto ec = ep->send(suback, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(unsuback, as::use_future).get();
+        auto ec = ep->send(unsuback, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(pingresp, as::use_future).get();
+        auto ec = ep->send(pingresp, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
     // recv connect
     {
-        auto pv = ep.recv(as::use_future).get();
+        auto pv = ep->recv(as::use_future).get();
         BOOST_TEST(am::packet_compare(connect, pv));
     }
 
     // offline publish success
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(publish, as::use_future).get();
+        auto ec = ep->send(publish, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::success);
     }
 
     // runtime error due to send before sending connack
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(puback, as::use_future).get();
+        auto ec = ep->send(puback, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(pubrec, as::use_future).get();
+        auto ec = ep->send(pubrec, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(pubrel, as::use_future).get();
+        auto ec = ep->send(pubrel, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(pubcomp, as::use_future).get();
+        auto ec = ep->send(pubcomp, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(suback, as::use_future).get();
+        auto ec = ep->send(suback, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(unsuback, as::use_future).get();
+        auto ec = ep->send(unsuback, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(pingresp, as::use_future).get();
+        auto ec = ep->send(pingresp, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
     // send connack
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(am::packet_compare(connack, wp));
         }
     );
     {
-        auto ec = ep.send(connack, as::use_future).get();
+        auto ec = ep->send(connack, as::use_future).get();
         BOOST_TEST(!ec);
     }
 
     // offline publish success
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(publish, as::use_future).get();
+        auto ec = ep->send(publish, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::success);
     }
 
     // runtime error due to send before receiving connack with not_authorized
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(puback, as::use_future).get();
+        auto ec = ep->send(puback, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(pubrec, as::use_future).get();
+        auto ec = ep->send(pubrec, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(pubrel, as::use_future).get();
+        auto ec = ep->send(pubrel, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(pubcomp, as::use_future).get();
+        auto ec = ep->send(pubcomp, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(suback, as::use_future).get();
+        auto ec = ep->send(suback, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(unsuback, as::use_future).get();
+        auto ec = ep->send(unsuback, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(pingresp, as::use_future).get();
+        auto ec = ep->send(pingresp, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
-    ep.close(as::use_future).get();
+    ep->close(as::use_future).get();
     guard.reset();
     th.join();
 }
@@ -1430,12 +1430,12 @@ BOOST_AUTO_TEST_CASE(valid_client_v5) {
         }
     };
 
-    am::endpoint<async_mqtt::role::client, async_mqtt::stub_socket> ep{
+    auto ep = am::endpoint<async_mqtt::role::client, async_mqtt::stub_socket>::create(
         version,
         // for stub_socket args
         version,
         ioc
-    };
+    );
 
     auto connect = am::v5::connect_packet{
         true,   // clean_start
@@ -1517,7 +1517,7 @@ BOOST_AUTO_TEST_CASE(valid_client_v5) {
 
     auto close = am::make_error(am::errc::network_reset, "pseudo close");
 
-    ep.next_layer().set_recv_packets(
+    ep->next_layer().set_recv_packets(
         {
             // receive packets
             connack,
@@ -1528,175 +1528,175 @@ BOOST_AUTO_TEST_CASE(valid_client_v5) {
     );
 
     // send connect
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(am::packet_compare(connect, wp));
         }
     );
     {
-        auto ec = ep.send(connect, as::use_future).get();
+        auto ec = ep->send(connect, as::use_future).get();
         BOOST_TEST(!ec);
     }
 
     // send auth packet that can be sent before connack receiving
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(am::packet_compare(auth, wp));
         }
     );
     {
-        auto ec = ep.send(auth, as::use_future).get();
+        auto ec = ep->send(auth, as::use_future).get();
         BOOST_TEST(!ec);
     }
 
     // recv connack
     {
-        auto pv = ep.recv(as::use_future).get();
+        auto pv = ep->recv(as::use_future).get();
         BOOST_TEST(am::packet_compare(connack, pv));
     }
 
     // send valid packets
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(am::packet_compare(auth, wp));
         }
     );
     {
-        auto ec = ep.send(auth, as::use_future).get();
+        auto ec = ep->send(auth, as::use_future).get();
         BOOST_TEST(!ec);
     }
 
     // register packet_id for testing
-    BOOST_TEST(ep.register_packet_id(0x1, as::use_future).get());
-    ep.next_layer().set_write_packet_checker(
+    BOOST_TEST(ep->register_packet_id(0x1, as::use_future).get());
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(am::packet_compare(publish, wp));
         }
     );
     {
-        auto ec = ep.send(publish, as::use_future).get();
+        auto ec = ep->send(publish, as::use_future).get();
         BOOST_TEST(!ec);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(am::packet_compare(puback, wp));
         }
     );
     {
-        auto ec = ep.send(puback, as::use_future).get();
+        auto ec = ep->send(puback, as::use_future).get();
         BOOST_TEST(!ec);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(am::packet_compare(pubrec, wp));
         }
     );
     {
-        auto ec = ep.send(pubrec, as::use_future).get();
+        auto ec = ep->send(pubrec, as::use_future).get();
         BOOST_TEST(!ec);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(am::packet_compare(pubrel, wp));
         }
     );
     {
-        auto ec = ep.send(pubrel, as::use_future).get();
+        auto ec = ep->send(pubrel, as::use_future).get();
         BOOST_TEST(!ec);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(am::packet_compare(pubcomp, wp));
         }
     );
     {
-        auto ec = ep.send(pubcomp, as::use_future).get();
+        auto ec = ep->send(pubcomp, as::use_future).get();
         BOOST_TEST(!ec);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(am::packet_compare(subscribe, wp));
         }
     );
     {
-        auto ec = ep.send(subscribe, as::use_future).get();
+        auto ec = ep->send(subscribe, as::use_future).get();
         BOOST_TEST(!ec);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(am::packet_compare(unsubscribe, wp));
         }
     );
     {
-        auto ec = ep.send(unsubscribe, as::use_future).get();
+        auto ec = ep->send(unsubscribe, as::use_future).get();
         BOOST_TEST(!ec);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(am::packet_compare(pingreq, wp));
         }
     );
     {
-        auto ec = ep.send(pingreq, as::use_future).get();
+        auto ec = ep->send(pingreq, as::use_future).get();
         BOOST_TEST(!ec);
     }
 
 
     // send disconnect
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(am::packet_compare(disconnect, wp));
         }
     );
     {
-        auto ec = ep.send(disconnect, as::use_future).get();
+        auto ec = ep->send(disconnect, as::use_future).get();
         BOOST_TEST(!ec);
     }
 
     // recv close
     {
-        auto pv = ep.recv(as::use_future).get();
+        auto pv = ep->recv(as::use_future).get();
         BOOST_TEST(pv.get_if<am::system_error>() != nullptr);
     }
 
     // send connect
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(am::packet_compare(connect, wp));
         }
     );
     {
-        auto ec = ep.send(connect, as::use_future).get();
+        auto ec = ep->send(connect, as::use_future).get();
         BOOST_TEST(!ec);
     }
 
     // recv connack
     {
-        auto pv = ep.recv(as::use_future).get();
+        auto pv = ep->recv(as::use_future).get();
         BOOST_TEST(am::packet_compare(connack, pv));
     }
 
     // send disconnect
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(am::packet_compare(disconnect, wp));
         }
     );
     {
-        auto ec = ep.send(disconnect, as::use_future).get();
+        auto ec = ep->send(disconnect, as::use_future).get();
         BOOST_TEST(!ec);
     }
 
     // recv close
     {
-        auto pv = ep.recv(as::use_future).get();
+        auto pv = ep->recv(as::use_future).get();
         BOOST_TEST(pv.get_if<am::system_error>() != nullptr);
     }
 
@@ -1714,12 +1714,12 @@ BOOST_AUTO_TEST_CASE(invalid_client_v5) {
         }
     };
 
-    am::endpoint<async_mqtt::role::client, async_mqtt::stub_socket> ep{
+    auto ep = am::endpoint<async_mqtt::role::client, async_mqtt::stub_socket>::create(
         version,
         // for stub_socket args
         version,
         ioc
-    };
+    );
 
     auto connect = am::v5::connect_packet{
         true,   // clean_start
@@ -1821,7 +1821,7 @@ BOOST_AUTO_TEST_CASE(invalid_client_v5) {
 
     auto close = am::make_error(am::errc::network_reset, "pseudo close");
 
-    ep.next_layer().set_recv_packets(
+    ep->next_layer().set_recv_packets(
         {
             // receive packets
             connack
@@ -1833,366 +1833,366 @@ BOOST_AUTO_TEST_CASE(invalid_client_v5) {
     // compile error as expected
 #if defined(ASYNC_MQTT_TEST_COMPILE_ERROR)
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(connack, as::use_future).get();
+        auto ec = ep->send(connack, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(suback, as::use_future).get();
+        auto ec = ep->send(suback, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(unsuback, as::use_future).get();
+        auto ec = ep->send(unsuback, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(pingresp, as::use_future).get();
+        auto ec = ep->send(pingresp, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
 #endif // defined(ASYNC_MQTT_TEST_COMPILE_ERROR)
 
     // runtime error due to unable send packet
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(am::packet_variant(connack), as::use_future).get();
+        auto ec = ep->send(am::packet_variant(connack), as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(am::packet_variant(suback), as::use_future).get();
+        auto ec = ep->send(am::packet_variant(suback), as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(am::packet_variant(unsuback), as::use_future).get();
+        auto ec = ep->send(am::packet_variant(unsuback), as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(am::packet_variant(pingresp), as::use_future).get();
+        auto ec = ep->send(am::packet_variant(pingresp), as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
     // register packet_id for testing
-    BOOST_TEST(ep.register_packet_id(0x1, as::use_future).get());
+    BOOST_TEST(ep->register_packet_id(0x1, as::use_future).get());
     // offline publish success
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(publish, as::use_future).get();
+        auto ec = ep->send(publish, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::success);
     }
 
     // runtime error due to send before sending connect
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(puback, as::use_future).get();
+        auto ec = ep->send(puback, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(pubrec, as::use_future).get();
+        auto ec = ep->send(pubrec, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(pubrel, as::use_future).get();
+        auto ec = ep->send(pubrel, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(pubcomp, as::use_future).get();
+        auto ec = ep->send(pubcomp, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(subscribe, as::use_future).get();
+        auto ec = ep->send(subscribe, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(unsubscribe, as::use_future).get();
+        auto ec = ep->send(unsubscribe, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(pingreq, as::use_future).get();
+        auto ec = ep->send(pingreq, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(auth, as::use_future).get();
+        auto ec = ep->send(auth, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
     // send connect
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(am::packet_compare(connect, wp));
         }
     );
     {
-        auto ec = ep.send(connect, as::use_future).get();
+        auto ec = ep->send(connect, as::use_future).get();
         BOOST_TEST(!ec);
     }
 
     // register packet_id for testing
-    BOOST_TEST(ep.register_packet_id(0x1, as::use_future).get());
+    BOOST_TEST(ep->register_packet_id(0x1, as::use_future).get());
     // offline publish success
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(publish, as::use_future).get();
+        auto ec = ep->send(publish, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::success);
     }
 
     // runtime error due to send before receiving connack
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(puback, as::use_future).get();
+        auto ec = ep->send(puback, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(pubrec, as::use_future).get();
+        auto ec = ep->send(pubrec, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(pubrel, as::use_future).get();
+        auto ec = ep->send(pubrel, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(pubcomp, as::use_future).get();
+        auto ec = ep->send(pubcomp, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(subscribe, as::use_future).get();
+        auto ec = ep->send(subscribe, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(unsubscribe, as::use_future).get();
+        auto ec = ep->send(unsubscribe, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(pingreq, as::use_future).get();
+        auto ec = ep->send(pingreq, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
     // recv connack
     {
-        auto pv = ep.recv(as::use_future).get();
+        auto pv = ep->recv(as::use_future).get();
         BOOST_TEST(am::packet_compare(connack, pv));
     }
 
     // offline publish success
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(publish, as::use_future).get();
+        auto ec = ep->send(publish, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::success);
     }
 
     // runtime error due to send before receiving connack with not_authorized
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(puback, as::use_future).get();
+        auto ec = ep->send(puback, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(pubrec, as::use_future).get();
+        auto ec = ep->send(pubrec, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(pubrel, as::use_future).get();
+        auto ec = ep->send(pubrel, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(pubcomp, as::use_future).get();
+        auto ec = ep->send(pubcomp, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(subscribe, as::use_future).get();
+        auto ec = ep->send(subscribe, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(unsubscribe, as::use_future).get();
+        auto ec = ep->send(unsubscribe, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(pingreq, as::use_future).get();
+        auto ec = ep->send(pingreq, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
-    ep.close(as::use_future).get();
+    ep->close(as::use_future).get();
     guard.reset();
     th.join();
 }
@@ -2207,19 +2207,19 @@ BOOST_AUTO_TEST_CASE(valid_server_v5) {
         }
     };
 
-    am::endpoint<async_mqtt::role::server, async_mqtt::stub_socket> ep1{
+    auto ep1 = am::endpoint<async_mqtt::role::server, async_mqtt::stub_socket>::create(
         version,
         // for stub_socket args
         version,
         ioc
-    };
+    );
 
-    am::endpoint<async_mqtt::role::server, async_mqtt::stub_socket> ep2{
+    auto ep2 = am::endpoint<async_mqtt::role::server, async_mqtt::stub_socket>::create(
         version,
         // for stub_socket args
         version,
         ioc
-    };
+    );
 
     auto connect = am::v5::connect_packet{
         true,   // clean_start
@@ -2301,7 +2301,7 @@ BOOST_AUTO_TEST_CASE(valid_server_v5) {
 
     auto close = am::make_error(am::errc::network_reset, "pseudo close");
 
-    ep1.next_layer().set_recv_packets(
+    ep1->next_layer().set_recv_packets(
         {
             // receive packets
             connect,
@@ -2311,134 +2311,134 @@ BOOST_AUTO_TEST_CASE(valid_server_v5) {
 
     // recv connect
     {
-        auto pv = ep1.recv(as::use_future).get();
+        auto pv = ep1->recv(as::use_future).get();
         BOOST_TEST(am::packet_compare(connect, pv));
     }
 
     // send auth
-    ep1.next_layer().set_write_packet_checker(
+    ep1->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(am::packet_compare(auth, wp));
         }
     );
     {
-        auto ec = ep1.send(auth, as::use_future).get();
+        auto ec = ep1->send(auth, as::use_future).get();
         BOOST_TEST(!ec);
     }
 
     // send connack
-    ep1.next_layer().set_write_packet_checker(
+    ep1->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(am::packet_compare(connack, wp));
         }
     );
     {
-        auto ec = ep1.send(connack, as::use_future).get();
+        auto ec = ep1->send(connack, as::use_future).get();
         BOOST_TEST(!ec);
     }
 
     // register packet_id for testing
-    BOOST_TEST(ep1.register_packet_id(0x1, as::use_future).get());
+    BOOST_TEST(ep1->register_packet_id(0x1, as::use_future).get());
 
     // send valid packets
-    ep1.next_layer().set_write_packet_checker(
+    ep1->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(am::packet_compare(auth, wp));
         }
     );
     {
-        auto ec = ep1.send(auth, as::use_future).get();
+        auto ec = ep1->send(auth, as::use_future).get();
         BOOST_TEST(!ec);
     }
 
-    ep1.next_layer().set_write_packet_checker(
+    ep1->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(am::packet_compare(publish, wp));
         }
     );
     {
-        auto ec = ep1.send(publish, as::use_future).get();
+        auto ec = ep1->send(publish, as::use_future).get();
         BOOST_TEST(!ec);
     }
 
-    ep1.next_layer().set_write_packet_checker(
+    ep1->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(am::packet_compare(puback, wp));
         }
     );
     {
-        auto ec = ep1.send(puback, as::use_future).get();
+        auto ec = ep1->send(puback, as::use_future).get();
         BOOST_TEST(!ec);
     }
 
-    ep1.next_layer().set_write_packet_checker(
+    ep1->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(am::packet_compare(pubrec, wp));
         }
     );
     {
-        auto ec = ep1.send(pubrec, as::use_future).get();
+        auto ec = ep1->send(pubrec, as::use_future).get();
         BOOST_TEST(!ec);
     }
 
-    ep1.next_layer().set_write_packet_checker(
+    ep1->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(am::packet_compare(pubrel, wp));
         }
     );
     {
-        auto ec = ep1.send(pubrel, as::use_future).get();
+        auto ec = ep1->send(pubrel, as::use_future).get();
         BOOST_TEST(!ec);
     }
 
-    ep1.next_layer().set_write_packet_checker(
+    ep1->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(am::packet_compare(pubcomp, wp));
         }
     );
     {
-        auto ec = ep1.send(pubcomp, as::use_future).get();
+        auto ec = ep1->send(pubcomp, as::use_future).get();
         BOOST_TEST(!ec);
     }
 
-    ep1.next_layer().set_write_packet_checker(
+    ep1->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(am::packet_compare(suback, wp));
         }
     );
     {
-        auto ec = ep1.send(suback, as::use_future).get();
+        auto ec = ep1->send(suback, as::use_future).get();
         BOOST_TEST(!ec);
     }
 
-    ep1.next_layer().set_write_packet_checker(
+    ep1->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(am::packet_compare(unsuback, wp));
         }
     );
     {
-        auto ec = ep1.send(unsuback, as::use_future).get();
+        auto ec = ep1->send(unsuback, as::use_future).get();
         BOOST_TEST(!ec);
     }
 
-    ep1.next_layer().set_write_packet_checker(
+    ep1->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(am::packet_compare(pingresp, wp));
         }
     );
     {
-        auto ec = ep1.send(pingresp, as::use_future).get();
+        auto ec = ep1->send(pingresp, as::use_future).get();
         BOOST_TEST(!ec);
     }
 
 
     // recv close
     {
-        auto pv = ep1.recv(as::use_future).get();
+        auto pv = ep1->recv(as::use_future).get();
         BOOST_TEST(pv.get_if<am::system_error>() != nullptr);
     }
 
-    ep2.next_layer().set_recv_packets(
+    ep2->next_layer().set_recv_packets(
         {
             // receive packets
             connect,
@@ -2448,38 +2448,38 @@ BOOST_AUTO_TEST_CASE(valid_server_v5) {
 
     // recv connect
     {
-        auto pv = ep2.recv(as::use_future).get();
+        auto pv = ep2->recv(as::use_future).get();
         BOOST_TEST(am::packet_compare(connect, pv));
     }
 
     // send connack
-    ep2.next_layer().set_write_packet_checker(
+    ep2->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(am::packet_compare(connack, wp));
         }
     );
     {
-        auto ec = ep2.send(connack, as::use_future).get();
+        auto ec = ep2->send(connack, as::use_future).get();
         BOOST_TEST(!ec);
     }
 
     // register packet_id for testing
-    BOOST_TEST(ep2.register_packet_id(0x1, as::use_future).get());
+    BOOST_TEST(ep2->register_packet_id(0x1, as::use_future).get());
 
     // send publish behalf of valid packets
-    ep2.next_layer().set_write_packet_checker(
+    ep2->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(am::packet_compare(publish, wp));
         }
     );
     {
-        auto ec = ep2.send(publish, as::use_future).get();
+        auto ec = ep2->send(publish, as::use_future).get();
         BOOST_TEST(!ec);
     }
 
     // recv close
     {
-        auto pv = ep2.recv(as::use_future).get();
+        auto pv = ep2->recv(as::use_future).get();
         BOOST_TEST(pv.get_if<am::system_error>() != nullptr);
     }
 
@@ -2497,12 +2497,12 @@ BOOST_AUTO_TEST_CASE(invalid_server_v5) {
         }
     };
 
-    am::endpoint<async_mqtt::role::server, async_mqtt::stub_socket> ep{
+    auto ep = am::endpoint<async_mqtt::role::server, async_mqtt::stub_socket>::create(
         version,
         // for stub_socket args
         version,
         ioc
-    };
+    );
 
     auto connect = am::v5::connect_packet{
         true,   // clean_start
@@ -2604,7 +2604,7 @@ BOOST_AUTO_TEST_CASE(invalid_server_v5) {
 
     auto close = am::make_error(am::errc::network_reset, "pseudo close");
 
-    ep.next_layer().set_recv_packets(
+    ep->next_layer().set_recv_packets(
         {
             // receive packets
             connect
@@ -2616,364 +2616,364 @@ BOOST_AUTO_TEST_CASE(invalid_server_v5) {
     // compile error as expected
 #if defined(ASYNC_MQTT_TEST_COMPILE_ERROR)
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(connect, as::use_future).get();
+        auto ec = ep->send(connect, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(subscribe, as::use_future).get();
+        auto ec = ep->send(subscribe, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(unsubscribe, as::use_future).get();
+        auto ec = ep->send(unsubscribe, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(pingreq, as::use_future).get();
+        auto ec = ep->send(pingreq, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
 #endif // defined(ASYNC_MQTT_TEST_COMPILE_ERROR)
 
     // runtime error due to unable send packet
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(am::packet_variant(connect), as::use_future).get();
+        auto ec = ep->send(am::packet_variant(connect), as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(am::packet_variant(subscribe), as::use_future).get();
+        auto ec = ep->send(am::packet_variant(subscribe), as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(am::packet_variant(unsubscribe), as::use_future).get();
+        auto ec = ep->send(am::packet_variant(unsubscribe), as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(am::packet_variant(pingreq), as::use_future).get();
+        auto ec = ep->send(am::packet_variant(pingreq), as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
     // register packet_id for testing
-    BOOST_TEST(ep.register_packet_id(0x1, as::use_future).get());
+    BOOST_TEST(ep->register_packet_id(0x1, as::use_future).get());
     // offline publish success
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(publish, as::use_future).get();
+        auto ec = ep->send(publish, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::success);
     }
 
     // runtime error due to send before receiving connect
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(auth, as::use_future).get();
+        auto ec = ep->send(auth, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(puback, as::use_future).get();
+        auto ec = ep->send(puback, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(pubrec, as::use_future).get();
+        auto ec = ep->send(pubrec, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(pubrel, as::use_future).get();
+        auto ec = ep->send(pubrel, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(pubcomp, as::use_future).get();
+        auto ec = ep->send(pubcomp, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(suback, as::use_future).get();
+        auto ec = ep->send(suback, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(unsuback, as::use_future).get();
+        auto ec = ep->send(unsuback, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(pingresp, as::use_future).get();
+        auto ec = ep->send(pingresp, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
     // recv connect
     {
-        auto pv = ep.recv(as::use_future).get();
+        auto pv = ep->recv(as::use_future).get();
         BOOST_TEST(am::packet_compare(connect, pv));
     }
 
     // offline publish success
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(publish, as::use_future).get();
+        auto ec = ep->send(publish, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::success);
     }
 
     // runtime error due to send before sending connack
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(puback, as::use_future).get();
+        auto ec = ep->send(puback, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(pubrec, as::use_future).get();
+        auto ec = ep->send(pubrec, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(pubrel, as::use_future).get();
+        auto ec = ep->send(pubrel, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(pubcomp, as::use_future).get();
+        auto ec = ep->send(pubcomp, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(suback, as::use_future).get();
+        auto ec = ep->send(suback, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(unsuback, as::use_future).get();
+        auto ec = ep->send(unsuback, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(pingresp, as::use_future).get();
+        auto ec = ep->send(pingresp, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
     // send connack
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(am::packet_compare(connack, wp));
         }
     );
     {
-        auto ec = ep.send(connack, as::use_future).get();
+        auto ec = ep->send(connack, as::use_future).get();
         BOOST_TEST(!ec);
     }
 
     // offline publish success
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(publish, as::use_future).get();
+        auto ec = ep->send(publish, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::success);
     }
 
     // runtime error due to send before receiving connack with not_authorized
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(puback, as::use_future).get();
+        auto ec = ep->send(puback, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(pubrec, as::use_future).get();
+        auto ec = ep->send(pubrec, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(pubrel, as::use_future).get();
+        auto ec = ep->send(pubrel, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(pubcomp, as::use_future).get();
+        auto ec = ep->send(pubcomp, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(suback, as::use_future).get();
+        auto ec = ep->send(suback, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(unsuback, as::use_future).get();
+        auto ec = ep->send(unsuback, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
 
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(pingresp, as::use_future).get();
+        auto ec = ep->send(pingresp, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::protocol_error);
     }
-    ep.close(as::use_future).get();
+    ep->close(as::use_future).get();
     guard.reset();
     th.join();
 }

--- a/test/unit/ut_ep_send_rt_chk.cpp
+++ b/test/unit/ut_ep_send_rt_chk.cpp
@@ -38,12 +38,12 @@ BOOST_AUTO_TEST_CASE(v311_client) {
             ioc.run();
         }
     };
-    am::endpoint<async_mqtt::role::client, async_mqtt::stub_socket> ep{
+    auto ep = am::endpoint<async_mqtt::role::client, async_mqtt::stub_socket>::create(
         version,
         // for stub_socket args
         version,
         ioc
-    };
+    );
 
     {
         auto p = am::v5::connect_packet{
@@ -55,7 +55,7 @@ BOOST_AUTO_TEST_CASE(v311_client) {
             am::allocate_buffer("pass1"),
             am::properties{}
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(ec_what_start_with(ec, "protocol version mismatch"));
     }
     {
@@ -67,7 +67,7 @@ BOOST_AUTO_TEST_CASE(v311_client) {
             am::allocate_buffer("user1"),
             am::allocate_buffer("pass1")
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
@@ -75,7 +75,7 @@ BOOST_AUTO_TEST_CASE(v311_client) {
             true,   // session_present
             am::connect_return_code::not_authorized
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
@@ -84,35 +84,35 @@ BOOST_AUTO_TEST_CASE(v311_client) {
             am::allocate_buffer("payload1"),
             am::qos::at_most_once | am::pub::retain::yes | am::pub::dup::yes
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
         auto p = am::v3_1_1::puback_packet{
             0x1234 // packet_id
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
         auto p = am::v3_1_1::pubrec_packet{
             0x1234 // packet_id
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
         auto p = am::v3_1_1::pubrel_packet(
             0x1234 // packet_id
         );
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
         auto p = am::v3_1_1::pubcomp_packet{
             0x1234 // packet_id
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
@@ -124,7 +124,7 @@ BOOST_AUTO_TEST_CASE(v311_client) {
             0x1234,         // packet_id
             args
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
@@ -136,7 +136,7 @@ BOOST_AUTO_TEST_CASE(v311_client) {
             0x1234,         // packet_id
             args
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
@@ -149,29 +149,29 @@ BOOST_AUTO_TEST_CASE(v311_client) {
             0x1234,         // packet_id
             args
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
         auto p = am::v3_1_1::unsuback_packet{
             0x1234 // packet_id
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
         auto p = am::v3_1_1::pingreq_packet{};
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
         auto p = am::v3_1_1::pingresp_packet{};
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
         auto p = am::v3_1_1::disconnect_packet();
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
 
@@ -188,12 +188,12 @@ BOOST_AUTO_TEST_CASE(v311_server) {
             ioc.run();
         }
     };
-    am::endpoint<async_mqtt::role::server, async_mqtt::stub_socket> ep{
+    auto ep = am::endpoint<async_mqtt::role::server, async_mqtt::stub_socket>::create(
         version,
         // for stub_socket args
         version,
         ioc
-    };
+    );
 
     {
         auto p = am::v3_1_1::connect_packet{
@@ -204,7 +204,7 @@ BOOST_AUTO_TEST_CASE(v311_server) {
             am::allocate_buffer("user1"),
             am::allocate_buffer("pass1")
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
@@ -212,7 +212,7 @@ BOOST_AUTO_TEST_CASE(v311_server) {
             true,   // session_present
             am::connect_return_code::not_authorized
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
@@ -221,35 +221,35 @@ BOOST_AUTO_TEST_CASE(v311_server) {
             am::allocate_buffer("payload1"),
             am::qos::at_most_once | am::pub::retain::yes | am::pub::dup::yes
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
         auto p = am::v3_1_1::puback_packet{
             0x1234 // packet_id
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
         auto p = am::v3_1_1::pubrec_packet{
             0x1234 // packet_id
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
         auto p = am::v3_1_1::pubrel_packet(
             0x1234 // packet_id
         );
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
         auto p = am::v3_1_1::pubcomp_packet{
             0x1234 // packet_id
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
@@ -261,7 +261,7 @@ BOOST_AUTO_TEST_CASE(v311_server) {
             0x1234,         // packet_id
             args
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
@@ -273,7 +273,7 @@ BOOST_AUTO_TEST_CASE(v311_server) {
             0x1234,         // packet_id
             args
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
@@ -286,29 +286,29 @@ BOOST_AUTO_TEST_CASE(v311_server) {
             0x1234,         // packet_id
             args
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
         auto p = am::v3_1_1::unsuback_packet{
             0x1234 // packet_id
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
         auto p = am::v3_1_1::pingreq_packet{};
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
         auto p = am::v3_1_1::pingresp_packet{};
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
         auto p = am::v3_1_1::disconnect_packet();
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
 
@@ -326,12 +326,12 @@ BOOST_AUTO_TEST_CASE(v311_any) {
             ioc.run();
         }
     };
-    am::endpoint<async_mqtt::role::any, async_mqtt::stub_socket> ep{
+    auto ep = am::endpoint<async_mqtt::role::any, async_mqtt::stub_socket>::create(
         version,
         // for stub_socket args
         version,
         ioc
-    };
+    );
 
     {
         auto p = am::v3_1_1::connect_packet{
@@ -342,7 +342,7 @@ BOOST_AUTO_TEST_CASE(v311_any) {
             am::allocate_buffer("user1"),
             am::allocate_buffer("pass1")
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
@@ -350,7 +350,7 @@ BOOST_AUTO_TEST_CASE(v311_any) {
             true,   // session_present
             am::connect_return_code::not_authorized
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
@@ -359,35 +359,35 @@ BOOST_AUTO_TEST_CASE(v311_any) {
             am::allocate_buffer("payload1"),
             am::qos::at_most_once | am::pub::retain::yes | am::pub::dup::yes
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
         auto p = am::v3_1_1::puback_packet{
             0x1234 // packet_id
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
         auto p = am::v3_1_1::pubrec_packet{
             0x1234 // packet_id
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
         auto p = am::v3_1_1::pubrel_packet(
             0x1234 // packet_id
         );
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
         auto p = am::v3_1_1::pubcomp_packet{
             0x1234 // packet_id
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
@@ -399,7 +399,7 @@ BOOST_AUTO_TEST_CASE(v311_any) {
             0x1234,         // packet_id
             args
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
@@ -411,7 +411,7 @@ BOOST_AUTO_TEST_CASE(v311_any) {
             0x1234,         // packet_id
             args
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
@@ -424,29 +424,29 @@ BOOST_AUTO_TEST_CASE(v311_any) {
             0x1234,         // packet_id
             args
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
         auto p = am::v3_1_1::unsuback_packet{
             0x1234 // packet_id
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
         auto p = am::v3_1_1::pingreq_packet{};
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
         auto p = am::v3_1_1::pingresp_packet{};
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
         auto p = am::v3_1_1::disconnect_packet();
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
 
@@ -463,12 +463,12 @@ BOOST_AUTO_TEST_CASE(v5_client) {
             ioc.run();
         }
     };
-    am::endpoint<async_mqtt::role::client, async_mqtt::stub_socket> ep{
+    auto ep = am::endpoint<async_mqtt::role::client, async_mqtt::stub_socket>::create(
         version,
         // for stub_socket args
         version,
         ioc
-    };
+    );
 
     {
         auto p = am::v3_1_1::connect_packet{
@@ -479,7 +479,7 @@ BOOST_AUTO_TEST_CASE(v5_client) {
             am::allocate_buffer("user1"),
             am::allocate_buffer("pass1")
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(ec_what_start_with(ec, "protocol version mismatch"));
     }
     {
@@ -492,7 +492,7 @@ BOOST_AUTO_TEST_CASE(v5_client) {
             am::allocate_buffer("pass1"),
             am::properties{}
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
@@ -501,7 +501,7 @@ BOOST_AUTO_TEST_CASE(v5_client) {
             am::connect_reason_code::not_authorized,
             am::properties{}
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         // packet type checking is prior to version checking
         BOOST_TEST(ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
@@ -512,7 +512,7 @@ BOOST_AUTO_TEST_CASE(v5_client) {
             am::qos::at_most_once | am::pub::retain::yes | am::pub::dup::yes,
             am::properties{}
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
@@ -521,7 +521,7 @@ BOOST_AUTO_TEST_CASE(v5_client) {
             am::puback_reason_code::packet_identifier_in_use,
             am::properties{}
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
@@ -530,7 +530,7 @@ BOOST_AUTO_TEST_CASE(v5_client) {
             am::pubrec_reason_code::packet_identifier_in_use,
             am::properties{}
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
@@ -539,7 +539,7 @@ BOOST_AUTO_TEST_CASE(v5_client) {
             am::pubrel_reason_code::packet_identifier_not_found,
             am::properties{}
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
@@ -548,7 +548,7 @@ BOOST_AUTO_TEST_CASE(v5_client) {
             am::pubcomp_reason_code::packet_identifier_not_found,
             am::properties{}
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
@@ -561,7 +561,7 @@ BOOST_AUTO_TEST_CASE(v5_client) {
             args,
             am::properties{}
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
@@ -574,7 +574,7 @@ BOOST_AUTO_TEST_CASE(v5_client) {
             args,
             am::properties{}
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
@@ -587,7 +587,7 @@ BOOST_AUTO_TEST_CASE(v5_client) {
             args,
             am::properties{}
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
@@ -600,17 +600,17 @@ BOOST_AUTO_TEST_CASE(v5_client) {
             args,
             am::properties{}
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
         auto p = am::v5::pingreq_packet{};
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
         auto p = am::v5::pingresp_packet{};
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
@@ -618,7 +618,7 @@ BOOST_AUTO_TEST_CASE(v5_client) {
             am::auth_reason_code::continue_authentication,
             am::properties{}
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
@@ -626,7 +626,7 @@ BOOST_AUTO_TEST_CASE(v5_client) {
             am::disconnect_reason_code::protocol_error,
             am::properties{}
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
 
@@ -643,12 +643,12 @@ BOOST_AUTO_TEST_CASE(v5_server) {
             ioc.run();
         }
     };
-    am::endpoint<async_mqtt::role::server, async_mqtt::stub_socket> ep{
+    auto ep = am::endpoint<async_mqtt::role::server, async_mqtt::stub_socket>::create(
         version,
         // for stub_socket args
         version,
         ioc
-    };
+    );
 
     {
         auto p = am::v5::connect_packet{
@@ -660,7 +660,7 @@ BOOST_AUTO_TEST_CASE(v5_server) {
             am::allocate_buffer("pass1"),
             am::properties{}
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
@@ -669,7 +669,7 @@ BOOST_AUTO_TEST_CASE(v5_server) {
             am::connect_reason_code::not_authorized,
             am::properties{}
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         // packet type checking is prior to version checking
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
@@ -680,7 +680,7 @@ BOOST_AUTO_TEST_CASE(v5_server) {
             am::qos::at_most_once | am::pub::retain::yes | am::pub::dup::yes,
             am::properties{}
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
@@ -689,7 +689,7 @@ BOOST_AUTO_TEST_CASE(v5_server) {
             am::puback_reason_code::packet_identifier_in_use,
             am::properties{}
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
@@ -698,7 +698,7 @@ BOOST_AUTO_TEST_CASE(v5_server) {
             am::pubrec_reason_code::packet_identifier_in_use,
             am::properties{}
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
@@ -707,7 +707,7 @@ BOOST_AUTO_TEST_CASE(v5_server) {
             am::pubrel_reason_code::packet_identifier_not_found,
             am::properties{}
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
@@ -716,7 +716,7 @@ BOOST_AUTO_TEST_CASE(v5_server) {
             am::pubcomp_reason_code::packet_identifier_not_found,
             am::properties{}
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
@@ -729,7 +729,7 @@ BOOST_AUTO_TEST_CASE(v5_server) {
             args,
             am::properties{}
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
@@ -742,7 +742,7 @@ BOOST_AUTO_TEST_CASE(v5_server) {
             args,
             am::properties{}
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
@@ -755,7 +755,7 @@ BOOST_AUTO_TEST_CASE(v5_server) {
             args,
             am::properties{}
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
@@ -768,17 +768,17 @@ BOOST_AUTO_TEST_CASE(v5_server) {
             args,
             am::properties{}
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
         auto p = am::v5::pingreq_packet{};
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
         auto p = am::v5::pingresp_packet{};
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
@@ -786,7 +786,7 @@ BOOST_AUTO_TEST_CASE(v5_server) {
             am::auth_reason_code::continue_authentication,
             am::properties{}
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
@@ -794,7 +794,7 @@ BOOST_AUTO_TEST_CASE(v5_server) {
             am::disconnect_reason_code::protocol_error,
             am::properties{}
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
 
@@ -811,12 +811,12 @@ BOOST_AUTO_TEST_CASE(v5_any) {
             ioc.run();
         }
     };
-    am::endpoint<async_mqtt::role::any, async_mqtt::stub_socket> ep{
+    auto ep = am::endpoint<async_mqtt::role::any, async_mqtt::stub_socket>::create(
         version,
         // for stub_socket args
         version,
         ioc
-    };
+    );
 
     {
         auto p = am::v5::connect_packet{
@@ -828,7 +828,7 @@ BOOST_AUTO_TEST_CASE(v5_any) {
             am::allocate_buffer("pass1"),
             am::properties{}
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
@@ -837,7 +837,7 @@ BOOST_AUTO_TEST_CASE(v5_any) {
             am::connect_reason_code::not_authorized,
             am::properties{}
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         // packet type checking is prior to version checking
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
@@ -848,7 +848,7 @@ BOOST_AUTO_TEST_CASE(v5_any) {
             am::qos::at_most_once | am::pub::retain::yes | am::pub::dup::yes,
             am::properties{}
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
@@ -857,7 +857,7 @@ BOOST_AUTO_TEST_CASE(v5_any) {
             am::puback_reason_code::packet_identifier_in_use,
             am::properties{}
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
@@ -866,7 +866,7 @@ BOOST_AUTO_TEST_CASE(v5_any) {
             am::pubrec_reason_code::packet_identifier_in_use,
             am::properties{}
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
@@ -875,7 +875,7 @@ BOOST_AUTO_TEST_CASE(v5_any) {
             am::pubrel_reason_code::packet_identifier_not_found,
             am::properties{}
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
@@ -884,7 +884,7 @@ BOOST_AUTO_TEST_CASE(v5_any) {
             am::pubcomp_reason_code::packet_identifier_not_found,
             am::properties{}
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
@@ -897,7 +897,7 @@ BOOST_AUTO_TEST_CASE(v5_any) {
             args,
             am::properties{}
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
@@ -910,7 +910,7 @@ BOOST_AUTO_TEST_CASE(v5_any) {
             args,
             am::properties{}
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
@@ -923,7 +923,7 @@ BOOST_AUTO_TEST_CASE(v5_any) {
             args,
             am::properties{}
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
@@ -936,17 +936,17 @@ BOOST_AUTO_TEST_CASE(v5_any) {
             args,
             am::properties{}
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
         auto p = am::v5::pingreq_packet{};
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
         auto p = am::v5::pingresp_packet{};
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
@@ -954,7 +954,7 @@ BOOST_AUTO_TEST_CASE(v5_any) {
             am::auth_reason_code::continue_authentication,
             am::properties{}
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
     {
@@ -962,7 +962,7 @@ BOOST_AUTO_TEST_CASE(v5_any) {
             am::disconnect_reason_code::protocol_error,
             am::properties{}
         };
-        auto ec = ep.send(am::packet_variant{p}, as::use_future).get();
+        auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
     }
 

--- a/test/unit/ut_ep_size_max.cpp
+++ b/test/unit/ut_ep_size_max.cpp
@@ -31,14 +31,14 @@ BOOST_AUTO_TEST_CASE(client_send) {
         }
     };
 
-    am::endpoint<async_mqtt::role::client, async_mqtt::stub_socket> ep{
+    auto ep = am::endpoint<async_mqtt::role::client, async_mqtt::stub_socket>::create(
         version,
         // for stub_socket args
         version,
         ioc
-    };
+    );
 
-    ep.next_layer().set_close_checker(
+    ep->next_layer().set_close_checker(
         [&] { BOOST_TEST(false); }
     );
 
@@ -62,7 +62,7 @@ BOOST_AUTO_TEST_CASE(client_send) {
         }
     };
 
-    ep.next_layer().set_recv_packets(
+    ep->next_layer().set_recv_packets(
         {
             // receive packets
             connack,
@@ -70,24 +70,24 @@ BOOST_AUTO_TEST_CASE(client_send) {
     );
 
     // send connect
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(am::packet_compare(connect, wp));
         }
     );
     {
-        auto ec = ep.send(connect, as::use_future).get();
+        auto ec = ep->send(connect, as::use_future).get();
         BOOST_TEST(!ec);
     }
 
     // recv connack
     {
-        auto pv = ep.recv(as::use_future).get();
+        auto pv = ep->recv(as::use_future).get();
         BOOST_TEST(am::packet_compare(connack, pv));
     }
 
     // size: 21bytes
-    auto pid_opt1 = ep.acquire_unique_packet_id(as::use_future).get();
+    auto pid_opt1 = ep->acquire_unique_packet_id(as::use_future).get();
     BOOST_TEST(pid_opt1.has_value());
     auto publish_1_q1 = am::v5::publish_packet(
         *pid_opt1,
@@ -98,7 +98,7 @@ BOOST_AUTO_TEST_CASE(client_send) {
     );
 
     // size: 22bytes
-    auto pid_opt2 = ep.acquire_unique_packet_id(as::use_future).get();
+    auto pid_opt2 = ep->acquire_unique_packet_id(as::use_future).get();
     BOOST_TEST(pid_opt2.has_value());
     auto publish_2_q1 = am::v5::publish_packet(
         *pid_opt2,
@@ -109,32 +109,32 @@ BOOST_AUTO_TEST_CASE(client_send) {
     );
 
     // send publish_1
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(am::packet_compare(publish_1_q1, wp));
         }
     );
     {
-        auto ec = ep.send(publish_1_q1, as::use_future).get();
+        auto ec = ep->send(publish_1_q1, as::use_future).get();
         BOOST_TEST(!ec);
     }
 
     // send publish_2
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant) {
             BOOST_TEST(false);
         }
     );
     {
-        auto ec = ep.send(publish_2_q1, as::use_future).get();
+        auto ec = ep->send(publish_2_q1, as::use_future).get();
         BOOST_TEST(ec.code() == am::errc::bad_message);
     }
-    auto pid_opt3 = ep.acquire_unique_packet_id(as::use_future).get();
+    auto pid_opt3 = ep->acquire_unique_packet_id(as::use_future).get();
     BOOST_TEST(pid_opt3.has_value());
     BOOST_TEST(*pid_opt3 == 2); // 2 can be resused
 
-    ep.next_layer().set_close_checker({});
-    ep.close(as::use_future).get();
+    ep->next_layer().set_close_checker({});
+    ep->close(as::use_future).get();
     guard.reset();
     th.join();
 }
@@ -149,14 +149,14 @@ BOOST_AUTO_TEST_CASE(client_recv) {
         }
     };
 
-    am::endpoint<async_mqtt::role::client, async_mqtt::stub_socket> ep{
+    auto ep = am::endpoint<async_mqtt::role::client, async_mqtt::stub_socket>::create(
         version,
         // for stub_socket args
         version,
         ioc
-    };
+    );
 
-    ep.next_layer().set_close_checker(
+    ep->next_layer().set_close_checker(
         [&] { BOOST_TEST(false); }
     );
 
@@ -185,7 +185,7 @@ BOOST_AUTO_TEST_CASE(client_recv) {
         am::properties{}
     };
 
-    ep.next_layer().set_recv_packets(
+    ep->next_layer().set_recv_packets(
         {
             // receive packets
             connack,
@@ -193,24 +193,24 @@ BOOST_AUTO_TEST_CASE(client_recv) {
     );
 
     // send connect
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(am::packet_compare(connect, wp));
         }
     );
     {
-        auto ec = ep.send(connect, as::use_future).get();
+        auto ec = ep->send(connect, as::use_future).get();
         BOOST_TEST(!ec);
     }
 
     // recv connack
     {
-        auto pv = ep.recv(as::use_future).get();
+        auto pv = ep->recv(as::use_future).get();
         BOOST_TEST(am::packet_compare(connack, pv));
     }
 
     // size: 21bytes
-    auto pid_opt1 = ep.acquire_unique_packet_id(as::use_future).get();
+    auto pid_opt1 = ep->acquire_unique_packet_id(as::use_future).get();
     BOOST_TEST(pid_opt1.has_value());
     auto publish_1_q1 = am::v5::publish_packet(
         *pid_opt1,
@@ -221,7 +221,7 @@ BOOST_AUTO_TEST_CASE(client_recv) {
     );
 
     // size: 22bytes
-    auto pid_opt2 = ep.acquire_unique_packet_id(as::use_future).get();
+    auto pid_opt2 = ep->acquire_unique_packet_id(as::use_future).get();
     BOOST_TEST(pid_opt2.has_value());
     auto publish_2_q1 = am::v5::publish_packet(
         *pid_opt2,
@@ -231,7 +231,7 @@ BOOST_AUTO_TEST_CASE(client_recv) {
         am::properties{}
     );
 
-    ep.next_layer().set_recv_packets(
+    ep->next_layer().set_recv_packets(
         {
             // receive packets
             publish_1_q1,
@@ -241,23 +241,23 @@ BOOST_AUTO_TEST_CASE(client_recv) {
 
     // recv publish1
     {
-        auto pv = ep.recv(as::use_future).get();
+        auto pv = ep->recv(as::use_future).get();
         BOOST_TEST(am::packet_compare(publish_1_q1, pv));
     }
 
     // recv publish2
     bool close_called = false;
-    ep.next_layer().set_close_checker(
+    ep->next_layer().set_close_checker(
         [&] { close_called = true; }
     );
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(!close_called);
             BOOST_TEST(am::packet_compare(disconnect, wp));
         }
     );
     {
-        auto pv = ep.recv(as::use_future).get();
+        auto pv = ep->recv(as::use_future).get();
         BOOST_TEST(pv.get_if<am::system_error>() != nullptr);
         BOOST_TEST(pv.get_if<am::system_error>()->code() == am::errc::bad_message);
     }
@@ -277,14 +277,14 @@ BOOST_AUTO_TEST_CASE(server_recv) {
         }
     };
 
-    am::endpoint<async_mqtt::role::server, async_mqtt::stub_socket> ep{
+    auto ep = am::endpoint<async_mqtt::role::server, async_mqtt::stub_socket>::create(
         version,
         // for stub_socket args
         version,
         ioc
-    };
+    );
 
-    ep.next_layer().set_close_checker(
+    ep->next_layer().set_close_checker(
         [&] { BOOST_TEST(false); }
     );
 
@@ -313,7 +313,7 @@ BOOST_AUTO_TEST_CASE(server_recv) {
         am::properties{}
     };
 
-    ep.next_layer().set_recv_packets(
+    ep->next_layer().set_recv_packets(
         {
             // receive packets
             connect,
@@ -322,23 +322,23 @@ BOOST_AUTO_TEST_CASE(server_recv) {
 
     // recv connect
     {
-        auto pv = ep.recv(as::use_future).get();
+        auto pv = ep->recv(as::use_future).get();
         BOOST_TEST(am::packet_compare(connect, pv));
     }
 
     // send connack
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(am::packet_compare(connack, wp));
         }
     );
     {
-        auto ec = ep.send(connack, as::use_future).get();
+        auto ec = ep->send(connack, as::use_future).get();
         BOOST_TEST(!ec);
     }
 
     // size: 21bytes
-    auto pid_opt1 = ep.acquire_unique_packet_id(as::use_future).get();
+    auto pid_opt1 = ep->acquire_unique_packet_id(as::use_future).get();
     BOOST_TEST(pid_opt1.has_value());
     auto publish_1_q1 = am::v5::publish_packet(
         *pid_opt1,
@@ -349,7 +349,7 @@ BOOST_AUTO_TEST_CASE(server_recv) {
     );
 
     // size: 22bytes
-    auto pid_opt2 = ep.acquire_unique_packet_id(as::use_future).get();
+    auto pid_opt2 = ep->acquire_unique_packet_id(as::use_future).get();
     BOOST_TEST(pid_opt2.has_value());
     auto publish_2_q1 = am::v5::publish_packet(
         *pid_opt2,
@@ -359,7 +359,7 @@ BOOST_AUTO_TEST_CASE(server_recv) {
         am::properties{}
     );
 
-    ep.next_layer().set_recv_packets(
+    ep->next_layer().set_recv_packets(
         {
             // receive packets
             publish_1_q1,
@@ -369,23 +369,23 @@ BOOST_AUTO_TEST_CASE(server_recv) {
 
     // recv publish1
     {
-        auto pv = ep.recv(as::use_future).get();
+        auto pv = ep->recv(as::use_future).get();
         BOOST_TEST(am::packet_compare(publish_1_q1, pv));
     }
 
     // recv publish2
     bool close_called = false;
-    ep.next_layer().set_close_checker(
+    ep->next_layer().set_close_checker(
         [&] { close_called = true; }
     );
-    ep.next_layer().set_write_packet_checker(
+    ep->next_layer().set_write_packet_checker(
         [&](am::packet_variant wp) {
             BOOST_TEST(!close_called);
             BOOST_TEST(am::packet_compare(disconnect, wp));
         }
     );
     {
-        auto pv = ep.recv(as::use_future).get();
+        auto pv = ep->recv(as::use_future).get();
         BOOST_TEST(pv.get_if<am::system_error>() != nullptr);
         BOOST_TEST(pv.get_if<am::system_error>()->code() == am::errc::bad_message);
     }

--- a/test/unit/ut_static_assert_fail_client.cpp
+++ b/test/unit/ut_static_assert_fail_client.cpp
@@ -18,17 +18,17 @@ namespace as = boost::asio;
 BOOST_AUTO_TEST_CASE(tc) {
     auto version = am::protocol_version::v3_1_1;
     as::io_context ioc;
-    am::endpoint<async_mqtt::role::client, async_mqtt::stub_socket> ep{
+    auto ep = am::endpoint<async_mqtt::role::client, async_mqtt::stub_socket>::create(
         version,
         // for stub_socket args
         version,
         ioc
-    };
+    );
     auto p = am::v3_1_1::connack_packet{
         true,   // session_present
         am::connect_return_code::not_authorized
     };
     // static_assert fail as expected
-    auto ec = ep.send(p, as::use_future).get();
+    auto ec = ep->send(p, as::use_future).get();
     BOOST_TEST(!ec);
 }

--- a/test/unit/ut_static_assert_fail_server.cpp
+++ b/test/unit/ut_static_assert_fail_server.cpp
@@ -18,12 +18,12 @@ namespace as = boost::asio;
 BOOST_AUTO_TEST_CASE(tc) {
     auto version = am::protocol_version::v3_1_1;
     as::io_context ioc;
-    am::endpoint<async_mqtt::role::server, async_mqtt::stub_socket> ep{
+    auto ep = am::endpoint<async_mqtt::role::server, async_mqtt::stub_socket>::create(
         version,
         // for stub_socket args
         version,
         ioc
-    };
+    );
     auto p = am::v3_1_1::connect_packet{
         true,   // clean_session
         0x0, // keep_alive
@@ -33,6 +33,6 @@ BOOST_AUTO_TEST_CASE(tc) {
         am::allocate_buffer("pass1")
     };
     // static_assert fail as expected
-    auto ec = ep.send(p, as::use_future).get();
+    auto ec = ep->send(p, as::use_future).get();
     BOOST_TEST(!ec);
 }

--- a/test/unit/ut_strm.cpp
+++ b/test/unit/ut_strm.cpp
@@ -23,7 +23,7 @@ namespace am = async_mqtt;
 namespace as = boost::asio;
 
 // packet_id is hard coded in this test case for just testing.
-// but users need to get packet_id via ep.acquire_unique_packet_id(...)
+// but users need to get packet_id via ep->acquire_unique_packet_id(...)
 // see other test cases.
 
 // v3_1_1
@@ -33,7 +33,7 @@ BOOST_AUTO_TEST_CASE(write_cont) {
     as::io_context ioc;
 
     using strm_t = am::stream<async_mqtt::stub_socket>;
-    auto s = std::make_shared<strm_t>(
+    auto s = strm_t::create(
         // for stub_socket args
         version,
         ioc

--- a/tool/bench.cpp
+++ b/tool/bench.cpp
@@ -1958,7 +1958,7 @@ int main(int argc, char *argv[]) {
             std::size_t hps_index = target_index;
             for (std::size_t i = 0; i != clients; ++i) {
                 cis.emplace_back(
-                    std::make_shared<client_t>(
+                    client_t::create(
                         version,
                         iocs.at(i % num_of_iocs).get_executor()
                     ),
@@ -2023,7 +2023,7 @@ int main(int argc, char *argv[]) {
                     ctx.set_verify_mode(am::tls::verify_none);
                 }
                 cis.emplace_back(
-                    std::make_shared<client_t>(
+                    client_t::create(
                         version,
                         iocs.at(i % num_of_iocs).get_executor(),
                         ctx
@@ -2086,7 +2086,7 @@ int main(int argc, char *argv[]) {
             std::size_t hps_index = target_index;
             for (std::size_t i = 0; i != clients; ++i) {
                 cis.emplace_back(
-                    std::make_shared<client_t>(
+                    client_t::create(
                         version,
                         iocs.at(i % num_of_iocs).get_executor()
                     ),
@@ -2156,7 +2156,7 @@ int main(int argc, char *argv[]) {
                     ctx.set_verify_mode(am::tls::verify_none);
                 }
                 cis.emplace_back(
-                    std::make_shared<client_t>(
+                    client_t::create(
                         version,
                         iocs.at(i % num_of_iocs).get_executor(),
                         ctx

--- a/tool/broker.cpp
+++ b/tool/broker.cpp
@@ -222,7 +222,7 @@ void run_broker(boost::program_options::variables_map const& vm) {
             mqtt_async_accept =
                 [&] {
                     auto epsp =
-                        std::make_shared<am::endpoint<am::role::server, am::protocol::mqtt>>(
+                        am::endpoint<am::role::server, am::protocol::mqtt>::create(
                             am::protocol_version::undetermined,
                             con_ioc_getter().get_executor()
                         );
@@ -258,7 +258,7 @@ void run_broker(boost::program_options::variables_map const& vm) {
             ws_async_accept =
                 [&] {
                     auto epsp =
-                        std::make_shared<am::endpoint<am::role::server, am::protocol::ws>>(
+                        am::endpoint<am::role::server, am::protocol::ws>::create(
                             am::protocol_version::undetermined,
                             con_ioc_getter().get_executor()
                         );
@@ -345,7 +345,7 @@ void run_broker(boost::program_options::variables_map const& vm) {
                         }
                     );
                     auto epsp =
-                        std::make_shared<am::endpoint<am::role::server, am::protocol::mqtts>>(
+                        am::endpoint<am::role::server, am::protocol::mqtts>::create(
                             am::protocol_version::undetermined,
                             con_ioc_getter().get_executor(),
                             *mqtts_ctx
@@ -433,7 +433,7 @@ void run_broker(boost::program_options::variables_map const& vm) {
                         }
                     );
                     auto epsp =
-                        std::make_shared<am::endpoint<am::role::server, am::protocol::wss>>(
+                        am::endpoint<am::role::server, am::protocol::wss>::create(
                             am::protocol_version::undetermined,
                             con_ioc_getter().get_executor(),
                             *wss_ctx

--- a/tool/client_cli.cpp
+++ b/tool/client_cli.cpp
@@ -1086,12 +1086,12 @@ int main(int argc, char* argv[]) {
         if (protocol == "mqtt") {
             as::ip::tcp::socket resolve_sock{ioc};
             as::ip::tcp::resolver res{resolve_sock.get_executor()};
-            am::endpoint<am::role::client, am::protocol::mqtt> amep {
+            auto amep = am::endpoint<am::role::client, am::protocol::mqtt>::create(
                 version,
                 ioc.get_executor()
-            };
-            auto cc = client_cli{ioc, amep, version};
-            auto nm = network_manager{amep, res, vm, version};
+            );
+            auto cc = client_cli{ioc, *amep, version};
+            auto nm = network_manager{*amep, res, vm, version};
             nm();
             ioc.run();
             return 0;
@@ -1120,13 +1120,13 @@ int main(int argc, char* argv[]) {
                 ctx.use_certificate_chain_file(vm["certificate"].as<std::string>());
                 ctx.use_private_key_file(vm["private_key"].as<std::string>(), boost::asio::ssl::context::pem);
             }
-            am::endpoint<am::role::client, am::protocol::mqtts> amep {
+            auto amep = am::endpoint<am::role::client, am::protocol::mqtts>::create(
                 version,
                 ioc.get_executor(),
                 ctx
-            };
-            auto cc = client_cli{ioc, amep, version};
-            auto nm = network_manager{amep, res, vm, version};
+            );
+            auto cc = client_cli{ioc, *amep, version};
+            auto nm = network_manager{*amep, res, vm, version};
             nm();
             ioc.run();
             return 0;
@@ -1136,12 +1136,12 @@ int main(int argc, char* argv[]) {
         else if (protocol == "ws") {
             as::ip::tcp::socket resolve_sock{ioc};
             as::ip::tcp::resolver res{resolve_sock.get_executor()};
-            am::endpoint<am::role::client, am::protocol::ws> amep {
+            auto amep = am::endpoint<am::role::client, am::protocol::ws>::create(
                 version,
                 ioc.get_executor()
-            };
-            auto cc = client_cli{ioc, amep, version};
-            auto nm = network_manager{amep, res, vm, version};
+            );
+            auto cc = client_cli{ioc, *amep, version};
+            auto nm = network_manager{*amep, res, vm, version};
             nm();
             ioc.run();
             return 0;
@@ -1171,13 +1171,13 @@ int main(int argc, char* argv[]) {
                 ctx.use_certificate_chain_file(vm["certificate"].as<std::string>());
                 ctx.use_private_key_file(vm["private_key"].as<std::string>(), boost::asio::ssl::context::pem);
             }
-            am::endpoint<am::role::client, am::protocol::wss> amep {
+            auto amep = am::endpoint<am::role::client, am::protocol::wss>::create(
                 version,
                 ioc.get_executor(),
                 ctx
-            };
-            auto cc = client_cli{ioc, amep, version};
-            auto nm = network_manager{amep, res, vm, version};
+            );
+            auto cc = client_cli{ioc, *amep, version};
+            auto nm = network_manager{*amep, res, vm, version};
             nm();
             ioc.run();
             return 0;


### PR DESCRIPTION
close async function is called not only by user but also internally. Their CompletionToken should be invoked validly. In order to do that, the mechanism to extend endpoint lifetime is required. So I made endpoint shared_ptr based design and using shared_from_this().