### PR TITLE
Implemented customization layer for underlying layers.

### DIFF
--- a/.github/workflows/gha.yml
+++ b/.github/workflows/gha.yml
@@ -29,10 +29,10 @@ jobs:
       env:
         OPENSSL_ROOT_DIR: /usr/local/opt/openssl
         S_CFLAGS:      -Werror -g -Wall -Wextra -Wno-ignored-qualifiers -Wconversion -fno-omit-frame-pointer -fsanitize=address
-        S_CXXFLAGS:    -Werror -g -Wall -Wextra -Wno-ignored-qualifiers -Wconversion -fno-omit-frame-pointer -fsanitize=address -pedantic -Wno-noexcept-type -DBOOST_ASIO_NO_DEPRECATED -DBOOST_MULTI_INDEX_ENABLE_SAFE_MODE -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -DBOOST_MULTI_INDEX_ENABLE_INVARIANT_CHECKING
+        S_CXXFLAGS:    -Werror -g -Wall -Wextra -Wno-ignored-qualifiers -Wconversion -fno-omit-frame-pointer -fsanitize=address -pedantic -Wno-noexcept-type -DBOOST_ASIO_NO_DEPRECATED -DBOOST_MULTI_INDEX_ENABLE_SAFE_MODE -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -DBOOST_MULTI_INDEX_ENABLE_INVARIANT_CHECKING -ftemplate-backtrace-limit=0
         S_LDFLAGS:     -Werror -g -Wall -Wextra -Wno-ignored-qualifiers -Wconversion -fno-omit-frame-pointer -fsanitize=address
         NS_CFLAGS:     -Werror -g -Wall -Wextra -Wno-ignored-qualifiers -Wconversion
-        NS_CXXFLAGS:   -Werror -g -Wall -Wextra -Wno-ignored-qualifiers -Wconversion -pedantic -Wno-noexcept-type -DBOOST_ASIO_NO_DEPRECATED -DBOOST_MULTI_INDEX_ENABLE_SAFE_MODE -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -DBOOST_MULTI_INDEX_ENABLE_INVARIANT_CHECKING
+        NS_CXXFLAGS:   -Werror -g -Wall -Wextra -Wno-ignored-qualifiers -Wconversion -pedantic -Wno-noexcept-type -DBOOST_ASIO_NO_DEPRECATED -DBOOST_MULTI_INDEX_ENABLE_SAFE_MODE -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -DBOOST_MULTI_INDEX_ENABLE_INVARIANT_CHECKING -ftemplate-backtrace-limit=0
         PROF_CXXFLAGS: -Werror -g -Wall -Wextra -Wno-ignored-qualifiers -Wconversion -pedantic -Wno-noexcept-type -DBOOST_ASIO_NO_DEPRECATED -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -fprofile-arcs -ftest-coverage
         NS_LDFLAGS:    -Werror -g -Wall -Wextra -Wno-ignored-qualifiers -Wconversion
       run: |
@@ -87,7 +87,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: usr
-        key: ${{ runner.os }}-boost-20230507
+        key: ${{ runner.os }}-boost-20240507-2
     - name: install clang++15
       run: |
          sudo apt-get install clang-15 clang++-15
@@ -97,12 +97,12 @@ jobs:
     - name: Configure
       env:
         S_CFLAGS:      -Werror -g -Wall -Wextra -Wno-ignored-qualifiers -Wconversion -fno-omit-frame-pointer -fsanitize=address
-        S_CXXFLAGS:    -Werror -g -Wall -Wextra -Wno-ignored-qualifiers -Wconversion -fno-omit-frame-pointer -fsanitize=address -pedantic -Wno-noexcept-type -DBOOST_ASIO_NO_DEPRECATED -DBOOST_MULTI_INDEX_ENABLE_SAFE_MODE -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -DBOOST_MULTI_INDEX_ENABLE_INVARIANT_CHECKING
+        S_CXXFLAGS:    -Werror -g -Wall -Wextra -Wno-ignored-qualifiers -Wconversion -fno-omit-frame-pointer -fsanitize=address -pedantic -Wno-noexcept-type -DBOOST_ASIO_NO_DEPRECATED -DBOOST_MULTI_INDEX_ENABLE_SAFE_MODE -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -DBOOST_MULTI_INDEX_ENABLE_INVARIANT_CHECKING -ftemplate-backtrace-limit=0
         S_LDFLAGS:     -Werror -g -Wall -Wextra -Wno-ignored-qualifiers -Wconversion -fno-omit-frame-pointer -fsanitize=address
         NS_CFLAGS:     -Werror -g -Wall -Wextra -Wno-ignored-qualifiers -Wconversion
-        NS_CXXFLAGS:   -Werror -g -Wall -Wextra -Wno-ignored-qualifiers -Wconversion -pedantic -Wno-noexcept-type -DBOOST_ASIO_NO_DEPRECATED -DBOOST_MULTI_INDEX_ENABLE_SAFE_MODE -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -DBOOST_MULTI_INDEX_ENABLE_INVARIANT_CHECKING
+        NS_CXXFLAGS:   -Werror -g -Wall -Wextra -Wno-ignored-qualifiers -Wconversion -pedantic -Wno-noexcept-type -DBOOST_ASIO_NO_DEPRECATED -DBOOST_MULTI_INDEX_ENABLE_SAFE_MODE -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -DBOOST_MULTI_INDEX_ENABLE_INVARIANT_CHECKING -ftemplate-backtrace-limit=0
         PROF_CXXFLAGS: -Werror -g -Wall -Wextra -Wno-ignored-qualifiers -Wconversion -pedantic -Wno-noexcept-type -DBOOST_ASIO_NO_DEPRECATED -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -fprofile-arcs -ftest-coverage
-        NS_CXXFLAGS_GCC:  -Werror -Wall -Wextra -Wno-ignored-qualifiers -Wconversion -pedantic -Wno-noexcept-type -DBOOST_ASIO_NO_DEPRECATED -DBOOST_MULTI_INDEX_ENABLE_SAFE_MODE -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -DBOOST_MULTI_INDEX_ENABLE_INVARIANT_CHECKING
+        NS_CXXFLAGS_GCC:  -Werror -Wall -Wextra -Wno-ignored-qualifiers -Wconversion -pedantic -Wno-noexcept-type -DBOOST_ASIO_NO_DEPRECATED -DBOOST_MULTI_INDEX_ENABLE_SAFE_MODE -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION -DBOOST_MULTI_INDEX_ENABLE_INVARIANT_CHECKING -ftemplate-backtrace-limit=0
         NS_LDFLAGS:    -Werror -g -Wall -Wextra -Wno-ignored-qualifiers -Wconversion
       run: |
         [ ${{ matrix.pattern }} == 0 ] || [ ${{ matrix.pattern }} == 1 ] && \

--- a/include/async_mqtt/all.hpp
+++ b/include/async_mqtt/all.hpp
@@ -19,6 +19,7 @@
 #include <async_mqtt/log.hpp>
 #include <async_mqtt/null_strand.hpp>
 #include <async_mqtt/packet_id_manager.hpp>
+#include <async_mqtt/predefined_layer_customize.hpp>
 #include <async_mqtt/predefined_underlying_layer.hpp>
 #include <async_mqtt/protocol_version.hpp>
 #include <async_mqtt/setup_log.hpp>

--- a/include/async_mqtt/predefined_layer_customize.hpp
+++ b/include/async_mqtt/predefined_layer_customize.hpp
@@ -1,0 +1,271 @@
+// Copyright Takatoshi Kondo 2024
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(ASYNC_MQTT_PREDEFINED_LAYER_CUSTOMIZE_HPP)
+#define ASYNC_MQTT_PREDEFINED_LAYER_CUSTOMIZE_HPP
+
+#include <boost/asio/bind_executor.hpp>
+#include <boost/asio/steady_timer.hpp>
+
+#include <async_mqtt/constant.hpp>
+
+#if defined(ASYNC_MQTT_USE_TLS)
+#include <async_mqtt/tls.hpp>
+#endif // defined(ASYNC_MQTT_USE_TLS)
+
+#include <async_mqtt/stream_traits.hpp>
+#include <async_mqtt/log.hpp>
+#include <async_mqtt/util/move.hpp>
+#include <async_mqtt/predefined_underlying_layer.hpp>
+
+/// @file
+
+namespace async_mqtt {
+
+namespace as = boost::asio;
+
+template <typename Protocol, typename Executor>
+struct layer_customize<as::basic_stream_socket<Protocol, Executor>> {
+    template <
+        typename CompletionToken
+    >
+    static auto
+    async_close(
+        as::any_io_executor exe,
+        as::basic_stream_socket<Protocol, Executor>& stream,
+        CompletionToken&& token
+    ) {
+        return as::async_initiate<
+            CompletionToken,
+            void(error_code const& ec)
+        > (
+            [] (auto completion_handler,
+                as::any_io_executor /* exe */,
+                as::basic_stream_socket<Protocol, Executor>& stream
+            ) {
+                error_code ec;
+                if (stream.is_open()) {
+                    ASYNC_MQTT_LOG("mqtt_impl", info)
+                        << "TCP close";
+                    stream.close(ec);
+                }
+                else {
+                    ASYNC_MQTT_LOG("mqtt_impl", info)
+                        << "TCP already closed";
+                }
+                force_move(completion_handler)(ec);
+            },
+            token,
+            exe,
+            std::ref(stream)
+        );
+    }
+};
+
+#if defined(ASYNC_MQTT_USE_WS)
+
+namespace bs = boost::beast;
+
+template <typename NextLayer>
+struct layer_customize<bs::websocket::stream<NextLayer>> {
+    static void initialize(bs::websocket::stream<NextLayer>& stream) {
+        stream.binary(true);
+        stream.set_option(
+            bs::websocket::stream_base::decorator(
+                [](bs::websocket::request_type& req) {
+                    req.set("Sec-WebSocket-Protocol", "mqtt");
+                }
+            )
+        );
+    }
+
+    template <
+        typename ConstBufferSequence,
+        typename CompletionToken
+    >
+    static auto
+    async_write(
+        as::any_io_executor exe,
+        bs::websocket::stream<NextLayer>& stream,
+        ConstBufferSequence const& cbs,
+        CompletionToken&& token
+    ) {
+        return as::async_initiate<
+            CompletionToken,
+            void(error_code const& ec, std::size_t)
+        > (
+            [] (auto completion_handler,
+                as::any_io_executor exe,
+                bs::websocket::stream<NextLayer>& stream,
+                ConstBufferSequence const& cbs
+            ) {
+                stream.async_write(
+                    cbs,
+                    // You must bind exe to the handler if you use underlying async_function
+                    // using the completion handler that you defined.
+                    as::bind_executor(
+                        exe,
+                        [completion_handler = std::forward<CompletionToken>(completion_handler)]
+                        (error_code const& ec_write, std::size_t size) mutable {
+                            force_move(completion_handler)(ec_write, size);
+                        }
+                    )
+                );
+            },
+            token,
+            exe,
+            std::ref(stream),
+            std::ref(cbs)
+        );
+    }
+
+    template <
+        typename CompletionToken
+    >
+    static auto
+    async_close(
+        as::any_io_executor exe,
+        bs::websocket::stream<NextLayer>& stream,
+        CompletionToken&& token
+    ) {
+        return as::async_initiate<
+            CompletionToken,
+            void(error_code const& ec)
+        > (
+            [] (auto completion_handler,
+                as::any_io_executor exe,
+                bs::websocket::stream<NextLayer>& stream
+            ) {
+                stream.async_close(
+                    bs::websocket::close_code::none,
+                    // You must bind exe to the handler if you use underlying async_function
+                    // using the completion handler that you defined.
+                    as::bind_executor(
+                        exe,
+                        [exe, &stream, completion_handler = force_move(completion_handler)]
+                        (error_code const& ec_stream) mutable {
+                            if (ec_stream) {
+                                force_move(completion_handler)(ec_stream);
+                            }
+                            else {
+                                do_read(exe, stream, force_move(completion_handler));
+                            }
+                        }
+                    )
+                );
+            },
+            token,
+            exe,
+            std::ref(stream)
+        );
+    }
+
+    template <typename CompletionToken>
+    static void do_read(
+        as::any_io_executor exe,
+        bs::websocket::stream<NextLayer>& stream,
+        CompletionToken&& completion_handler
+    ) {
+        auto buffer = std::make_shared<bs::flat_buffer>();
+        stream.async_read(
+            *buffer,
+            // You must bind exe to the handler if you use underlying async_function
+            // using the completion handler that you defined.
+            as::bind_executor(
+                exe,
+                [exe, &stream, buffer, completion_handler = std::forward<CompletionToken>(completion_handler)]
+                (error_code const& ec_read, std::size_t) mutable {
+                    if (ec_read) {
+                        if (ec_read == bs::websocket::error::closed) {
+                            ASYNC_MQTT_LOG("mqtt_impl", info)
+                                << "ws async_read (for close)  success";
+                        }
+                        else {
+                            ASYNC_MQTT_LOG("mqtt_impl", info)
+                                << "ws async_read (for close):" << ec_read.message();
+                        }
+                        force_move(completion_handler)(ec_read);
+                    }
+                    else {
+                        do_read(exe, stream, force_move(completion_handler));
+                    }
+                }
+            )
+        );
+    }
+};
+
+#endif // defined(ASYNC_MQTT_USE_WS)
+
+#if defined(ASYNC_MQTT_USE_TLS)
+
+template <typename NextLayer>
+struct layer_customize<tls::stream<NextLayer>> {
+    template <
+        typename CompletionToken
+    >
+    static auto
+    async_close(
+        as::any_io_executor exe,
+        tls::stream<NextLayer>& stream,
+        CompletionToken&& token
+    ) {
+        return as::async_initiate<
+            CompletionToken,
+            void(error_code const& ec)
+        > (
+            [] (auto completion_handler,
+                as::any_io_executor exe,
+                tls::stream<NextLayer>& stream
+            ) {
+                auto tim = std::make_shared<as::steady_timer>(
+                    exe,
+                    shutdown_timeout
+                );
+                auto ch_sp = std::make_shared<decltype(completion_handler)>(force_move(completion_handler));
+                tim->async_wait(
+                    // You must bind exe to the handler if you use underlying async_function
+                    // using the completion handler that you defined.
+                    as::bind_executor(
+                        exe,
+                        [wp = std::weak_ptr<as::steady_timer>(tim), ch_sp]
+                        (error_code const& ec) mutable {
+                            if (!ec) {
+                                if (auto sp = wp.lock()) {
+                                    ASYNC_MQTT_LOG("mqtt_impl", info)
+                                        << "TLS async_shutdown timeout";
+                                    force_move(*ch_sp)(ec);
+                                }
+                            }
+                        }
+                    )
+                );
+                stream.async_shutdown(
+                    // You must bind exe to the handler if you use underlying async_function
+                    // using the completion handler that you defined.
+                    as::bind_executor(
+                        exe,
+                        [tim, ch_sp]
+                        (error_code const& ec_shutdown) mutable {
+                            ASYNC_MQTT_LOG("mqtt_impl", info)
+                                << "TLS async_shutdown ec:" << ec_shutdown.message();
+                            force_move(*ch_sp)(ec_shutdown);
+                        }
+                    )
+                );
+            },
+            token,
+            exe,
+            std::ref(stream)
+        );
+    }
+};
+
+#endif // defined(ASYNC_MQTT_USE_TLS)
+
+} // namespace async_mqtt
+
+#endif // ASYNC_MQTT_PREDEFINED_LAYER_CUSTOMIZE_HPP

--- a/include/async_mqtt/predefined_underlying_layer.hpp
+++ b/include/async_mqtt/predefined_underlying_layer.hpp
@@ -7,17 +7,40 @@
 #if !defined(ASYNC_MQTT_PREDEFINED_UNDERLYING_LAYER_HPP)
 #define ASYNC_MQTT_PREDEFINED_UNDERLYING_LAYER_HPP
 
-#include <boost/asio/ip/tcp.hpp>
+#include <boost/asio.hpp>
+
+#if defined(ASYNC_MQTT_USE_WS)
 #include <boost/beast/websocket/stream.hpp>
+#include <boost/beast/websocket/error.hpp>
+#endif // defined(ASYNC_MQTT_USE_WS)
+
+#include <async_mqtt/constant.hpp>
+
+#if defined(ASYNC_MQTT_USE_TLS)
 
 #include <async_mqtt/tls.hpp>
+
+#if defined(ASYNC_MQTT_USE_WS)
+
+#if !defined(ASYNC_MQTT_TLS_WS_INCLUDE)
+#define ASYNC_MQTT_TLS_WS_INCLUDE <boost/beast/websocket/ssl.hpp>
+#endif // !defined(ASYNC_MQTT_TLS_WS_INCLUDE)
+
+#include ASYNC_MQTT_TLS_WS_INCLUDE
+
+#endif // defined(ASYNC_MQTT_USE_WS)
+
+#endif // defined(ASYNC_MQTT_USE_TLS)
 
 /// @file
 
 namespace async_mqtt {
 
 namespace as = boost::asio;
+
+#if defined(ASYNC_MQTT_USE_WS)
 namespace bs = boost::beast;
+#endif //defined(ASYNC_MQTT_USE_WS)
 
 namespace protocol {
 
@@ -29,26 +52,18 @@ using mqtt = as::basic_stream_socket<as::ip::tcp, as::any_io_executor>;
 #if defined(ASYNC_MQTT_USE_WS)
 
 namespace detail {
-
 using mqtt_beast_workaround = as::basic_stream_socket<as::ip::tcp, as::io_context::executor_type>;
-
 } // namespace detail
 
 /**
  * @breif Type alias of Boost.Beast WebScoket
  */
 using ws = bs::websocket::stream<detail::mqtt_beast_workaround>;
+
 #endif //defined(ASYNC_MQTT_USE_WS)
 
-} // namespace procotol
-
-} // namespace async_mqtt
 
 #if defined(ASYNC_MQTT_USE_TLS)
-
-namespace async_mqtt {
-
-namespace protocol {
 
 /**
  * @breif Type alias of TLS stream
@@ -58,22 +73,18 @@ using mqtts = tls::stream<mqtt>;
 #if defined(ASYNC_MQTT_USE_WS)
 
 namespace detail {
-
 using mqtts_beast_workaround = tls::stream<mqtt_beast_workaround>;
-
 } // namespace detail
 
 /**
  * @breif Type alias of Boost.Beast WebSocket on TLS stream
  */
 using wss = bs::websocket::stream<detail::mqtts_beast_workaround>;
+
 #endif // defined(ASYNC_MQTT_USE_WS)
-
-
-} // namespace procotol
-
-} // namespace async_mqtt
-
 #endif // defined(ASYNC_MQTT_USE_TLS)
+
+} // namespace protocol
+} // namespace async_mqtt
 
 #endif // ASYNC_MQTT_PREDEFINED_UNDERLYING_LAYER_HPP

--- a/include/async_mqtt/stream_traits.hpp
+++ b/include/async_mqtt/stream_traits.hpp
@@ -8,8 +8,17 @@
 #define ASYNC_MQTT_STREAM_TRAITS_HPP
 
 #include <type_traits>
+#include <vector>
+
+#include <boost/asio/buffer.hpp>
+#include <boost/asio/any_completion_handler.hpp>
+#include <boost/asio/any_io_executor.hpp>
+
+#include <async_mqtt/exception.hpp>
 
 namespace async_mqtt {
+
+namespace as = boost::asio;
 
 namespace detail {
 
@@ -20,8 +29,13 @@ template <typename T>
 auto has_next_layer_impl(decltype(nullptr)) ->
     decltype(std::declval<T&>().next_layer(), std::true_type{});
 
+} // namespace detail
+
 template <typename T>
-using has_next_layer = decltype(has_next_layer_impl<T>(nullptr));
+using has_next_layer = decltype(detail::has_next_layer_impl<T>(nullptr));
+
+
+namespace detail {
 
 template<typename T, bool = has_next_layer<T>::value>
 struct lowest_layer_type_impl {
@@ -34,8 +48,12 @@ struct lowest_layer_type_impl<T, true> {
         decltype(std::declval<T&>().next_layer())>::type;
 };
 
+} // namespace detail
+
 template<typename T>
-using lowest_layer_type = typename lowest_layer_type_impl<T>::type;
+using lowest_layer_type = typename detail::lowest_layer_type_impl<T>::type;
+
+namespace detail {
 
 template<typename T>
 T&
@@ -55,21 +73,98 @@ get_lowest_layer_impl(T& t, std::true_type) noexcept {
 
 } // namespace detail
 
-template<typename T>
-using executor_type = decltype(std::declval<T>().get_executor());
+
 
 template<typename T>
-using lowest_layer_type = detail::lowest_layer_type<T>;
+using executor_type = decltype(std::declval<T>().get_executor());
 
 template<typename T>
 lowest_layer_type<T>& get_lowest_layer(T& t) noexcept {
     return
         detail::get_lowest_layer_impl(
             t,
-            detail::has_next_layer<T>{}
+            has_next_layer<T>{}
         );
 }
 
+/**
+ * @brief customization class for underlying layer
+ * @tparam Layer Specialized parameter for your own layer
+ */
+template <typename Layer>
+struct layer_customize;
+
+// initialze
+
+template <typename Layer, typename = void>
+struct has_initialize : std::false_type {};
+
+template <typename Layer>
+struct has_initialize<
+    Layer,
+    std::void_t<
+        decltype(layer_customize<Layer>::initialize(std::declval<Layer&>()))
+    >
+> : std::true_type {};
+
+// async_read
+
+template <typename Layer, typename = void>
+struct has_async_read : std::false_type {};
+
+template <typename Layer>
+struct has_async_read<
+    Layer,
+    std::void_t<
+        decltype(
+            layer_customize<Layer>::async_read(
+                std::declval<as::any_io_executor>(),
+                std::declval<Layer&>(),
+                std::declval<as::mutable_buffer const&>(),
+                std::declval<as::any_completion_handler<void(error_code const&, std::size_t)>>()
+            )
+        )
+    >
+> : std::true_type {};
+
+// async_write
+
+template <typename Layer, typename = void>
+struct has_async_write : std::false_type {};
+
+template <typename Layer>
+struct has_async_write<
+    Layer,
+    std::void_t<
+        decltype(
+            layer_customize<Layer>::async_write(
+                std::declval<as::any_io_executor>(),
+                std::declval<Layer&>(),
+                std::declval<std::vector<as::const_buffer> const&>(),
+                std::declval<as::any_completion_handler<void(error_code const&, std::size_t)>>()
+            )
+        )
+    >
+> : std::true_type {};
+
+// async_close
+
+template <typename Layer, typename = void>
+struct has_async_close : std::false_type {};
+
+template <typename Layer>
+struct has_async_close<
+    Layer,
+    std::void_t<
+        decltype(
+            layer_customize<Layer>::async_close(
+                std::declval<as::any_io_executor>(),
+                std::declval<Layer&>(),
+                std::declval<as::any_completion_handler<void(error_code const&)>>()
+            )
+        )
+    >
+> : std::true_type {};
 
 } // namespace async_mqtt
 

--- a/include/async_mqtt/tls.hpp
+++ b/include/async_mqtt/tls.hpp
@@ -23,18 +23,6 @@ namespace async_mqtt {
 namespace tls = ASYNC_MQTT_TLS_NS;
 } // namespace async_mqtt
 
-
-#if defined(ASYNC_MQTT_USE_WS)
-
-#if !defined(ASYNC_MQTT_TLS_WS_INCLUDE)
-#define ASYNC_MQTT_TLS_WS_INCLUDE <boost/beast/websocket/ssl.hpp>
-#endif // !defined(ASYNC_MQTT_TLS_WS_INCLUDE)
-
-#include ASYNC_MQTT_TLS_WS_INCLUDE
-
-#endif // defined(ASYNC_MQTT_USE_WS)
-
 #endif // defined(ASYNC_MQTT_USE_TLS)
-
 
 #endif // ASYNC_MQTT_TLS_HPP

--- a/test/unit/stub_socket.hpp
+++ b/test/unit/stub_socket.hpp
@@ -228,6 +228,162 @@ void async_read(
     socket.async_read_some(mb, std::forward<CompletionToken>(token));
 }
 
+template <>
+struct layer_customize<stub_socket> {
+    template <
+        typename MutableBufferSequence,
+        typename CompletionToken
+    >
+    static auto
+    async_read(
+        as::any_io_executor exe,
+        stub_socket& stream,
+        MutableBufferSequence const& mbs,
+        CompletionToken&& token
+    ) {
+        return as::async_initiate<
+            CompletionToken,
+            void(error_code const& ec, std::size_t)
+        > (
+            [] (auto completion_handler,
+                as::any_io_executor exe,
+                stub_socket& stream,
+                MutableBufferSequence const& mbs
+            ) {
+                return stream.async_read_some(
+                    mbs,
+                    // You must bind exe to the handler if you use underlying async_function
+                    // using the completion handler that you defined.
+                    as::bind_executor(
+                        exe,
+                        [completion_handler = force_move(completion_handler)]
+                        (error_code const& ec, std::size_t size) mutable {
+                            force_move(completion_handler)(ec, size);
+                        }
+                    )
+                );
+            },
+            token,
+            exe,
+            std::ref(stream),
+            std::ref(mbs)
+        );
+    }
+
+    template <
+        typename CompletionToken
+    >
+    static auto
+    async_close(
+        as::any_io_executor exe,
+        stub_socket& stream,
+        CompletionToken&& token
+    ) {
+        return as::async_initiate<
+            CompletionToken,
+            void(error_code const& ec)
+        > (
+            [] (auto completion_handler,
+                as::any_io_executor /* exe */,
+                stub_socket& stream
+            ) {
+                error_code ec;
+                if (stream.is_open()) {
+                    ASYNC_MQTT_LOG("mqtt_impl", info)
+                        << "stub close";
+                    stream.close(ec);
+                }
+                else {
+                    ASYNC_MQTT_LOG("mqtt_impl", info)
+                        << "stub already closed";
+                }
+                force_move(completion_handler)(ec);
+            },
+            token,
+            exe,
+            std::ref(stream)
+        );
+    }
+};
+
+template <>
+struct layer_customize<basic_stub_socket<4>> {
+    template <
+        typename MutableBufferSequence,
+        typename CompletionToken
+    >
+    static auto
+    async_read(
+        as::any_io_executor exe,
+        basic_stub_socket<4>& stream,
+        MutableBufferSequence const& mbs,
+        CompletionToken&& token
+    ) {
+        return as::async_initiate<
+            CompletionToken,
+            void(error_code const& ec, std::size_t)
+        > (
+            [] (auto completion_handler,
+                as::any_io_executor exe,
+                basic_stub_socket<4>& stream,
+                MutableBufferSequence const& mbs
+            ) {
+                return stream.async_read_some(
+                    mbs,
+                    // You must bind exe to the handler if you use underlying async_function
+                    // using the completion handler that you defined.
+                    as::bind_executor(
+                        exe,
+                        [completion_handler = force_move(completion_handler)]
+                        (error_code const& ec, std::size_t size) mutable {
+                            force_move(completion_handler)(ec, size);
+                        }
+                    )
+                );
+            },
+            token,
+            exe,
+            std::ref(stream),
+            std::ref(mbs)
+        );
+    }
+
+    template <
+        typename CompletionToken
+    >
+    static auto
+    async_close(
+        as::any_io_executor exe,
+        basic_stub_socket<4>& stream,
+        CompletionToken&& token
+    ) {
+        return as::async_initiate<
+            CompletionToken,
+            void(error_code const& ec)
+        > (
+            [] (auto completion_handler,
+                as::any_io_executor /* exe */,
+                basic_stub_socket<4>& stream
+            ) {
+                error_code ec;
+                if (stream.is_open()) {
+                    ASYNC_MQTT_LOG("mqtt_impl", info)
+                        << "stub close";
+                    stream.close(ec);
+                }
+                else {
+                    ASYNC_MQTT_LOG("mqtt_impl", info)
+                        << "stub already closed";
+                }
+                force_move(completion_handler)(ec);
+            },
+            token,
+            exe,
+            std::ref(stream)
+        );
+    }
+};
+
 } // namespace async_mqtt
 
 #endif // ASYNC_MQTT_STUB_SOCKET_HPP

--- a/tool/bench.cpp
+++ b/tool/bench.cpp
@@ -12,11 +12,7 @@
 #include <boost/program_options.hpp>
 #include <boost/format.hpp>
 
-#include <async_mqtt/host_port.hpp>
-#include <async_mqtt/setup_log.hpp>
-#include <async_mqtt/endpoint.hpp>
-#include <async_mqtt/packet/pubopts.hpp>
-#include <async_mqtt/predefined_underlying_layer.hpp>
+#include <async_mqtt/all.hpp>
 
 #include "locked_cout.hpp"
 

--- a/tool/broker.cpp
+++ b/tool/broker.cpp
@@ -15,7 +15,7 @@
 #include <boost/format.hpp>
 #include <boost/asio/signal_set.hpp>
 
-#include <async_mqtt/predefined_underlying_layer.hpp>
+#include <async_mqtt/predefined_layer_customize.hpp>
 #include <async_mqtt/broker/endpoint_variant.hpp>
 #include <async_mqtt/broker/broker.hpp>
 #include <async_mqtt/broker/constant.hpp>


### PR DESCRIPTION
All underlying layer specific codes are removed from stream.hpp.

Note:
Boost.1.83.0 on Linux CI (ubuntu) failed. But osx, windows success. When I update to Boost.1.85.0 on Linux CI (ubuntu), the error is solved.