### PR TITLE
Fix unused variable in release build

### DIFF
--- a/include/async_mqtt/stream.hpp
+++ b/include/async_mqtt/stream.hpp
@@ -278,7 +278,7 @@ private:
             error_code const& ec,
             std::size_t bytes_transferred
         ) {
-            boost::ignore_unused(bytes_transferred);
+            (void)bytes_transferred; // Ignore unused argument in release build
 
             BOOST_ASSERT(strm.in_strand());
             if (ec) {


### PR DESCRIPTION
bytes_transferred is only used by a BOOST_ASSERT that translates to nothing in a release build, causing an unused variable warning