### PR TITLE
Re-designed unique_scope_guard.

### DIFF
--- a/.github/workflows/gha.yml
+++ b/.github/workflows/gha.yml
@@ -104,7 +104,7 @@ jobs:
         NS_LDFLAGS:    -Werror -g -Wall -Wextra -Wno-ignored-qualifiers -Wconversion
       run: |
         [ ${{ matrix.pattern }} == 0 ] || [ ${{ matrix.pattern }} == 1 ] && \
-        export CFLAGS=${S_CFLAGS} && export CXXFLAGS=${S_CXXFLAGS} && export LDFLAGS=${S_LDFLAGS}
+        export CFLAGS=${NS_CFLAGS} && export CXXFLAGS=${NS_CXXFLAGS} && export LDFLAGS=${NS_LDFLAGS}
         [ ${{ matrix.pattern }} == 2 ] && \
         export CFLAGS=${NS_CFLAGS} && export CXXFLAGS=${NS_CXXFLAGS} && export LDFLAGS=${NS_LDFLAGS}
         [ ${{ matrix.pattern }} == 3 ] && \

--- a/include/async_mqtt/util/scope_guard.hpp
+++ b/include/async_mqtt/util/scope_guard.hpp
@@ -12,11 +12,32 @@
 
 namespace async_mqtt {
 
+namespace detail {
 template <typename Proc>
-inline auto unique_scope_guard(Proc&& proc) {
-    static int nouse;
-    auto deleter = [proc = std::forward<Proc>(proc)](void*) { std::move(proc)(); };
-    return std::unique_ptr<void, decltype(deleter)>(&nouse, force_move(deleter));
+class unique_sg {
+public:
+    unique_sg(Proc proc) noexcept
+        :proc_{std::move(proc)}
+    {}
+    unique_sg(unique_sg const&) = delete;
+    unique_sg(unique_sg&& other) noexcept
+        :proc_{other.proc_} {
+        other.moved_ = true;
+    }
+    ~unique_sg() noexcept {
+        if (!moved_) std::move(proc_)();
+    }
+
+private:
+    Proc proc_;
+    bool moved_ = false;
+};
+
+} // namespace detail
+
+template <typename Proc>
+inline detail::unique_sg<Proc> unique_scope_guard(Proc&& proc) noexcept {
+    return detail::unique_sg<Proc>{std::forward<Proc>(proc)};
 }
 
 } // namespace async_mqtt

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -68,6 +68,7 @@ list(APPEND check_PROGRAMS
     ut_topic_alias.cpp
     ut_topic_sharename.cpp
     ut_topic_subopts.cpp
+    ut_unique_scope_guard.cpp
     ut_value_allocator.cpp
 )
 

--- a/test/unit/ut_unique_scope_guard.cpp
+++ b/test/unit/ut_unique_scope_guard.cpp
@@ -1,0 +1,44 @@
+// Copyright Takatoshi Kondo 2021
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include "../common/test_main.hpp"
+#include "../common/global_fixture.hpp"
+
+#include <string_view>
+#include <sstream>
+
+#include <async_mqtt/util/scope_guard.hpp>
+
+BOOST_AUTO_TEST_SUITE(ut_unique_scope_guard)
+
+namespace am = async_mqtt;
+
+BOOST_AUTO_TEST_CASE( simple ) {
+    int i = 0;
+    {
+        auto g1 = am::unique_scope_guard(
+            [&] {
+                ++i;
+            }
+        );
+    }
+    BOOST_TEST(i == 1);
+}
+
+BOOST_AUTO_TEST_CASE( move_c ) {
+    int i = 0;
+    {
+        auto g1 = am::unique_scope_guard(
+            [&] {
+                ++i;
+            }
+        );
+        auto g2{std::move(g1)};
+    }
+    BOOST_TEST(i == 1);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
When Boost.1.85.0 would released, it will migrate to Boost.Scope.