### PR TITLE
Used any_io_executor as the base of predefined `mqtt` protocol.

### DIFF
--- a/example/ep_cpp20coro_mqtt_client.cpp
+++ b/example/ep_cpp20coro_mqtt_client.cpp
@@ -14,9 +14,9 @@
 namespace as = boost::asio;
 namespace am = async_mqtt;
 
-template <typename Executor>
 as::awaitable<void>
-proc(Executor exe, std::string_view host, std::string_view port) {
+proc(std::string_view host, std::string_view port) {
+    auto exe = co_await as::this_coro::executor;
     as::ip::tcp::socket resolve_sock{exe};
     as::ip::tcp::resolver res{exe};
     auto amep = am::endpoint<am::role::client, am::protocol::mqtt>::create(
@@ -183,6 +183,6 @@ int main(int argc, char* argv[]) {
         return -1;
     }
     as::io_context ioc;
-    as::co_spawn(ioc, proc(ioc.get_executor(), argv[1], argv[2]), as::detached);
+    as::co_spawn(ioc.get_executor(), proc(argv[1], argv[2]), as::detached);
     ioc.run();
 }

--- a/include/async_mqtt/predefined_underlying_layer.hpp
+++ b/include/async_mqtt/predefined_underlying_layer.hpp
@@ -24,13 +24,20 @@ namespace protocol {
 /**
  * @breif Type alias of Boost.Asio TCP socket
  */
-using mqtt = as::basic_stream_socket<as::ip::tcp, as::io_context::executor_type>;
+using mqtt = as::basic_stream_socket<as::ip::tcp, as::any_io_executor>;
 
 #if defined(ASYNC_MQTT_USE_WS)
+
+namespace detail {
+
+using mqtt_beast_workaround = as::basic_stream_socket<as::ip::tcp, as::io_context::executor_type>;
+
+} // namespace detail
+
 /**
  * @breif Type alias of Boost.Beast WebScoket
  */
-using ws = bs::websocket::stream<mqtt>;
+using ws = bs::websocket::stream<detail::mqtt_beast_workaround>;
 #endif //defined(ASYNC_MQTT_USE_WS)
 
 } // namespace procotol
@@ -49,10 +56,17 @@ namespace protocol {
 using mqtts = tls::stream<mqtt>;
 
 #if defined(ASYNC_MQTT_USE_WS)
+
+namespace detail {
+
+using mqtts_beast_workaround = tls::stream<mqtt_beast_workaround>;
+
+} // namespace detail
+
 /**
  * @breif Type alias of Boost.Beast WebSocket on TLS stream
  */
-using wss = bs::websocket::stream<mqtts>;
+using wss = bs::websocket::stream<detail::mqtts_beast_workaround>;
 #endif // defined(ASYNC_MQTT_USE_WS)
 
 


### PR DESCRIPTION
ws and wss don't support any_io_executor due to the following issue: https://github.com/boostorg/beast/issues/2775