### PR TITLE
Removed async_mqtt::buffer from public APIs.

### DIFF
--- a/example/cl_cpp20coro_mqtt.cpp
+++ b/example/cl_cpp20coro_mqtt.cpp
@@ -21,7 +21,6 @@ proc(
     client_t& amcl,
     std::string_view host,
     std::string_view port) {
-    using namespace am::literals;
 
     auto exe = co_await as::this_coro::executor;
     as::ip::tcp::socket resolve_sock{exe};
@@ -49,7 +48,7 @@ proc(
             am::v5::connect_packet{
                 true,   // clean_session
                 0x1234, // keep_alive
-                "cid1"_mb,
+                "cid1",
                 std::nullopt, // will
                 std::nullopt, // username set like allocate_buffer("user1"),
                 std::nullopt  // password set like allocate_buffer("pass1")
@@ -63,9 +62,9 @@ proc(
         // subscribe
         // MQTT send subscribe and wait suback
         std::vector<am::topic_subopts> sub_entry{
-            {"topic1"_mb, am::qos::at_most_once},
-            {"topic2"_mb, am::qos::at_least_once},
-            {"topic3"_mb, am::qos::exactly_once},
+            {"topic1", am::qos::at_most_once},
+            {"topic2", am::qos::at_least_once},
+            {"topic3", am::qos::exactly_once},
         };
         auto suback_opt = co_await amcl.subscribe(
             am::v5::subscribe_packet{
@@ -94,8 +93,8 @@ proc(
         // MQTT publish QoS0 and wait response (socket write complete)
         auto pubres0 = co_await amcl.publish(
             am::v5::publish_packet{
-                "topic1"_mb,
-                "payload1"_mb,
+                "topic1",
+                "payload1",
                 am::qos::at_most_once
             },
             as::use_awaitable
@@ -107,8 +106,8 @@ proc(
         auto pubres1 = co_await amcl.publish(
             am::v5::publish_packet{
                 *pid_pub1_opt,
-                "topic2"_mb,
-                "payload2"_mb,
+                "topic2",
+                "payload2",
                 am::qos::at_least_once
             },
             as::use_awaitable
@@ -120,6 +119,8 @@ proc(
             auto [publish_opt, disconnect_opt] = co_await amcl.recv(as::use_awaitable);
             if (publish_opt) {
                 std::cout << *publish_opt << std::endl;
+                std::cout << "topic   : " << publish_opt->topic() << std::endl;
+                std::cout << "payload : " << publish_opt->payload() << std::endl;
             }
             if (disconnect_opt) {
                 std::cout << *disconnect_opt << std::endl;
@@ -131,6 +132,8 @@ proc(
                 std::cout << ec.message() << std::endl;
                 if (publish_opt) {
                     std::cout << *publish_opt << std::endl;
+                    std::cout << "topic   : " << publish_opt->topic() << std::endl;
+                    std::cout << "payload : " << publish_opt->payload() << std::endl;
                 }
                 if (disconnect_opt) {
                     std::cout << *disconnect_opt << std::endl;
@@ -143,8 +146,8 @@ proc(
         auto pubres2 = co_await amcl.publish(
             am::v5::publish_packet{
                 pid_pub2,
-                "topic3"_mb,
-                "payload3"_mb,
+                "topic3",
+                "payload3",
                 am::qos::exactly_once
             },
             as::use_awaitable
@@ -153,9 +156,9 @@ proc(
 
         // MQTT send unsubscribe and wait unsuback
         std::vector<am::topic_sharename> unsub_entry{
-            {"topic1"_mb},
-            {"topic2"_mb},
-            {"topic3"_mb},
+            {"topic1"},
+            {"topic2"},
+            {"topic3"},
         };
 
         auto unsuback_opt = co_await amcl.unsubscribe(

--- a/example/ep_cb_mqtt_client.cpp
+++ b/example/ep_cb_mqtt_client.cpp
@@ -15,7 +15,6 @@ namespace as = boost::asio;
 namespace am = async_mqtt;
 
 int main(int argc, char* argv[]) {
-    using namespace am::literals;
     if (argc != 3) {
         std::cout << "Usage: " << argv[0] << " host port" << std::endl;
         return -1;
@@ -59,10 +58,10 @@ int main(int argc, char* argv[]) {
                         am::v3_1_1::connect_packet{
                             true,   // clean_session
                             0x1234, // keep_alive
-                            "cid1"_mb,
+                            "cid1",
                             std::nullopt, // will
-                            std::nullopt, // username set like "user1"_mb,
-                            std::nullopt  // password set like "pass1"_mb
+                            std::nullopt, // username set like "user1",
+                            std::nullopt  // password set like "pass1"
                         },
                         [&]
                         (am::system_error const& se) {
@@ -86,7 +85,7 @@ int main(int argc, char* argv[]) {
                                                     amep->send(
                                                         am::v3_1_1::subscribe_packet{
                                                             *amep->acquire_unique_packet_id(),
-                                                            { {"topic1"_mb, am::qos::at_most_once} }
+                                                            { {"topic1", am::qos::at_most_once} }
                                                         },
                                                         [&]
                                                         (am::system_error const& se) {
@@ -114,8 +113,8 @@ int main(int argc, char* argv[]) {
                                                                                     amep->send(
                                                                                         am::v3_1_1::publish_packet{
                                                                                             *amep->acquire_unique_packet_id(),
-                                                                                            "topic1"_mb,
-                                                                                            "payload1"_mb,
+                                                                                            "topic1",
+                                                                                            "payload1",
                                                                                             am::qos::at_least_once
                                                                                         },
                                                                                         [&]
@@ -137,7 +136,7 @@ int main(int argc, char* argv[]) {
                                                                                                                         << "MQTT PUBLISH recv"
                                                                                                                         << " pid:" << p.packet_id()
                                                                                                                         << " topic:" << p.topic()
-                                                                                                                        << " payload:" << am::to_string(p.payload())
+                                                                                                                        << " payload:" << p.payload()
                                                                                                                         << " qos:" << p.opts().get_qos()
                                                                                                                         << " retain:" << p.opts().get_retain()
                                                                                                                         << " dup:" << p.opts().get_dup()

--- a/example/ep_cpp20coro_mqtt_client.cpp
+++ b/example/ep_cpp20coro_mqtt_client.cpp
@@ -19,7 +19,6 @@ proc(
     auto& amep,
     std::string_view host,
     std::string_view port) {
-    using namespace am::literals;
 
     auto exe = co_await as::this_coro::executor;
     as::ip::tcp::socket resolve_sock{exe};
@@ -47,10 +46,10 @@ proc(
                 am::v3_1_1::connect_packet{
                     true,   // clean_session
                     0x1234, // keep_alive
-                    "cid1"_mb,
+                    "cid1",
                     std::nullopt, // will
-                    std::nullopt, // username set like "user1"_mb,
-                    std::nullopt  // password set like "pass1"_mb
+                    std::nullopt, // username set like "user1",
+                    std::nullopt  // password set like "pass1"
                 },
                 as::use_awaitable
             )
@@ -83,7 +82,7 @@ proc(
 
         // Send MQTT SUBSCRIBE
         std::vector<am::topic_subopts> sub_entry{
-            {"topic1"_mb, am::qos::at_most_once}
+            {"topic1", am::qos::at_most_once}
         };
         if (auto se = co_await amep->send(
                 am::v3_1_1::subscribe_packet{
@@ -125,8 +124,8 @@ proc(
         if (auto se = co_await amep->send(
                 am::v3_1_1::publish_packet{
                     *amep->acquire_unique_packet_id(),
-                    "topic1"_mb,
-                    "payload1"_mb,
+                    "topic1",
+                    "payload1",
                     am::qos::at_least_once
                 },
                 as::use_awaitable
@@ -145,7 +144,7 @@ proc(
                                 << "MQTT PUBLISH recv"
                                 << " pid:" << p.packet_id()
                                 << " topic:" << p.topic()
-                                << " payload:" << am::to_string(p.payload())
+                                << " payload:" << p.payload()
                                 << " qos:" << p.opts().get_qos()
                                 << " retain:" << p.opts().get_retain()
                                 << " dup:" << p.opts().get_dup()

--- a/example/ep_future_mqtt_client.cpp
+++ b/example/ep_future_mqtt_client.cpp
@@ -15,7 +15,6 @@ namespace as = boost::asio;
 namespace am = async_mqtt;
 
 int main(int argc, char* argv[]) {
-    using namespace am::literals;
 
     if (argc != 3) {
         std::cout << "Usage: " << argv[0] << " host port" << std::endl;
@@ -71,10 +70,10 @@ int main(int argc, char* argv[]) {
                 am::v3_1_1::connect_packet{
                     true,   // clean_session
                     0x1234, // keep_alive
-                    "cid1"_mb,
+                    "cid1",
                     std::nullopt, // will
-                    std::nullopt, // username set like "user1"_mb,
-                    std::nullopt  // password set like "pass1"_mb
+                    std::nullopt, // username set like "user1",
+                    std::nullopt  // password set like "pass1"
                 },
                 as::use_future
             );
@@ -119,7 +118,7 @@ int main(int argc, char* argv[]) {
             auto fut = amep->send(
                 am::v3_1_1::subscribe_packet{
                     *pid,
-                    { {"topic1"_mb, am::qos::at_most_once} }
+                    { {"topic1", am::qos::at_most_once} }
                 },
                 as::use_future
             );
@@ -167,8 +166,8 @@ int main(int argc, char* argv[]) {
             auto fut = amep->send(
                 am::v3_1_1::publish_packet{
                     *pid,
-                    "topic1"_mb,
-                    "payload1"_mb,
+                    "topic1",
+                    "payload1",
                     am::qos::at_least_once
                 },
                 as::use_future
@@ -193,7 +192,7 @@ int main(int argc, char* argv[]) {
                                     << "MQTT PUBLISH recv"
                                     << " pid:" << p.packet_id()
                                     << " topic:" << p.topic()
-                                    << " payload:" << am::to_string(p.payload())
+                                    << " payload:" << p.payload()
                                     << " qos:" << p.opts().get_qos()
                                     << " retain:" << p.opts().get_retain()
                                     << " dup:" << p.opts().get_dup()

--- a/example/ep_slcoro_mqtt_client.cpp
+++ b/example/ep_slcoro_mqtt_client.cpp
@@ -60,7 +60,6 @@ private:
             am::packet_variant pv,
             std::optional<as::ip::tcp::resolver::results_type> eps
         ) const {
-            using namespace am::literals;
 
             reenter (coro_) {
                 std::cout << "start" << std::endl;
@@ -91,10 +90,10 @@ private:
                     am::v3_1_1::connect_packet{
                         true,   // clean_session
                         0x1234, // keep_alive
-                        "cid1"_mb,
+                        "cid1",
                         std::nullopt, // will
-                        std::nullopt, // username set like "user1"_mb,
-                        std::nullopt  // password set like "pass1"_mb
+                        std::nullopt, // username set like "user1",
+                        std::nullopt  // password set like "pass1"
                     },
                     *this
                 );
@@ -130,7 +129,7 @@ private:
                 yield app_.amep_->send(
                     am::v3_1_1::subscribe_packet{
                         *app_.amep_->acquire_unique_packet_id(),
-                        { {"topic1"_mb, am::qos::at_most_once} }
+                        { {"topic1", am::qos::at_most_once} }
                     },
                     *this
                 );
@@ -168,8 +167,8 @@ private:
                 yield app_.amep_->send(
                     am::v3_1_1::publish_packet{
                         *app_.amep_->acquire_unique_packet_id(),
-                        "topic1"_mb,
-                        "payload1"_mb,
+                        "topic1",
+                        "payload1",
                         am::qos::at_least_once
                     },
                     *this
@@ -189,7 +188,7 @@ private:
                                         << "MQTT PUBLISH recv"
                                         << " pid:" << p.packet_id()
                                         << " topic:" << p.topic()
-                                        << " payload:" << am::to_string(p.payload())
+                                        << " payload:" << p.payload()
                                         << " qos:" << p.opts().get_qos()
                                         << " retain:" << p.opts().get_retain()
                                         << " dup:" << p.opts().get_dup()

--- a/example/ep_slcoro_mqtts_client.cpp
+++ b/example/ep_slcoro_mqtts_client.cpp
@@ -66,7 +66,6 @@ private:
             am::packet_variant pv,
             std::optional<as::ip::tcp::resolver::results_type> eps
         ) const {
-            using namespace am::literals;
 
             reenter (coro_) {
                 std::cout << "start" << std::endl;
@@ -107,10 +106,10 @@ private:
                     am::v3_1_1::connect_packet{
                         true,   // clean_session
                         0x1234, // keep_alive
-                        "cid1"_mb,
+                        "cid1",
                         std::nullopt, // will
-                        std::nullopt, // username set like "user1"_mb,
-                        std::nullopt  // password set like "pass1"_mb
+                        std::nullopt, // username set like "user1",
+                        std::nullopt  // password set like "pass1"
                     },
                     *this
                 );
@@ -146,7 +145,7 @@ private:
                 yield app_.amep_->send(
                     am::v3_1_1::subscribe_packet{
                         *app_.amep_->acquire_unique_packet_id(),
-                        { {"topic1"_mb, am::qos::at_most_once} }
+                        { {"topic1", am::qos::at_most_once} }
                     },
                     *this
                 );
@@ -184,8 +183,8 @@ private:
                 yield app_.amep_->send(
                     am::v3_1_1::publish_packet{
                         *app_.amep_->acquire_unique_packet_id(),
-                        "topic1"_mb,
-                        "payload1"_mb,
+                        "topic1",
+                        "payload1",
                         am::qos::at_least_once
                     },
                     *this
@@ -205,7 +204,7 @@ private:
                                         << "MQTT PUBLISH recv"
                                         << " pid:" << p.packet_id()
                                         << " topic:" << p.topic()
-                                        << " payload:" << am::to_string(p.payload())
+                                        << " payload:" << p.payload()
                                         << " qos:" << p.opts().get_qos()
                                         << " retain:" << p.opts().get_retain()
                                         << " dup:" << p.opts().get_dup()

--- a/example/ep_slcoro_ws_client.cpp
+++ b/example/ep_slcoro_ws_client.cpp
@@ -61,7 +61,6 @@ private:
             am::packet_variant pv,
             std::optional<as::ip::tcp::resolver::results_type> eps
         ) const {
-            using namespace am::literals;
 
             reenter (coro_) {
                 std::cout << "start" << std::endl;
@@ -103,10 +102,10 @@ private:
                     am::v3_1_1::connect_packet{
                         true,   // clean_session
                         0x1234, // keep_alive
-                        "cid1"_mb,
+                        "cid1",
                         std::nullopt, // will
-                        std::nullopt, // username set like "user1"_mb,
-                        std::nullopt  // password set like "pass1"_mb
+                        std::nullopt, // username set like "user1",
+                        std::nullopt  // password set like "pass1"
                     },
                     *this
                 );
@@ -142,7 +141,7 @@ private:
                 yield app_.amep_->send(
                     am::v3_1_1::subscribe_packet{
                         *app_.amep_->acquire_unique_packet_id(),
-                        { {"topic1"_mb, am::qos::at_most_once} }
+                        { {"topic1", am::qos::at_most_once} }
                     },
                     *this
                 );
@@ -180,8 +179,8 @@ private:
                 yield app_.amep_->send(
                     am::v3_1_1::publish_packet{
                         *app_.amep_->acquire_unique_packet_id(),
-                        "topic1"_mb,
-                        "payload1"_mb,
+                        "topic1",
+                        "payload1",
                         am::qos::at_least_once
                     },
                     *this
@@ -201,7 +200,7 @@ private:
                                         << "MQTT PUBLISH recv"
                                         << " pid:" << p.packet_id()
                                         << " topic:" << p.topic()
-                                        << " payload:" << am::to_string(p.payload())
+                                        << " payload:" << p.payload()
                                         << " qos:" << p.opts().get_qos()
                                         << " retain:" << p.opts().get_retain()
                                         << " dup:" << p.opts().get_dup()

--- a/example/ep_slcoro_wss_client.cpp
+++ b/example/ep_slcoro_wss_client.cpp
@@ -62,7 +62,6 @@ private:
             am::packet_variant pv,
             std::optional<as::ip::tcp::resolver::results_type> eps
         ) const {
-            using namespace am::literals;
 
             reenter (coro_) {
                 std::cout << "start" << std::endl;
@@ -114,10 +113,10 @@ private:
                     am::v3_1_1::connect_packet{
                         true,   // clean_session
                         0x1234, // keep_alive
-                        "cid1"_mb,
+                        "cid1",
                         std::nullopt, // will
-                        std::nullopt, // username set like "user1"_mb,
-                        std::nullopt  // password set like "pass1"_mb
+                        std::nullopt, // username set like "user1",
+                        std::nullopt  // password set like "pass1"
                     },
                     *this
                 );
@@ -153,7 +152,7 @@ private:
                 yield app_.amep_->send(
                     am::v3_1_1::subscribe_packet{
                         *app_.amep_->acquire_unique_packet_id(),
-                        { {"topic1"_mb, am::qos::at_most_once} }
+                        { {"topic1", am::qos::at_most_once} }
                     },
                     *this
                 );
@@ -191,8 +190,8 @@ private:
                 yield app_.amep_->send(
                     am::v3_1_1::publish_packet{
                         *app_.amep_->acquire_unique_packet_id(),
-                        "topic1"_mb,
-                        "payload1"_mb,
+                        "topic1",
+                        "payload1",
                         am::qos::at_least_once
                     },
                     *this
@@ -212,7 +211,7 @@ private:
                                         << "MQTT PUBLISH recv"
                                         << " pid:" << p.packet_id()
                                         << " topic:" << p.topic()
-                                        << " payload:" << am::to_string(p.payload())
+                                        << " payload:" << p.payload()
                                         << " qos:" << p.opts().get_qos()
                                         << " retain:" << p.opts().get_retain()
                                         << " dup:" << p.opts().get_dup()

--- a/include/async_mqtt/all.hpp
+++ b/include/async_mqtt/all.hpp
@@ -9,6 +9,7 @@
 
 #include <async_mqtt/buffer.hpp>
 #include <async_mqtt/buffer_to_packet_variant.hpp>
+#include <async_mqtt/buffer_to_packet_variant_fwd.hpp>
 #include <async_mqtt/client.hpp>
 #include <async_mqtt/constant.hpp>
 #include <async_mqtt/endpoint.hpp>

--- a/include/async_mqtt/broker/endpoint_variant.hpp
+++ b/include/async_mqtt/broker/endpoint_variant.hpp
@@ -353,11 +353,11 @@ public:
         );
     }
 
-    void set_client_id(buffer cid) {
+    void set_client_id(std::string cid) {
         client_id_ = force_move(cid);
     }
 
-    buffer const& get_client_id() const {
+    std::string const& get_client_id() const {
         return client_id_;
     }
 
@@ -394,7 +394,7 @@ public:
 
 private:
     epsp_t epsp_;
-    buffer client_id_;
+    std::string client_id_;
     std::optional<std::string> preauthed_user_name_;
     mutable std::optional<protocol_version> protocol_version_;
 };

--- a/include/async_mqtt/broker/offline_message.hpp
+++ b/include/async_mqtt/broker/offline_message.hpp
@@ -48,7 +48,7 @@ public:
         >* = nullptr
     >
     offline_message(
-        buffer topic,
+        std::string topic,
         BufferSequence&& payload,
         pub::opts pubopts,
         properties props,
@@ -141,7 +141,7 @@ public:
 private:
     friend class offline_messages;
 
-    buffer topic_;
+    std::string topic_;
     std::vector<buffer> payload_;
     pub::opts pubopts_;
     properties props_;
@@ -186,7 +186,7 @@ public:
     >
     push_back(
         as::io_context& timer_ioc,
-        buffer pub_topic,
+        std::string pub_topic,
         BufferSequence&& payload,
         pub::opts pubopts,
         properties props) {

--- a/include/async_mqtt/broker/retain_t.hpp
+++ b/include/async_mqtt/broker/retain_t.hpp
@@ -26,7 +26,7 @@ struct retain_t {
         > = nullptr
     >
     retain_t(
-        buffer topic,
+        std::string topic,
         BufferSequence&& payload,
         properties props,
         qos qos_value,
@@ -43,7 +43,7 @@ struct retain_t {
         }
     }
 
-    buffer topic;
+    std::string topic;
     std::vector<buffer> payload;
     properties props;
     qos qos_value;

--- a/include/async_mqtt/broker/session_state.hpp
+++ b/include/async_mqtt/broker/session_state.hpp
@@ -58,7 +58,7 @@ struct session_state : std::enable_shared_from_this<session_state<Sp>> {
     using will_sender_t = std::function<
         void(
             session_state<epsp_t> const& source_ss,
-            buffer topic,
+            std::string topic,
             buffer payload,
             pub::opts pubopts,
             properties props
@@ -71,7 +71,7 @@ struct session_state : std::enable_shared_from_this<session_state<Sp>> {
         sub_con_map<epsp_t>& subs_map,
         shared_target<epsp_t>& shared_targets,
         epsp_t epsp,
-        buffer client_id,
+        std::string client_id,
         std::string const& username,
         std::optional<will> will,
         will_sender_t will_sender,
@@ -86,7 +86,7 @@ struct session_state : std::enable_shared_from_this<session_state<Sp>> {
                 sub_con_map<epsp_t>& subs_map,
                 shared_target<epsp_t>& shared_targets,
                 epsp_t epsp,
-                buffer client_id,
+                std::string client_id,
                 std::string const& username,
                 will_sender_t will_sender,
                 bool clean_start,
@@ -240,7 +240,7 @@ struct session_state : std::enable_shared_from_this<session_state<Sp>> {
     publish(
         epsp_t& epsp,
         as::io_context& timer_ioc,
-        buffer pub_topic,
+        std::string pub_topic,
         BufferSequence&& payload,
         pub::opts pubopts,
         properties props) {
@@ -332,7 +332,7 @@ struct session_state : std::enable_shared_from_this<session_state<Sp>> {
     >
     deliver(
         as::io_context& timer_ioc,
-        buffer pub_topic,
+        std::string pub_topic,
         BufferSequence&& payload,
         pub::opts pubopts,
         properties props) {
@@ -390,8 +390,8 @@ struct session_state : std::enable_shared_from_this<session_state<Sp>> {
 
     template <typename PublishRetainHandler>
     void subscribe(
-        buffer share_name,
-        buffer topic_filter,
+        std::string share_name,
+        std::string topic_filter,
         sub::opts subopts,
         PublishRetainHandler&& h,
         std::optional<std::size_t> sid = std::nullopt
@@ -441,7 +441,7 @@ struct session_state : std::enable_shared_from_this<session_state<Sp>> {
         }
     }
 
-    void unsubscribe(buffer const& share_name, buffer const& topic_filter) {
+    void unsubscribe(std::string const& share_name, std::string const& topic_filter) {
         if (!share_name.empty()) {
             shared_targets_.erase(share_name, topic_filter, *this);
         }
@@ -585,7 +585,7 @@ struct session_state : std::enable_shared_from_this<session_state<Sp>> {
         return version_;
     }
 
-    buffer const& client_id() const {
+    std::string const& client_id() const {
         return client_id_;
     }
 
@@ -652,7 +652,7 @@ private:
         sub_con_map<epsp_t>& subs_map,
         shared_target<epsp_t>& shared_targets,
         epsp_t epsp,
-        buffer client_id,
+        std::string client_id,
         std::string const& username,
         will_sender_t will_sender,
         bool clean_start,
@@ -692,7 +692,7 @@ private:
             << "send will. cid:" << client_id_;
 
         auto topic = force_move(will_value_->topic());
-        auto payload = force_move(will_value_->message());
+        auto payload = force_move(will_value_->message_as_buffer());
         auto opts = will_value_->get_qos() | will_value_->get_retain();
         auto props = force_move(will_value_->props());
         properties forward_props;
@@ -758,7 +758,7 @@ private:
     shared_target<epsp_t>& shared_targets_;
     epwp_t epwp_;
     protocol_version version_;
-    buffer client_id_;
+    std::string client_id_;
 
     std::string username_;
 

--- a/include/async_mqtt/broker/shared_target.hpp
+++ b/include/async_mqtt/broker/shared_target.hpp
@@ -14,7 +14,6 @@
 #include <boost/multi_index/ordered_index.hpp>
 #include <boost/multi_index/key.hpp>
 
-#include <async_mqtt/buffer.hpp>
 #include <async_mqtt/time_point_t.hpp>
 
 #include <async_mqtt/broker/session_state_fwd.hpp>
@@ -29,20 +28,21 @@ namespace mi = boost::multi_index;
 template <typename Sp>
 class shared_target {
 public:
-    void insert(buffer share_name, buffer topic_filter, subscription<Sp> sub, session_state<Sp>& ss);
-    void erase(buffer share_name, buffer topic_filter, session_state<Sp> const& ss);
+    void insert(std::string share_name, std::string topic_filter, subscription<Sp> sub, session_state<Sp>& ss);
+    void erase(std::string share_name, std::string topic_filter, session_state<Sp> const& ss);
     void erase(session_state<Sp> const& ss);
-    std::optional<std::tuple<session_state_ref<Sp>, subscription<Sp>>> get_target(buffer const& share_name, buffer const& topic_filter);
+    std::optional<std::tuple<session_state_ref<Sp>, subscription<Sp>>>
+    get_target(std::string const& share_name, std::string const& topic_filter);
 
 private:
     struct entry {
-        entry(buffer share_name, session_state<Sp>& ss, time_point_t tp);
+        entry(std::string share_name, session_state<Sp>& ss, time_point_t tp);
 
-        buffer const& client_id() const;
-        buffer share_name;
+        std::string const& client_id() const;
+        std::string share_name;
         session_state_ref<Sp> ssr;
         time_point_t tp;
-        std::map<buffer, subscription<Sp>> tf_subs;
+        std::map<std::string, subscription<Sp>> tf_subs;
     };
 
     using mi_shared_target = mi::multi_index_container<

--- a/include/async_mqtt/broker/shared_target_impl.hpp
+++ b/include/async_mqtt/broker/shared_target_impl.hpp
@@ -16,8 +16,8 @@ namespace async_mqtt {
 
 template <typename Sp>
 inline void shared_target<Sp>::insert(
-    buffer share_name,
-    buffer topic_filter,
+    std::string share_name,
+    std::string topic_filter,
     subscription<Sp> sub,
     session_state<Sp>& ss
 ) {
@@ -46,8 +46,8 @@ inline void shared_target<Sp>::insert(
 
 template <typename Sp>
 inline void shared_target<Sp>::erase(
-    buffer share_name,
-    buffer topic_filter,
+    std::string share_name,
+    std::string topic_filter,
     session_state<Sp> const& ss
 ) {
     std::lock_guard<mutex> g{mtx_targets_};
@@ -85,8 +85,8 @@ inline void shared_target<Sp>::erase(
 
 template <typename Sp>
 inline std::optional<std::tuple<session_state_ref<Sp>, subscription<Sp>>> shared_target<Sp>::get_target(
-    buffer const& share_name,
-    buffer const& topic_filter
+    std::string const& share_name,
+    std::string const& topic_filter
 ) {
     std::lock_guard<mutex> g{mtx_targets_};
     // get share_name matched range ordered by timestamp (ascending)
@@ -109,7 +109,7 @@ inline std::optional<std::tuple<session_state_ref<Sp>, subscription<Sp>>> shared
 
 template <typename Sp>
 inline shared_target<Sp>::entry::entry(
-    buffer share_name,
+    std::string share_name,
     session_state<Sp>& ss,
     time_point_t tp)
     : share_name { force_move(share_name) },
@@ -118,7 +118,7 @@ inline shared_target<Sp>::entry::entry(
 {}
 
 template <typename Sp>
-inline buffer const& shared_target<Sp>::entry::client_id() const {
+inline std::string const& shared_target<Sp>::entry::client_id() const {
     return ssr.get().client_id();
 }
 

--- a/include/async_mqtt/broker/sub_con_map.hpp
+++ b/include/async_mqtt/broker/sub_con_map.hpp
@@ -13,7 +13,7 @@
 namespace async_mqtt {
 
 template <typename Sp>
-using sub_con_map = multiple_subscription_map<buffer, subscription<Sp>, boost::hash<buffer>>;
+using sub_con_map = multiple_subscription_map<std::string, subscription<Sp>>;
 
 } // namespace async_mqtt
 

--- a/include/async_mqtt/broker/subscription.hpp
+++ b/include/async_mqtt/broker/subscription.hpp
@@ -8,10 +8,11 @@
 #define ASYNC_MQTT_BROKER_SUBSCRIPTION_HPP
 
 #include <optional>
+#include <string>
 
 #include <async_mqtt/packet/subopts.hpp>
-#include <async_mqtt/buffer.hpp>
 #include <async_mqtt/broker/session_state_fwd.hpp>
+#include <async_mqtt/util/move.hpp>
 
 namespace async_mqtt {
 
@@ -19,8 +20,8 @@ template <typename Sp>
 struct subscription {
     subscription(
         session_state_ref<Sp> ss,
-        buffer sharename,
-        buffer topic,
+        std::string sharename,
+        std::string topic,
         sub::opts opts,
         std::optional<std::size_t> sid)
         :ss{ss},
@@ -31,8 +32,8 @@ struct subscription {
     {}
 
     session_state_ref<Sp> ss;
-    buffer sharename;
-    buffer topic;
+    std::string sharename;
+    std::string topic;
     sub::opts opts;
     std::optional<std::size_t> sid;
 };

--- a/include/async_mqtt/broker/subscription_map.hpp
+++ b/include/async_mqtt/broker/subscription_map.hpp
@@ -168,7 +168,7 @@ template<typename Value>
 class subscription_map_base {
 public:
     using node_id_t = std::size_t;
-    using path_entry_key = std::pair<node_id_t, buffer>;
+    using path_entry_key = std::pair<node_id_t, std::string>;
     using handle = path_entry_key;
 
 private:
@@ -281,7 +281,7 @@ protected:
                         map.emplace(
                             path_entry_key(
                                 parent->second.id,
-                                allocate_buffer(t)
+                                t
                             ),
                             path_entry(generate_node_id(), parent->first)
                         ).first;

--- a/include/async_mqtt/buffer_to_packet_variant.hpp
+++ b/include/async_mqtt/buffer_to_packet_variant.hpp
@@ -7,9 +7,40 @@
 #if !defined(ASYNC_MQTT_BUFFER_TO_PACKET_VARIANT_HPP)
 #define ASYNC_MQTT_BUFFER_TO_PACKET_VARIANT_HPP
 
+#include <async_mqtt/buffer_to_packet_variant_fwd.hpp>
+
 #include <async_mqtt/packet/packet_variant.hpp>
 #include <async_mqtt/packet/control_packet_type.hpp>
 #include <async_mqtt/packet/get_protocol_version.hpp>
+#include <async_mqtt/packet/v3_1_1_connect.hpp>
+#include <async_mqtt/packet/v3_1_1_connack.hpp>
+#include <async_mqtt/packet/v3_1_1_publish.hpp>
+#include <async_mqtt/packet/v3_1_1_puback.hpp>
+#include <async_mqtt/packet/v3_1_1_pubrec.hpp>
+#include <async_mqtt/packet/v3_1_1_pubrel.hpp>
+#include <async_mqtt/packet/v3_1_1_pubcomp.hpp>
+#include <async_mqtt/packet/v3_1_1_subscribe.hpp>
+#include <async_mqtt/packet/v3_1_1_suback.hpp>
+#include <async_mqtt/packet/v3_1_1_unsubscribe.hpp>
+#include <async_mqtt/packet/v3_1_1_unsuback.hpp>
+#include <async_mqtt/packet/v3_1_1_pingreq.hpp>
+#include <async_mqtt/packet/v3_1_1_pingresp.hpp>
+#include <async_mqtt/packet/v3_1_1_disconnect.hpp>
+#include <async_mqtt/packet/v5_connect.hpp>
+#include <async_mqtt/packet/v5_connack.hpp>
+#include <async_mqtt/packet/v5_publish.hpp>
+#include <async_mqtt/packet/v5_puback.hpp>
+#include <async_mqtt/packet/v5_pubrec.hpp>
+#include <async_mqtt/packet/v5_pubrel.hpp>
+#include <async_mqtt/packet/v5_pubcomp.hpp>
+#include <async_mqtt/packet/v5_subscribe.hpp>
+#include <async_mqtt/packet/v5_suback.hpp>
+#include <async_mqtt/packet/v5_unsubscribe.hpp>
+#include <async_mqtt/packet/v5_unsuback.hpp>
+#include <async_mqtt/packet/v5_pingreq.hpp>
+#include <async_mqtt/packet/v5_pingresp.hpp>
+#include <async_mqtt/packet/v5_disconnect.hpp>
+#include <async_mqtt/packet/v5_auth.hpp>
 
 namespace async_mqtt {
 

--- a/include/async_mqtt/buffer_to_packet_variant_fwd.hpp
+++ b/include/async_mqtt/buffer_to_packet_variant_fwd.hpp
@@ -1,0 +1,23 @@
+// Copyright Takatoshi Kondo 2022
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(ASYNC_MQTT_BUFFER_TO_PACKET_VARIANT_FWD_HPP)
+#define ASYNC_MQTT_BUFFER_TO_PACKET_VARIANT_FWD_HPP
+
+#include <async_mqtt/protocol_version.hpp>
+#include <async_mqtt/buffer.hpp>
+
+namespace async_mqtt {
+
+template <std::size_t PacketIdBytes>
+class basic_packet_variant;
+
+template <std::size_t PacketIdBytes>
+basic_packet_variant<PacketIdBytes> buffer_to_basic_packet_variant(buffer buf, protocol_version ver);
+
+} // namespace async_mqtt
+
+#endif // ASYNC_MQTT_BUFFER_TO_PACKET_VARIANT_FWD_HPP

--- a/include/async_mqtt/client.hpp
+++ b/include/async_mqtt/client.hpp
@@ -8,6 +8,7 @@
 #define ASYNC_MQTT_CLIENT_HPP
 
 #include <deque>
+#include <optional>
 
 #include <boost/asio/async_result.hpp>
 #include <boost/asio/any_io_executor.hpp>

--- a/include/async_mqtt/detail/client_packet_type_getter.hpp
+++ b/include/async_mqtt/detail/client_packet_type_getter.hpp
@@ -10,7 +10,7 @@
 #include <boost/preprocessor/cat.hpp>
 
 #include <async_mqtt/protocol_version.hpp>
-#include <async_mqtt/packet/packet_variant.hpp>
+#include <async_mqtt/packet/packet_fwd.hpp>
 
 namespace async_mqtt::detail {
 

--- a/include/async_mqtt/impl/client_recv.hpp
+++ b/include/async_mqtt/impl/client_recv.hpp
@@ -49,10 +49,7 @@ recv_op {
                 a_cl.tim_notify_publish_recv_.async_wait(
                     as::bind_executor(
                         a_cl.get_executor(),
-                        as::append(
-                            force_move(self),
-                            a_cl.recv_queue_inserted_
-                        )
+                        force_move(self)
                     )
                 );
             }
@@ -71,11 +68,10 @@ recv_op {
     template <typename Self>
     void operator()(
         Self& self,
-        error_code /* ec */,
-        bool get_queue
+        error_code /* ec */
     ) {
         BOOST_ASSERT(state == complete);
-        if (get_queue) {
+        if (cl.recv_queue_inserted_) {
             auto [ec, publish_opt, disconnect_opt] = cl.recv_queue_.front();
             cl.recv_queue_.pop_front();
             self.complete(

--- a/include/async_mqtt/impl/endpoint_recv.hpp
+++ b/include/async_mqtt/impl/endpoint_recv.hpp
@@ -311,7 +311,7 @@ recv_op {
                                         return;
                                     }
                                     else {
-                                        p.add_topic(buffer{force_move(topic)});
+                                        p.add_topic(force_move(topic));
                                     }
                                 }
                             }

--- a/include/async_mqtt/impl/endpoint_regulate_for_store.hpp
+++ b/include/async_mqtt/impl/endpoint_regulate_for_store.hpp
@@ -82,7 +82,7 @@ basic_endpoint<Role, PacketIdBytes, NextLayer>::regulate_for_store(
         if (auto ta_opt = get_topic_alias(packet.props())) {
             auto topic = topic_alias_send_->find_without_touch(*ta_opt);
             if (!topic.empty()) {
-                packet.remove_topic_alias_add_topic(buffer{force_move(topic)});
+                packet.remove_topic_alias_add_topic(force_move(topic));
             }
         }
     }

--- a/include/async_mqtt/impl/endpoint_send.hpp
+++ b/include/async_mqtt/impl/endpoint_send.hpp
@@ -346,8 +346,8 @@ send_op {
                             auto store_packet =
                                 ActualPacket(
                                     actual_packet.packet_id(),
-                                    buffer{force_move(*topic_opt)},
-                                    actual_packet.payload(),
+                                    force_move(*topic_opt),
+                                    actual_packet.payload_as_buffer(),
                                     actual_packet.opts(),
                                     force_move(props)
                                 );
@@ -378,7 +378,7 @@ send_op {
                                 ActualPacket(
                                     actual_packet.packet_id(),
                                     actual_packet.topic(),
-                                    actual_packet.payload(),
+                                    actual_packet.payload_as_buffer(),
                                     actual_packet.opts(),
                                     force_move(props)
                                 );

--- a/include/async_mqtt/packet/packet_fwd.hpp
+++ b/include/async_mqtt/packet/packet_fwd.hpp
@@ -1,0 +1,73 @@
+// Copyright Takatoshi Kondo 2022
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(ASYNC_MQTT_PACKET_PACKET_FWD_HPP)
+#define ASYNC_MQTT_PACKET_PACKET_FWD_HPP
+
+#include <cstddef>
+
+namespace async_mqtt {
+
+namespace v3_1_1 {
+
+class connack_packet;
+class connect_packet;
+template <std::size_t PacketIdBytes> class basic_publish_packet;
+template <std::size_t PacketIdBytes> class basic_puback_packet;
+template <std::size_t PacketIdBytes> class basic_pubrec_packet;
+template <std::size_t PacketIdBytes> class basic_pubrel_packet;
+template <std::size_t PacketIdBytes> class basic_pubcomp_packet;
+template <std::size_t PacketIdBytes> class basic_subscribe_packet;
+template <std::size_t PacketIdBytes> class basic_suback_packet;
+template <std::size_t PacketIdBytes> class basic_unsubscribe_packet;
+template <std::size_t PacketIdBytes> class basic_unsuback_packet;
+class pingreq_packet;
+class pingresp_packet;
+class disconnect_packet;
+using publish_packet = basic_publish_packet<2>;
+using puback_packet = basic_puback_packet<2>;
+using pubrec_packet = basic_pubrec_packet<2>;
+using pubrel_packet = basic_pubrel_packet<2>;
+using pubcomp_packet = basic_pubcomp_packet<2>;
+using subscribe_packet = basic_subscribe_packet<2>;
+using suback_packet = basic_suback_packet<2>;
+using unsubscribe_packet = basic_unsubscribe_packet<2>;
+using unsuback_packet = basic_unsuback_packet<2>;
+
+} // namespace v3_1_1
+
+namespace v5 {
+
+class connack_packet;
+class connect_packet;
+template <std::size_t PacketIdBytes> class basic_publish_packet;
+template <std::size_t PacketIdBytes> class basic_puback_packet;
+template <std::size_t PacketIdBytes> class basic_pubrec_packet;
+template <std::size_t PacketIdBytes> class basic_pubrel_packet;
+template <std::size_t PacketIdBytes> class basic_pubcomp_packet;
+template <std::size_t PacketIdBytes> class basic_subscribe_packet;
+template <std::size_t PacketIdBytes> class basic_suback_packet;
+template <std::size_t PacketIdBytes> class basic_unsubscribe_packet;
+template <std::size_t PacketIdBytes> class basic_unsuback_packet;
+class pingreq_packet;
+class pingresp_packet;
+class disconnect_packet;
+class auth_packet;
+using publish_packet = basic_publish_packet<2>;
+using puback_packet = basic_puback_packet<2>;
+using pubrec_packet = basic_pubrec_packet<2>;
+using pubrel_packet = basic_pubrel_packet<2>;
+using pubcomp_packet = basic_pubcomp_packet<2>;
+using subscribe_packet = basic_subscribe_packet<2>;
+using suback_packet = basic_suback_packet<2>;
+using unsubscribe_packet = basic_unsubscribe_packet<2>;
+using unsuback_packet = basic_unsuback_packet<2>;
+
+} // namespace v5
+
+} // namespace async_mqtt
+
+#endif // ASYNC_MQTT_PACKET_PACKET_FWD_HPP

--- a/include/async_mqtt/packet/packet_iterator.hpp
+++ b/include/async_mqtt/packet/packet_iterator.hpp
@@ -39,19 +39,6 @@ to_string(Container<Buffer> const& cbs) {
     return std::string(b, e);
 }
 
-template <template <typename...> typename Container, typename Buffer>
-buffer
-to_buffer(Container<Buffer> const& cbs) {
-    switch (cbs.size()) {
-    case 0: return buffer{};
-    case 1: return cbs.front();
-    default: {
-        auto [b, e] = make_packet_range(cbs);
-        return allocate_buffer(b, e);
-    }
-    }
-}
-
 } // namespace async_mqtt
 
 #endif // ASYNC_MQTT_PACKET_PACKET_ITERATOR_HPP

--- a/include/async_mqtt/packet/packet_variant.hpp
+++ b/include/async_mqtt/packet/packet_variant.hpp
@@ -9,7 +9,12 @@
 
 #include <variant>
 
-#include <async_mqtt/util/overload.hpp>
+#include <boost/asio/buffer.hpp>
+
+#include <async_mqtt/exception.hpp>
+
+#include <async_mqtt/packet/control_packet_type.hpp>
+#include <async_mqtt/packet/packet_fwd.hpp>
 #include <async_mqtt/packet/v3_1_1_connect.hpp>
 #include <async_mqtt/packet/v3_1_1_connack.hpp>
 #include <async_mqtt/packet/v3_1_1_publish.hpp>
@@ -39,9 +44,11 @@
 #include <async_mqtt/packet/v5_pingresp.hpp>
 #include <async_mqtt/packet/v5_disconnect.hpp>
 #include <async_mqtt/packet/v5_auth.hpp>
-#include <async_mqtt/exception.hpp>
+
+#include <async_mqtt/util/overload.hpp>
 
 namespace async_mqtt {
+namespace as = boost::asio;
 
 /**
  * @breif The varaint type of all packets and system_error
@@ -214,7 +221,7 @@ private:
         v5::pingresp_packet,
         v5::disconnect_packet,
         v5::auth_packet
->;
+    >;
 
     variant_t var_;
 };

--- a/include/async_mqtt/packet/property.hpp
+++ b/include/async_mqtt/packet/property.hpp
@@ -38,6 +38,11 @@ namespace async_mqtt {
 
 namespace as = boost::asio;
 
+// forward declarations
+class property_variant;
+enum class property_location;
+property_variant make_property_variant(buffer& buf, property_location loc);
+
 /**
  * @breif payload_format
  */
@@ -323,10 +328,6 @@ public:
           }
     {}
 
-    template <typename It, typename End>
-    payload_format_indicator(It b, End e)
-        : detail::n_bytes_property<1>{id::payload_format_indicator, b, e} {}
-
     /**
      * @brief Get value
      * @return payload_format
@@ -340,6 +341,16 @@ public:
     }
 
     static constexpr detail::ostream_format const of_ = detail::ostream_format::binary_string;
+
+private:
+    friend property_variant async_mqtt::make_property_variant(buffer& buf, property_location loc);
+
+    // private constructor for internal use
+    template <typename It, typename End>
+    payload_format_indicator(It b, End e)
+        : detail::n_bytes_property<1>{id::payload_format_indicator, b, e} {}
+
+
 };
 
 
@@ -355,10 +366,6 @@ public:
     message_expiry_interval(std::uint32_t val)
         : detail::n_bytes_property<4>{id::message_expiry_interval, endian_static_vector(val)} {}
 
-    template <typename It, typename End>
-    message_expiry_interval(It b, End e)
-        : detail::n_bytes_property<4>{id::message_expiry_interval, b, e} {}
-
     /**
      * @brief Get value
      * @return message_expiry_interval seconds
@@ -366,6 +373,14 @@ public:
     std::uint32_t val() const {
         return endian_load<std::uint32_t>(buf_.data());
     }
+
+private:
+    friend property_variant async_mqtt::make_property_variant(buffer& buf, property_location loc);
+
+    // private constructor for internal use
+    template <typename It, typename End>
+    message_expiry_interval(It b, End e)
+        : detail::n_bytes_property<4>{id::message_expiry_interval, b, e} {}
 };
 
 /**
@@ -375,10 +390,21 @@ class content_type : public detail::string_property {
 public:
     /**
      * @brief constructor
-     * @param val content_type string
+     * @param val content type string
      */
-    explicit content_type(buffer val)
-        : detail::string_property{id::content_type, force_move(val)} {}
+    explicit content_type(std::string val)
+        : detail::string_property{id::content_type, buffer{force_move(val)}} {}
+
+private:
+    friend property_variant async_mqtt::make_property_variant(buffer& buf, property_location loc);
+
+    // private constructor for internal use
+    template <
+        typename Buffer,
+        std::enable_if_t<std::is_same_v<Buffer, buffer>, std::nullptr_t> = nullptr
+    >
+    explicit content_type(Buffer&& val)
+        : detail::string_property{id::content_type, std::forward<Buffer>(val)} {}
 };
 
 /**
@@ -390,8 +416,18 @@ public:
      * @brief constructor
      * @param val response_topic string
      */
-    explicit response_topic(buffer val)
-        : detail::string_property{id::response_topic, force_move(val)} {}
+    explicit response_topic(std::string val)
+        : detail::string_property{id::response_topic, buffer{force_move(val)}} {}
+private:
+    friend property_variant async_mqtt::make_property_variant(buffer& buf, property_location loc);
+
+    // private constructor for internal use
+    template <
+        typename Buffer,
+        std::enable_if_t<std::is_same_v<Buffer, buffer>, std::nullptr_t> = nullptr
+    >
+    explicit response_topic(Buffer&& val)
+        : detail::string_property{id::response_topic, std::forward<Buffer>(val)} {}
 };
 
 /**
@@ -403,8 +439,18 @@ public:
      * @brief constructor
      * @param val correlation_data string
      */
-    explicit correlation_data(buffer val)
-        : detail::binary_property{id::correlation_data, force_move(val)} {}
+    explicit correlation_data(std::string val)
+        : detail::binary_property{id::correlation_data, buffer{force_move(val)}} {}
+private:
+    friend property_variant async_mqtt::make_property_variant(buffer& buf, property_location loc);
+
+    // private constructor for internal use
+    template <
+        typename Buffer,
+        std::enable_if_t<std::is_same_v<Buffer, buffer>, std::nullptr_t> = nullptr
+    >
+    explicit correlation_data(Buffer&& val)
+        : detail::binary_property{id::correlation_data, std::forward<Buffer>(val)} {}
 };
 
 /**
@@ -433,10 +479,6 @@ public:
         : detail::n_bytes_property<4>{id::session_expiry_interval, endian_static_vector(val)} {
     }
 
-    template <typename It>
-    session_expiry_interval(It b, It e)
-        : detail::n_bytes_property<4>{id::session_expiry_interval, b, e} {}
-
     /**
      * @brief Get value
      * @return session_expiry_interval seconds
@@ -444,6 +486,14 @@ public:
     std::uint32_t val() const {
         return endian_load<std::uint32_t>(buf_.data());
     }
+
+private:
+    friend property_variant async_mqtt::make_property_variant(buffer& buf, property_location loc);
+
+    // private constructor for internal use
+    template <typename It>
+    session_expiry_interval(It b, It e)
+        : detail::n_bytes_property<4>{id::session_expiry_interval, b, e} {}
 };
 
 /**
@@ -455,8 +505,19 @@ public:
      * @brief constructor
      * @param val assigned_client_identifier string
      */
-    explicit assigned_client_identifier(buffer val)
-        : detail::string_property{id::assigned_client_identifier, force_move(val)} {}
+    explicit assigned_client_identifier(std::string val)
+        : detail::string_property{id::assigned_client_identifier, buffer{force_move(val)}} {}
+
+private:
+    friend property_variant async_mqtt::make_property_variant(buffer& buf, property_location loc);
+
+    // private constructor for internal use
+    template <
+        typename Buffer,
+        std::enable_if_t<std::is_same_v<Buffer, buffer>, std::nullptr_t> = nullptr
+    >
+    explicit assigned_client_identifier(Buffer&& val)
+        : detail::string_property{id::assigned_client_identifier, std::forward<Buffer>(val)} {}
 };
 
 /**
@@ -471,10 +532,6 @@ public:
     server_keep_alive(std::uint16_t val)
         : detail::n_bytes_property<2>{id::server_keep_alive, endian_static_vector(val)} {}
 
-    template <typename It, typename End>
-    server_keep_alive(It b, End e)
-        : detail::n_bytes_property<2>{id::server_keep_alive, b, e} {}
-
     /**
      * @brief Get value
      * @return server_keep_alive seconds
@@ -482,6 +539,14 @@ public:
     std::uint16_t val() const {
         return endian_load<uint16_t>(buf_.data());
     }
+
+private:
+    friend property_variant async_mqtt::make_property_variant(buffer& buf, property_location loc);
+
+    // private constructor for internal use
+    template <typename It, typename End>
+    server_keep_alive(It b, End e)
+        : detail::n_bytes_property<2>{id::server_keep_alive, b, e} {}
 };
 
 /**
@@ -493,8 +558,19 @@ public:
      * @brief constructor
      * @param val authentication_method string
      */
-    explicit authentication_method(buffer val)
-        : detail::string_property{id::authentication_method, force_move(val)} {}
+    explicit authentication_method(std::string val)
+        : detail::string_property{id::authentication_method, buffer{force_move(val)}} {}
+
+private:
+    friend property_variant async_mqtt::make_property_variant(buffer& buf, property_location loc);
+
+    // private constructor for internal use
+    template <
+        typename Buffer,
+        std::enable_if_t<std::is_same_v<Buffer, buffer>, std::nullptr_t> = nullptr
+    >
+    explicit authentication_method(Buffer&& val)
+        : detail::string_property{id::authentication_method, std::forward<Buffer>(val)} {}
 };
 
 /**
@@ -506,8 +582,18 @@ public:
      * @brief constructor
      * @param val authentication_data string
      */
-    explicit authentication_data(buffer val)
-        : detail::binary_property{id::authentication_data, force_move(val)} {}
+    explicit authentication_data(std::string val)
+        : detail::binary_property{id::authentication_data, buffer{force_move(val)}} {}
+private:
+    friend property_variant async_mqtt::make_property_variant(buffer& buf, property_location loc);
+
+    // private constructor for internal use
+    template <
+        typename Buffer,
+        std::enable_if_t<std::is_same_v<Buffer, buffer>, std::nullptr_t> = nullptr
+    >
+    explicit authentication_data(Buffer&& val)
+        : detail::binary_property{id::authentication_data, std::forward<Buffer>(val)} {}
 };
 
 /**
@@ -530,9 +616,6 @@ public:
               }
           }
     {}
-    template <typename It, typename End>
-    request_problem_information(It b, End e)
-        : detail::n_bytes_property<1>{id::request_problem_information, b, e} {}
 
     /**
      * @brief Get value
@@ -541,6 +624,14 @@ public:
     bool val() const {
         return buf_.front() == 1;
     }
+
+private:
+    friend property_variant async_mqtt::make_property_variant(buffer& buf, property_location loc);
+
+    // private constructor for internal use
+    template <typename It, typename End>
+    request_problem_information(It b, End e)
+        : detail::n_bytes_property<1>{id::request_problem_information, b, e} {}
 };
 
 /**
@@ -555,10 +646,6 @@ public:
     will_delay_interval(std::uint32_t val)
         : detail::n_bytes_property<4>{id::will_delay_interval, endian_static_vector(val)} {}
 
-    template <typename It, typename End>
-    will_delay_interval(It b, End e)
-        : detail::n_bytes_property<4>{id::will_delay_interval, b, e} {}
-
     /**
      * @brief Get value
      * @return will_delay_interval seconds
@@ -566,6 +653,14 @@ public:
     std::uint32_t val() const {
         return endian_load<uint32_t>(buf_.data());
     }
+
+private:
+    friend property_variant async_mqtt::make_property_variant(buffer& buf, property_location loc);
+
+    // private constructor for internal use
+    template <typename It, typename End>
+    will_delay_interval(It b, End e)
+        : detail::n_bytes_property<4>{id::will_delay_interval, b, e} {}
 };
 
 /**
@@ -589,10 +684,6 @@ public:
           }
     {}
 
-    template <typename It, typename End>
-    request_response_information(It b, End e)
-        : detail::n_bytes_property<1>(id::request_response_information, b, e) {}
-
     /**
      * @brief Get value
      * @return value
@@ -600,6 +691,14 @@ public:
     bool val() const {
         return buf_.front() == 1;
     }
+
+private:
+    friend property_variant async_mqtt::make_property_variant(buffer& buf, property_location loc);
+
+    // private constructor for internal use
+    template <typename It, typename End>
+    request_response_information(It b, End e)
+        : detail::n_bytes_property<1>(id::request_response_information, b, e) {}
 };
 
 /**
@@ -611,8 +710,19 @@ public:
      * @brief constructor
      * @param val response_information string
      */
-    explicit response_information(buffer val)
-        : detail::string_property{id::response_information, force_move(val)} {}
+    explicit response_information(std::string val)
+        : detail::string_property{id::response_information, buffer{force_move(val)}} {}
+
+private:
+    friend property_variant async_mqtt::make_property_variant(buffer& buf, property_location loc);
+
+    // private constructor for internal use
+    template <
+        typename Buffer,
+        std::enable_if_t<std::is_same_v<Buffer, buffer>, std::nullptr_t> = nullptr
+    >
+    explicit response_information(Buffer&& val)
+        : detail::string_property{id::response_information, std::forward<Buffer>(val)} {}
 };
 
 /**
@@ -624,8 +734,19 @@ public:
      * @brief constructor
      * @param val server_reference string
      */
-    explicit server_reference(buffer val)
-        : detail::string_property{id::server_reference, force_move(val)} {}
+    explicit server_reference(std::string val)
+        : detail::string_property{id::server_reference, buffer{force_move(val)}} {}
+
+private:
+    friend property_variant async_mqtt::make_property_variant(buffer& buf, property_location loc);
+
+    // private constructor for internal use
+    template <
+        typename Buffer,
+        std::enable_if_t<std::is_same_v<Buffer, buffer>, std::nullptr_t> = nullptr
+    >
+    explicit server_reference(Buffer&& val)
+        : detail::string_property{id::server_reference, std::forward<Buffer>(val)} {}
 };
 
 /**
@@ -637,8 +758,19 @@ public:
      * @brief constructor
      * @param val reason_string
      */
-    explicit reason_string(buffer val)
-        : detail::string_property{id::reason_string, force_move(val)} {}
+    explicit reason_string(std::string val)
+        : detail::string_property{id::reason_string, buffer{force_move(val)}} {}
+
+private:
+    friend property_variant async_mqtt::make_property_variant(buffer& buf, property_location loc);
+
+    // private constructor for internal use
+    template <
+        typename Buffer,
+        std::enable_if_t<std::is_same_v<Buffer, buffer>, std::nullptr_t> = nullptr
+    >
+    explicit reason_string(Buffer&& val)
+        : detail::string_property{id::reason_string, std::forward<Buffer>(val)} {}
 };
 
 /**
@@ -660,6 +792,18 @@ public:
         }
     }
 
+    /**
+     * @brief Get value
+     * @return value
+     */
+    std::uint16_t val() const {
+        return endian_load<std::uint16_t>(buf_.data());
+    }
+
+private:
+    friend property_variant async_mqtt::make_property_variant(buffer& buf, property_location loc);
+
+    // private constructor for internal use
     template <typename It, typename End>
     receive_maximum(It b, End e)
         : detail::n_bytes_property<2>{id::receive_maximum, b, e} {
@@ -669,14 +813,6 @@ public:
                 "property::receive_maximum value is invalid"
             );
         }
-    }
-
-    /**
-     * @brief Get value
-     * @return value
-     */
-    std::uint16_t val() const {
-        return endian_load<std::uint16_t>(buf_.data());
     }
 };
 
@@ -693,10 +829,6 @@ public:
     topic_alias_maximum(std::uint16_t val)
         : detail::n_bytes_property<2>{id::topic_alias_maximum, endian_static_vector(val)} {}
 
-    template <typename It, typename End>
-    topic_alias_maximum(It b, End e)
-        : detail::n_bytes_property<2>{id::topic_alias_maximum, b, e} {}
-
     /**
      * @brief Get value
      * @return value
@@ -704,6 +836,14 @@ public:
     std::uint16_t val() const {
         return endian_load<std::uint16_t>(buf_.data());
     }
+
+private:
+    friend property_variant async_mqtt::make_property_variant(buffer& buf, property_location loc);
+
+    // private constructor for internal use
+    template <typename It, typename End>
+    topic_alias_maximum(It b, End e)
+        : detail::n_bytes_property<2>{id::topic_alias_maximum, b, e} {}
 };
 
 
@@ -719,10 +859,6 @@ public:
     topic_alias(std::uint16_t val)
         : detail::n_bytes_property<2>{id::topic_alias, endian_static_vector(val)} {}
 
-    template <typename It, typename End>
-    topic_alias(It b, End e)
-        : detail::n_bytes_property<2>(id::topic_alias, b, e) {}
-
     /**
      * @brief Get value
      * @return value
@@ -730,6 +866,14 @@ public:
     std::uint16_t val() const {
         return endian_load<std::uint16_t>(buf_.data());
     }
+
+private:
+    friend property_variant async_mqtt::make_property_variant(buffer& buf, property_location loc);
+
+    // private constructor for internal use
+    template <typename It, typename End>
+    topic_alias(It b, End e)
+        : detail::n_bytes_property<2>(id::topic_alias, b, e) {}
 };
 
 /**
@@ -752,10 +896,6 @@ public:
         }
     }
 
-    template <typename It, typename End>
-    maximum_qos(It b, End e)
-        : detail::n_bytes_property<1>{id::maximum_qos, b, e} {}
-
     /**
      * @brief Get value
      * @return value
@@ -765,6 +905,14 @@ public:
     }
 
     static constexpr const detail::ostream_format of_ = detail::ostream_format::int_cast;
+
+private:
+    friend property_variant async_mqtt::make_property_variant(buffer& buf, property_location loc);
+
+    // private constructor for internal use
+    template <typename It, typename End>
+    maximum_qos(It b, End e)
+        : detail::n_bytes_property<1>{id::maximum_qos, b, e} {}
 };
 
 /**
@@ -788,10 +936,6 @@ public:
           }
     {}
 
-    template <typename It, typename End>
-    retain_available(It b, End e)
-        : detail::n_bytes_property<1>{id::retain_available, b, e} {}
-
     /**
      * @brief Get value
      * @return value
@@ -799,6 +943,14 @@ public:
     bool val() const {
         return buf_.front() == 1;
     }
+
+private:
+    friend property_variant async_mqtt::make_property_variant(buffer& buf, property_location loc);
+
+    // private constructor for internal use
+    template <typename It, typename End>
+    retain_available(It b, End e)
+        : detail::n_bytes_property<1>{id::retain_available, b, e} {}
 };
 
 
@@ -811,21 +963,9 @@ public:
      * @brief constructor
      * @param val response_information string
      */
-    user_property(buffer key, buffer val)
-        : key_{force_move(key)}, val_{force_move(val)} {
-        if (key_.size() > 0xffff) {
-            throw make_error(
-                errc::bad_message,
-                "property::user_property key length is invalid"
-            );
-        }
-        if (val_.size() > 0xffff) {
-            throw make_error(
-                errc::bad_message,
-                "property::user_property val length is invalid"
-            );
-        }
-    }
+    user_property(std::string key, std::string val)
+        : user_property{buffer{force_move(key)}, buffer{force_move(val)}}
+    {}
 
     /**
      * @brief Add const buffer sequence into the given buffer.
@@ -918,6 +1058,30 @@ private:
     };
 
 private:
+    friend property_variant async_mqtt::make_property_variant(buffer& buf, property_location loc);
+
+    // private constructor for internal use
+    template <
+        typename Buffer,
+        std::enable_if_t<std::is_same_v<Buffer, buffer>, std::nullptr_t> = nullptr
+    >
+    explicit user_property(Buffer&& key, Buffer&& val)
+        : key_{std::forward<Buffer>(key)}, val_{std::forward<Buffer>(val)} {
+        if (key_.size() > 0xffff) {
+            throw make_error(
+                errc::bad_message,
+                "property::user_property key length is invalid"
+            );
+        }
+        if (val_.size() > 0xffff) {
+            throw make_error(
+                errc::bad_message,
+                "property::user_property val length is invalid"
+            );
+        }
+    }
+
+private:
     property::id id_ = id::user_property;
     len_str key_;
     len_str val_;
@@ -942,6 +1106,18 @@ public:
         }
     }
 
+    /**
+     * @brief Get value
+     * @return value
+     */
+    std::uint32_t val() const {
+        return endian_load<std::uint32_t>(buf_.data());
+    }
+
+private:
+    friend property_variant async_mqtt::make_property_variant(buffer& buf, property_location loc);
+
+    // private constructor for internal use
     template <typename It, typename End>
     maximum_packet_size(It b, End e)
         : detail::n_bytes_property<4>{id::maximum_packet_size, b, e} {
@@ -951,14 +1127,6 @@ public:
                 "property::maximum_packet_size value is invalid"
             );
         }
-    }
-
-    /**
-     * @brief Get value
-     * @return value
-     */
-    std::uint32_t val() const {
-        return endian_load<std::uint32_t>(buf_.data());
     }
 };
 
@@ -984,10 +1152,6 @@ public:
           }
     {}
 
-    template <typename It, typename End>
-    wildcard_subscription_available(It b, End e)
-        : detail::n_bytes_property<1>{id::wildcard_subscription_available, b, e} {}
-
     /**
      * @brief Get value
      * @return value
@@ -995,6 +1159,14 @@ public:
     bool val() const {
         return buf_.front() == 1;
     }
+
+private:
+    friend property_variant async_mqtt::make_property_variant(buffer& buf, property_location loc);
+
+    // private constructor for internal use
+    template <typename It, typename End>
+    wildcard_subscription_available(It b, End e)
+        : detail::n_bytes_property<1>{id::wildcard_subscription_available, b, e} {}
 };
 
 
@@ -1019,10 +1191,6 @@ public:
           }
     {}
 
-    template <typename It, typename End>
-    subscription_identifier_available(It b, End e)
-        : detail::n_bytes_property<1>{id::subscription_identifier_available, b, e} {}
-
     /**
      * @brief Get value
      * @return value
@@ -1030,6 +1198,14 @@ public:
     bool val() const {
         return buf_.front() == 1;
     }
+
+private:
+    friend property_variant async_mqtt::make_property_variant(buffer& buf, property_location loc);
+
+    // private constructor for internal use
+    template <typename It, typename End>
+    subscription_identifier_available(It b, End e)
+        : detail::n_bytes_property<1>{id::subscription_identifier_available, b, e} {}
 };
 
 
@@ -1054,10 +1230,6 @@ public:
           }
     {}
 
-    template <typename It, typename End>
-    shared_subscription_available(It b, End e)
-        : detail::n_bytes_property<1>{id::shared_subscription_available, b, e} {}
-
     /**
      * @brief Get value
      * @return value
@@ -1065,6 +1237,14 @@ public:
     bool val() const {
         return buf_.front() == 1;
     }
+
+private:
+    friend property_variant async_mqtt::make_property_variant(buffer& buf, property_location loc);
+
+    // private constructor for internal use
+    template <typename It, typename End>
+    shared_subscription_available(It b, End e)
+        : detail::n_bytes_property<1>{id::shared_subscription_available, b, e} {}
 };
 
 template <typename Property>

--- a/include/async_mqtt/packet/topic_sharename.hpp
+++ b/include/async_mqtt/packet/topic_sharename.hpp
@@ -23,9 +23,16 @@ public:
      * @brief constructor
      * @param all_topic TopicFilter. It could contain sharename on MQTT v5.0.
      */
+    template <
+        typename AllTopic,
+        typename std::enable_if_t<
+            std::is_convertible_v<std::decay_t<AllTopic>, std::string_view>,
+            std::nullptr_t
+        > = nullptr
+    >
     topic_sharename(
-        buffer all_topic
-    ): all_topic_{force_move(all_topic)} {
+        AllTopic&& all_topic
+    ): all_topic_{std::forward<AllTopic>(all_topic)} {
         BOOST_ASSERT(all_topic_.size() <= 0xffff);
         auto const shared_prefix = std::string_view("$share/");
         if (all_topic_.substr(0, shared_prefix.size()) == shared_prefix) {
@@ -36,7 +43,7 @@ public:
             if (idx == 0 || idx == std::string_view::npos) return;
 
             topic_ = sharename_.substr(idx + 1);
-            sharename_.remove_suffix(sharename_.size() - idx);
+            sharename_ = sharename_.substr(0, sharename_.size() - topic_.size() - 1);
         }
         else {
             topic_ = all_topic_;
@@ -47,15 +54,15 @@ public:
      * @brief Get topic
      * @return topic
      */
-    buffer const& topic() const {
+    std::string const& topic() const {
         return topic_;
     }
 
     /**
      * @brief Get sharename
-     * @return sharename. If no sharename then return empty size buffer.
+     * @return sharename. If no sharename then return empty size std::string.
      */
-    buffer const& sharename() const {
+    std::string const& sharename() const {
         return sharename_;
     }
 
@@ -65,7 +72,7 @@ public:
      * If sharename is contained, $share/ prefix is contained.
      * @return all_topic that is given to the constructor.
      */
-    buffer const& all_topic() const {
+    std::string const& all_topic() const {
         return all_topic_;
     }
 
@@ -99,9 +106,9 @@ public:
     }
 
 private:
-    buffer all_topic_;
-    buffer topic_;
-    buffer sharename_;
+    std::string all_topic_;
+    std::string topic_;
+    std::string sharename_;
 };
 
 } // namespace async_mqtt

--- a/include/async_mqtt/packet/topic_subopts.hpp
+++ b/include/async_mqtt/packet/topic_subopts.hpp
@@ -24,7 +24,7 @@ public:
      * @param opts      subscribe options
      */
     topic_subopts(
-        buffer all_topic,
+        std::string all_topic,
         sub::opts opts
     ): topic_sharename_{force_move(all_topic)},
        opts_{opts}
@@ -35,15 +35,15 @@ public:
      * @brief Get topic
      * @return topic
      */
-    buffer const& topic() const {
+    std::string const& topic() const {
         return topic_sharename_.topic();
     }
 
     /**
      * @brief Get sharename
-     * @return sharename. If no sharename then return empty size buffer.
+     * @return sharename. If no sharename then return empty size std::string.
      */
-    buffer const& sharename() const {
+    std::string const& sharename() const {
         return topic_sharename_.sharename();
     }
 
@@ -53,7 +53,7 @@ public:
      * If sharename is contained, $share/ prefix is contained.
      * @return all_topic that is given to the constructor.
      */
-    buffer const& all_topic() const {
+    std::string const& all_topic() const {
         return topic_sharename_.all_topic();
     }
 

--- a/include/async_mqtt/packet/v3_1_1_pingreq.hpp
+++ b/include/async_mqtt/packet/v3_1_1_pingreq.hpp
@@ -12,6 +12,7 @@
 
 #include <boost/numeric/conversion/cast.hpp>
 
+#include <async_mqtt/buffer_to_packet_variant_fwd.hpp>
 #include <async_mqtt/exception.hpp>
 #include <async_mqtt/buffer.hpp>
 
@@ -50,6 +51,53 @@ public:
         all_[1] = char(0);
     }
 
+    /**
+     * @brief Get MQTT control packet type
+     * @return control packet type
+     */
+    constexpr control_packet_type type() const {
+        return control_packet_type::pingreq;
+    }
+
+    /**
+     * @brief Create const buffer sequence
+     *        it is for boost asio APIs
+     * @return const buffer sequence
+     */
+    std::vector<as::const_buffer> const_buffer_sequence() const {
+        std::vector<as::const_buffer> ret;
+
+        ret.emplace_back(as::buffer(all_.data(), all_.size()));
+        return ret;
+    }
+
+    /**
+     * @brief Get packet size.
+     * @return packet size
+     */
+    std::size_t size() const {
+        return all_.size();
+    }
+
+    /**
+     * @brief Get number of element of const_buffer_sequence
+     * @return number of element of const_buffer_sequence
+     */
+    static constexpr std::size_t num_of_const_buffer_sequence() {
+        return 1; // all
+    }
+
+private:
+
+    template <std::size_t PacketIdBytesArg>
+    friend basic_packet_variant<PacketIdBytesArg>
+    async_mqtt::buffer_to_basic_packet_variant(buffer buf, protocol_version ver);
+
+#if defined(ASYNC_MQTT_UNIT_TEST_FOR_PACKET)
+    friend struct ::ut_packet::v311_pingreq;
+#endif // defined(ASYNC_MQTT_UNIT_TEST_FOR_PACKET)
+
+    // private constructor for internal use
     pingreq_packet(buffer buf) {
         // fixed_header
         if (buf.empty()) {
@@ -85,42 +133,14 @@ public:
         }
     }
 
-    constexpr control_packet_type type() const {
-        return control_packet_type::pingreq;
-    }
-
-    /**
-     * @brief Create const buffer sequence
-     *        it is for boost asio APIs
-     * @return const buffer sequence
-     */
-    std::vector<as::const_buffer> const_buffer_sequence() const {
-        std::vector<as::const_buffer> ret;
-
-        ret.emplace_back(as::buffer(all_.data(), all_.size()));
-        return ret;
-    }
-
-    /**
-     * @brief Get packet size.
-     * @return packet size
-     */
-    std::size_t size() const {
-        return all_.size();
-    }
-
-    /**
-     * @brief Get number of element of const_buffer_sequence
-     * @return number of element of const_buffer_sequence
-     */
-    static constexpr std::size_t num_of_const_buffer_sequence() {
-        return 1; // all
-    }
 
 private:
     static_vector<char, 2> all_;
 };
 
+/**
+ * @brief stream output operator
+ */
 inline std::ostream& operator<<(std::ostream& o, pingreq_packet const& /*v*/) {
     o <<
         "v3_1_1::pingreq{}";

--- a/include/async_mqtt/packet/v3_1_1_pingresp.hpp
+++ b/include/async_mqtt/packet/v3_1_1_pingresp.hpp
@@ -12,6 +12,7 @@
 
 #include <boost/numeric/conversion/cast.hpp>
 
+#include <async_mqtt/buffer_to_packet_variant_fwd.hpp>
 #include <async_mqtt/exception.hpp>
 #include <async_mqtt/buffer.hpp>
 
@@ -50,6 +51,53 @@ public:
         all_[1] = char(0);
     }
 
+    /**
+     * @brief Get MQTT control packet type
+     * @return control packet type
+     */
+    constexpr control_packet_type type() const {
+        return control_packet_type::pingresp;
+    }
+
+    /**
+     * @brief Create const buffer sequence
+     *        it is for boost asio APIs
+     * @return const buffer sequence
+     */
+    std::vector<as::const_buffer> const_buffer_sequence() const {
+        std::vector<as::const_buffer> ret;
+
+        ret.emplace_back(as::buffer(all_.data(), all_.size()));
+        return ret;
+    }
+
+    /**
+     * @brief Get packet size.
+     * @return packet size
+     */
+    std::size_t size() const {
+        return all_.size();
+    }
+
+    /**
+     * @brief Get number of element of const_buffer_sequence
+     * @return number of element of const_buffer_sequence
+     */
+    static constexpr std::size_t num_of_const_buffer_sequence() {
+        return 1; // all
+    }
+
+private:
+
+    template <std::size_t PacketIdBytesArg>
+    friend basic_packet_variant<PacketIdBytesArg>
+    async_mqtt::buffer_to_basic_packet_variant(buffer buf, protocol_version ver);
+
+#if defined(ASYNC_MQTT_UNIT_TEST_FOR_PACKET)
+    friend struct ::ut_packet::v311_pingresp;
+#endif // defined(ASYNC_MQTT_UNIT_TEST_FOR_PACKET)
+
+    // private constructor for internal use
     pingresp_packet(buffer buf) {
         // fixed_header
         if (buf.empty()) {
@@ -85,42 +133,14 @@ public:
         }
     }
 
-    constexpr control_packet_type type() const {
-        return control_packet_type::pingresp;
-    }
-
-    /**
-     * @brief Create const buffer sequence
-     *        it is for boost asio APIs
-     * @return const buffer sequence
-     */
-    std::vector<as::const_buffer> const_buffer_sequence() const {
-        std::vector<as::const_buffer> ret;
-
-        ret.emplace_back(as::buffer(all_.data(), all_.size()));
-        return ret;
-    }
-
-    /**
-     * @brief Get packet size.
-     * @return packet size
-     */
-    std::size_t size() const {
-        return all_.size();
-    }
-
-    /**
-     * @brief Get number of element of const_buffer_sequence
-     * @return number of element of const_buffer_sequence
-     */
-    static constexpr std::size_t num_of_const_buffer_sequence() {
-        return 1; // all
-    }
 
 private:
     static_vector<char, 2> all_;
 };
 
+/**
+ * @brief stream output operator
+ */
 inline std::ostream& operator<<(std::ostream& o, pingresp_packet const& /*v*/) {
     o <<
         "v3_1_1::pingresp{}";

--- a/include/async_mqtt/packet/v3_1_1_puback.hpp
+++ b/include/async_mqtt/packet/v3_1_1_puback.hpp
@@ -12,6 +12,7 @@
 
 #include <boost/numeric/conversion/cast.hpp>
 
+#include <async_mqtt/buffer_to_packet_variant_fwd.hpp>
 #include <async_mqtt/exception.hpp>
 #include <async_mqtt/buffer.hpp>
 
@@ -55,6 +56,62 @@ public:
         endian_store(packet_id, &all_[2]);
     }
 
+    /**
+     * @brief Get MQTT control packet type
+     * @return control packet type
+     */
+    constexpr control_packet_type type() const {
+        return control_packet_type::puback;
+    }
+
+    /**
+     * @brief Create const buffer sequence
+     *        it is for boost asio APIs
+     * @return const buffer sequence
+     */
+    std::vector<as::const_buffer> const_buffer_sequence() const {
+        std::vector<as::const_buffer> ret;
+
+        ret.emplace_back(as::buffer(all_.data(), all_.size()));
+        return ret;
+    }
+
+    /**
+     * @brief Get packet size.
+     * @return packet size
+     */
+    std::size_t size() const {
+        return all_.size();
+    }
+
+    /**
+     * @brief Get number of element of const_buffer_sequence
+     * @return number of element of const_buffer_sequence
+     */
+    static constexpr std::size_t num_of_const_buffer_sequence() {
+        return 1; // all
+    }
+
+    /**
+     * @brief Get packet_id.
+     * @return packet_id
+     */
+    packet_id_t packet_id() const {
+        return endian_load<packet_id_t>(&all_[2]);
+    }
+
+private:
+
+    template <std::size_t PacketIdBytesArg>
+    friend basic_packet_variant<PacketIdBytesArg>
+    async_mqtt::buffer_to_basic_packet_variant(buffer buf, protocol_version ver);
+
+#if defined(ASYNC_MQTT_UNIT_TEST_FOR_PACKET)
+    friend struct ::ut_packet::v311_puback;
+    friend struct ::ut_packet::v311_puback_pid4;
+#endif // defined(ASYNC_MQTT_UNIT_TEST_FOR_PACKET)
+
+    // private constructor for internal use
     basic_puback_packet(buffer buf) {
         // fixed_header
         if (buf.empty()) {
@@ -99,50 +156,13 @@ public:
         std::copy(buf.begin(), buf.end(), std::back_inserter(all_));
     }
 
-    constexpr control_packet_type type() const {
-        return control_packet_type::puback;
-    }
-
-    /**
-     * @brief Create const buffer sequence
-     *        it is for boost asio APIs
-     * @return const buffer sequence
-     */
-    std::vector<as::const_buffer> const_buffer_sequence() const {
-        std::vector<as::const_buffer> ret;
-
-        ret.emplace_back(as::buffer(all_.data(), all_.size()));
-        return ret;
-    }
-
-    /**
-     * @brief Get packet size.
-     * @return packet size
-     */
-    std::size_t size() const {
-        return all_.size();
-    }
-
-    /**
-     * @brief Get number of element of const_buffer_sequence
-     * @return number of element of const_buffer_sequence
-     */
-    static constexpr std::size_t num_of_const_buffer_sequence() {
-        return 1; // all
-    }
-
-    /**
-     * @brief Get packet_id.
-     * @return packet_id
-     */
-    packet_id_t packet_id() const {
-        return endian_load<packet_id_t>(&all_[2]);
-    }
-
 private:
     static_vector<char, 2 + PacketIdBytes> all_;
 };
 
+/**
+ * @brief stream output operator
+ */
 template <std::size_t PacketIdBytes>
 inline std::ostream& operator<<(std::ostream& o, basic_puback_packet<PacketIdBytes> const& v) {
     o <<

--- a/include/async_mqtt/packet/v3_1_1_pubcomp.hpp
+++ b/include/async_mqtt/packet/v3_1_1_pubcomp.hpp
@@ -12,6 +12,7 @@
 
 #include <boost/numeric/conversion/cast.hpp>
 
+#include <async_mqtt/buffer_to_packet_variant_fwd.hpp>
 #include <async_mqtt/exception.hpp>
 #include <async_mqtt/buffer.hpp>
 
@@ -55,6 +56,62 @@ public:
         endian_store(packet_id, &all_[2]);
     }
 
+    /**
+     * @brief Get MQTT control packet type
+     * @return control packet type
+     */
+    constexpr control_packet_type type() const {
+        return control_packet_type::pubcomp;
+    }
+
+    /**
+     * @brief Create const buffer sequence
+     *        it is for boost asio APIs
+     * @return const buffer sequence
+     */
+    std::vector<as::const_buffer> const_buffer_sequence() const {
+        std::vector<as::const_buffer> ret;
+
+        ret.emplace_back(as::buffer(all_.data(), all_.size()));
+        return ret;
+    }
+
+    /**
+     * @brief Get packet size.
+     * @return packet size
+     */
+    std::size_t size() const {
+        return all_.size();
+    }
+
+    /**
+     * @brief Get number of element of const_buffer_sequence
+     * @return number of element of const_buffer_sequence
+     */
+    static constexpr std::size_t num_of_const_buffer_sequence() {
+        return 1; // all
+    }
+
+    /**
+     * @brief Get packet_id.
+     * @return packet_id
+     */
+    packet_id_t packet_id() const {
+        return endian_load<packet_id_t>(&all_[2]);
+    }
+
+private:
+
+    template <std::size_t PacketIdBytesArg>
+    friend basic_packet_variant<PacketIdBytesArg>
+    async_mqtt::buffer_to_basic_packet_variant(buffer buf, protocol_version ver);
+
+#if defined(ASYNC_MQTT_UNIT_TEST_FOR_PACKET)
+    friend struct ::ut_packet::v311_pubcomp;
+    friend struct ::ut_packet::v311_pubcomp_pid4;
+#endif // defined(ASYNC_MQTT_UNIT_TEST_FOR_PACKET)
+
+    // private constructor for internal use
     basic_pubcomp_packet(buffer buf) {
         // fixed_header
         if (buf.empty()) {
@@ -99,50 +156,13 @@ public:
         std::copy(buf.begin(), buf.end(), std::back_inserter(all_));
     }
 
-    constexpr control_packet_type type() const {
-        return control_packet_type::pubcomp;
-    }
-
-    /**
-     * @brief Create const buffer sequence
-     *        it is for boost asio APIs
-     * @return const buffer sequence
-     */
-    std::vector<as::const_buffer> const_buffer_sequence() const {
-        std::vector<as::const_buffer> ret;
-
-        ret.emplace_back(as::buffer(all_.data(), all_.size()));
-        return ret;
-    }
-
-    /**
-     * @brief Get packet size.
-     * @return packet size
-     */
-    std::size_t size() const {
-        return all_.size();
-    }
-
-    /**
-     * @brief Get number of element of const_buffer_sequence
-     * @return number of element of const_buffer_sequence
-     */
-    static constexpr std::size_t num_of_const_buffer_sequence() {
-        return 1; // all
-    }
-
-    /**
-     * @brief Get packet_id.
-     * @return packet_id
-     */
-    packet_id_t packet_id() const {
-        return endian_load<packet_id_t>(&all_[2]);
-    }
-
 private:
     boost::container::static_vector<char, 2 + PacketIdBytes> all_;
 };
 
+/**
+ * @brief stream output operator
+ */
 template <std::size_t PacketIdBytes>
 inline std::ostream& operator<<(std::ostream& o, basic_pubcomp_packet<PacketIdBytes> const& v) {
     o <<

--- a/include/async_mqtt/packet/v3_1_1_pubrec.hpp
+++ b/include/async_mqtt/packet/v3_1_1_pubrec.hpp
@@ -12,6 +12,7 @@
 
 #include <boost/numeric/conversion/cast.hpp>
 
+#include <async_mqtt/buffer_to_packet_variant_fwd.hpp>
 #include <async_mqtt/exception.hpp>
 #include <async_mqtt/buffer.hpp>
 
@@ -54,6 +55,62 @@ public:
         endian_store(packet_id, &all_[2]);
     }
 
+    /**
+     * @brief Get MQTT control packet type
+     * @return control packet type
+     */
+    constexpr control_packet_type type() const {
+        return control_packet_type::pubrec;
+    }
+
+    /**
+     * @brief Create const buffer sequence
+     *        it is for boost asio APIs
+     * @return const buffer sequence
+     */
+    std::vector<as::const_buffer> const_buffer_sequence() const {
+        std::vector<as::const_buffer> ret;
+
+        ret.emplace_back(as::buffer(all_.data(), all_.size()));
+        return ret;
+    }
+
+    /**
+     * @brief Get packet size.
+     * @return packet size
+     */
+    std::size_t size() const {
+        return all_.size();
+    }
+
+    /**
+     * @brief Get number of element of const_buffer_sequence
+     * @return number of element of const_buffer_sequence
+     */
+    static constexpr std::size_t num_of_const_buffer_sequence() {
+        return 1; // all
+    }
+
+    /**
+     * @brief Get packet_id.
+     * @return packet_id
+     */
+    packet_id_t packet_id() const {
+        return endian_load<packet_id_t>(&all_[2]);
+    }
+
+private:
+
+    template <std::size_t PacketIdBytesArg>
+    friend basic_packet_variant<PacketIdBytesArg>
+    async_mqtt::buffer_to_basic_packet_variant(buffer buf, protocol_version ver);
+
+#if defined(ASYNC_MQTT_UNIT_TEST_FOR_PACKET)
+    friend struct ::ut_packet::v311_pubrec;
+    friend struct ::ut_packet::v311_pubrec_pid4;
+#endif // defined(ASYNC_MQTT_UNIT_TEST_FOR_PACKET)
+
+    // private constructor for internal use
     basic_pubrec_packet(buffer buf) {
         // fixed_header
         if (buf.empty()) {
@@ -98,50 +155,13 @@ public:
         std::copy(buf.begin(), buf.end(), std::back_inserter(all_));
     }
 
-    constexpr control_packet_type type() const {
-        return control_packet_type::pubrec;
-    }
-
-    /**
-     * @brief Create const buffer sequence
-     *        it is for boost asio APIs
-     * @return const buffer sequence
-     */
-    std::vector<as::const_buffer> const_buffer_sequence() const {
-        std::vector<as::const_buffer> ret;
-
-        ret.emplace_back(as::buffer(all_.data(), all_.size()));
-        return ret;
-    }
-
-    /**
-     * @brief Get packet size.
-     * @return packet size
-     */
-    std::size_t size() const {
-        return all_.size();
-    }
-
-    /**
-     * @brief Get number of element of const_buffer_sequence
-     * @return number of element of const_buffer_sequence
-     */
-    static constexpr std::size_t num_of_const_buffer_sequence() {
-        return 1; // all
-    }
-
-    /**
-     * @brief Get packet_id.
-     * @return packet_id
-     */
-    packet_id_t packet_id() const {
-        return endian_load<packet_id_t>(&all_[2]);
-    }
-
 private:
     static_vector<char, 2 + PacketIdBytes> all_;
 };
 
+/**
+ * @brief stream output operator
+ */
 template <std::size_t PacketIdBytes>
 inline std::ostream& operator<<(std::ostream& o, basic_pubrec_packet<PacketIdBytes> const& v) {
     o <<

--- a/include/async_mqtt/packet/v3_1_1_pubrel.hpp
+++ b/include/async_mqtt/packet/v3_1_1_pubrel.hpp
@@ -12,6 +12,7 @@
 
 #include <boost/numeric/conversion/cast.hpp>
 
+#include <async_mqtt/buffer_to_packet_variant_fwd.hpp>
 #include <async_mqtt/exception.hpp>
 #include <async_mqtt/buffer.hpp>
 
@@ -56,6 +57,62 @@ public:
         endian_store(packet_id, &all_[2]);
     }
 
+    /**
+     * @brief Get MQTT control packet type
+     * @return control packet type
+     */
+    constexpr control_packet_type type() const {
+        return control_packet_type::pubrel;
+    }
+
+    /**
+     * @brief Create const buffer sequence
+     *        it is for boost asio APIs
+     * @return const buffer sequence
+     */
+    std::vector<as::const_buffer> const_buffer_sequence() const {
+        std::vector<as::const_buffer> ret;
+
+        ret.emplace_back(as::buffer(all_.data(), all_.size()));
+        return ret;
+    }
+
+    /**
+     * @brief Get packet size.
+     * @return packet size
+     */
+    std::size_t size() const {
+        return all_.size();
+    }
+
+    /**
+     * @brief Get number of element of const_buffer_sequence
+     * @return number of element of const_buffer_sequence
+     */
+    static constexpr std::size_t num_of_const_buffer_sequence() {
+        return 1; // all
+    }
+
+    /**
+     * @brief Get packet_id.
+     * @return packet_id
+     */
+    packet_id_t packet_id() const {
+        return endian_load<packet_id_t>(&all_[2]);
+    }
+
+private:
+
+    template <std::size_t PacketIdBytesArg>
+    friend basic_packet_variant<PacketIdBytesArg>
+    async_mqtt::buffer_to_basic_packet_variant(buffer buf, protocol_version ver);
+
+#if defined(ASYNC_MQTT_UNIT_TEST_FOR_PACKET)
+    friend struct ::ut_packet::v311_pubrel;
+    friend struct ::ut_packet::v311_pubrel_pid4;
+#endif // defined(ASYNC_MQTT_UNIT_TEST_FOR_PACKET)
+
+    // private constructor for internal use
     basic_pubrel_packet(buffer buf) {
         // fixed_header
         if (buf.empty()) {
@@ -100,50 +157,13 @@ public:
         std::copy(buf.begin(), buf.end(), std::back_inserter(all_));
     }
 
-    constexpr control_packet_type type() const {
-        return control_packet_type::pubrel;
-    }
-
-    /**
-     * @brief Create const buffer sequence
-     *        it is for boost asio APIs
-     * @return const buffer sequence
-     */
-    std::vector<as::const_buffer> const_buffer_sequence() const {
-        std::vector<as::const_buffer> ret;
-
-        ret.emplace_back(as::buffer(all_.data(), all_.size()));
-        return ret;
-    }
-
-    /**
-     * @brief Get packet size.
-     * @return packet size
-     */
-    std::size_t size() const {
-        return all_.size();
-    }
-
-    /**
-     * @brief Get number of element of const_buffer_sequence
-     * @return number of element of const_buffer_sequence
-     */
-    static constexpr std::size_t num_of_const_buffer_sequence() {
-        return 1; // all
-    }
-
-    /**
-     * @brief Get packet_id.
-     * @return packet_id
-     */
-    packet_id_t packet_id() const {
-        return endian_load<packet_id_t>(&all_[2]);
-    }
-
 private:
     static_vector<char, 2 + PacketIdBytes> all_;
 };
 
+/**
+ * @brief stream output operator
+ */
 template <std::size_t PacketIdBytes>
 inline std::ostream& operator<<(std::ostream& o, basic_pubrel_packet<PacketIdBytes> const& v) {
     o <<

--- a/include/async_mqtt/packet/v3_1_1_suback.hpp
+++ b/include/async_mqtt/packet/v3_1_1_suback.hpp
@@ -12,6 +12,7 @@
 
 #include <boost/numeric/conversion/cast.hpp>
 
+#include <async_mqtt/buffer_to_packet_variant_fwd.hpp>
 #include <async_mqtt/exception.hpp>
 #include <async_mqtt/buffer.hpp>
 
@@ -59,61 +60,10 @@ public:
         remaining_length_buf_ = val_to_variable_bytes(boost::numeric_cast<std::uint32_t>(remaining_length_));
     }
 
-    basic_suback_packet(buffer buf) {
-        // fixed_header
-        if (buf.empty()) {
-            throw make_error(
-                errc::bad_message,
-                "v3_1_1::suback_packet fixed_header doesn't exist"
-            );
-        }
-        fixed_header_ = static_cast<std::uint8_t>(buf.front());
-        buf.remove_prefix(1);
-        auto cpt_opt = get_control_packet_type_with_check(static_cast<std::uint8_t>(fixed_header_));
-        if (!cpt_opt || *cpt_opt != control_packet_type::suback) {
-            throw make_error(
-                errc::bad_message,
-                "v3_1_1::suback_packet fixed_header is invalid"
-            );
-        }
-
-        // remaining_length
-        if (auto vl_opt = insert_advance_variable_length(buf, remaining_length_buf_)) {
-            remaining_length_ = *vl_opt;
-        }
-        else {
-            throw make_error(errc::bad_message, "v3_1_1::suback_packet remaining length is invalid");
-        }
-        if (remaining_length_ != buf.size()) {
-            throw make_error(errc::bad_message, "v3_1_1::suback_packet remaining length doesn't match buf.size()");
-        }
-
-        // packet_id
-        if (!copy_advance(buf, packet_id_)) {
-            throw make_error(
-                errc::bad_message,
-                "v3_1_1::suback_packet packet_id doesn't exist"
-            );
-        }
-
-        if (remaining_length_ == 0) {
-            throw make_error(errc::bad_message, "v3_1_1::suback_packet doesn't have entries");
-        }
-
-        while (!buf.empty()) {
-            // suback_return_code
-            if (buf.empty()) {
-                throw make_error(
-                    errc::bad_message,
-                    "v3_1_1::suback_packet suback_return_code  doesn't exist"
-                );
-            }
-            auto rc = static_cast<suback_return_code>(buf.front());
-            entries_.emplace_back(rc);
-            buf.remove_prefix(1);
-        }
-    }
-
+    /**
+     * @brief Get MQTT control packet type
+     * @return control packet type
+     */
     constexpr control_packet_type type() const {
         return control_packet_type::suback;
     }
@@ -178,6 +128,73 @@ public:
     }
 
 private:
+
+    template <std::size_t PacketIdBytesArg>
+    friend basic_packet_variant<PacketIdBytesArg>
+    async_mqtt::buffer_to_basic_packet_variant(buffer buf, protocol_version ver);
+
+#if defined(ASYNC_MQTT_UNIT_TEST_FOR_PACKET)
+    friend struct ::ut_packet::v311_suback;
+    friend struct ::ut_packet::v311_suback_pid4;
+#endif // defined(ASYNC_MQTT_UNIT_TEST_FOR_PACKET)
+
+    // private constructor for internal use
+    basic_suback_packet(buffer buf) {
+        // fixed_header
+        if (buf.empty()) {
+            throw make_error(
+                errc::bad_message,
+                "v3_1_1::suback_packet fixed_header doesn't exist"
+            );
+        }
+        fixed_header_ = static_cast<std::uint8_t>(buf.front());
+        buf.remove_prefix(1);
+        auto cpt_opt = get_control_packet_type_with_check(static_cast<std::uint8_t>(fixed_header_));
+        if (!cpt_opt || *cpt_opt != control_packet_type::suback) {
+            throw make_error(
+                errc::bad_message,
+                "v3_1_1::suback_packet fixed_header is invalid"
+            );
+        }
+
+        // remaining_length
+        if (auto vl_opt = insert_advance_variable_length(buf, remaining_length_buf_)) {
+            remaining_length_ = *vl_opt;
+        }
+        else {
+            throw make_error(errc::bad_message, "v3_1_1::suback_packet remaining length is invalid");
+        }
+        if (remaining_length_ != buf.size()) {
+            throw make_error(errc::bad_message, "v3_1_1::suback_packet remaining length doesn't match buf.size()");
+        }
+
+        // packet_id
+        if (!copy_advance(buf, packet_id_)) {
+            throw make_error(
+                errc::bad_message,
+                "v3_1_1::suback_packet packet_id doesn't exist"
+            );
+        }
+
+        if (remaining_length_ == 0) {
+            throw make_error(errc::bad_message, "v3_1_1::suback_packet doesn't have entries");
+        }
+
+        while (!buf.empty()) {
+            // suback_return_code
+            if (buf.empty()) {
+                throw make_error(
+                    errc::bad_message,
+                    "v3_1_1::suback_packet suback_return_code  doesn't exist"
+                );
+            }
+            auto rc = static_cast<suback_return_code>(buf.front());
+            entries_.emplace_back(rc);
+            buf.remove_prefix(1);
+        }
+    }
+
+private:
     std::uint8_t fixed_header_;
     std::vector<suback_return_code> entries_;
     static_vector<char, PacketIdBytes> packet_id_ = static_vector<char, PacketIdBytes>(PacketIdBytes);
@@ -185,6 +202,9 @@ private:
     static_vector<char, 4> remaining_length_buf_;
 };
 
+/**
+ * @brief stream output operator
+ */
 template <std::size_t PacketIdBytes>
 inline std::ostream& operator<<(std::ostream& o, basic_suback_packet<PacketIdBytes> const& v) {
     o <<

--- a/include/async_mqtt/packet/v3_1_1_subscribe.hpp
+++ b/include/async_mqtt/packet/v3_1_1_subscribe.hpp
@@ -9,6 +9,7 @@
 
 #include <boost/numeric/conversion/cast.hpp>
 
+#include <async_mqtt/buffer_to_packet_variant_fwd.hpp>
 #include <async_mqtt/exception.hpp>
 #include <async_mqtt/buffer.hpp>
 
@@ -108,6 +109,92 @@ public:
         remaining_length_buf_ = val_to_variable_bytes(boost::numeric_cast<std::uint32_t>(remaining_length_));
     }
 
+    /**
+     * @brief Get MQTT control packet type
+     * @return control packet type
+     */
+    constexpr control_packet_type type() const {
+        return control_packet_type::subscribe;
+    }
+
+    /**
+     * @brief Create const buffer sequence
+     *        it is for boost asio APIs
+     * @return const buffer sequence
+     */
+    std::vector<as::const_buffer> const_buffer_sequence() const {
+        std::vector<as::const_buffer> ret;
+        ret.reserve(num_of_const_buffer_sequence());
+
+        ret.emplace_back(as::buffer(&fixed_header_, 1));
+
+        ret.emplace_back(as::buffer(remaining_length_buf_.data(), remaining_length_buf_.size()));
+
+        ret.emplace_back(as::buffer(packet_id_.data(), packet_id_.size()));
+
+        BOOST_ASSERT(entries_.size() == topic_length_buf_entries_.size());
+        auto it = topic_length_buf_entries_.begin();
+        for (auto const& e : entries_) {
+            ret.emplace_back(as::buffer(it->data(), it->size()));
+            ret.emplace_back(as::buffer(e.all_topic()));
+            ret.emplace_back(as::buffer(&e.opts(), 1));
+            ++it;
+        }
+
+        return ret;
+    }
+
+    /**
+     * @brief Get packet size.
+     * @return packet size
+     */
+    std::size_t size() const {
+        return
+            1 +                            // fixed header
+            remaining_length_buf_.size() +
+            remaining_length_;
+    }
+
+    /**
+     * @brief Get number of element of const_buffer_sequence
+     * @return number of element of const_buffer_sequence
+     */
+    std::size_t num_of_const_buffer_sequence() const {
+        return
+            1 +                   // fixed header
+            1 +                   // remaining length
+            1 +                   // packet id
+            entries_.size() * 3;  // topic name length, topic name, qos
+    }
+
+    /**
+     * @brief Get packet_id.
+     * @return packet_id
+     */
+    packet_id_t packet_id() const {
+        return endian_load<packet_id_t>(packet_id_.data());
+    }
+
+    /**
+     * @brief Get entries
+     * @return entries
+     */
+    std::vector<topic_subopts> const& entries() const {
+        return entries_;
+    }
+
+private:
+
+    template <std::size_t PacketIdBytesArg>
+    friend basic_packet_variant<PacketIdBytesArg>
+    async_mqtt::buffer_to_basic_packet_variant(buffer buf, protocol_version ver);
+
+#if defined(ASYNC_MQTT_UNIT_TEST_FOR_PACKET)
+    friend struct ::ut_packet::v311_subscribe;
+    friend struct ::ut_packet::v311_subscribe_pid4;
+#endif // defined(ASYNC_MQTT_UNIT_TEST_FOR_PACKET)
+
+    // private constructor for internal use
     basic_subscribe_packet(buffer buf) {
         // fixed_header
         if (buf.empty()) {
@@ -205,79 +292,9 @@ public:
                 );
                 break;
             }
-            entries_.emplace_back(force_move(topic), opts);
+            entries_.emplace_back(std::string{topic}, opts);
             buf.remove_prefix(1);
         }
-    }
-
-    constexpr control_packet_type type() const {
-        return control_packet_type::subscribe;
-    }
-
-    /**
-     * @brief Create const buffer sequence
-     *        it is for boost asio APIs
-     * @return const buffer sequence
-     */
-    std::vector<as::const_buffer> const_buffer_sequence() const {
-        std::vector<as::const_buffer> ret;
-        ret.reserve(num_of_const_buffer_sequence());
-
-        ret.emplace_back(as::buffer(&fixed_header_, 1));
-
-        ret.emplace_back(as::buffer(remaining_length_buf_.data(), remaining_length_buf_.size()));
-
-        ret.emplace_back(as::buffer(packet_id_.data(), packet_id_.size()));
-
-        BOOST_ASSERT(entries_.size() == topic_length_buf_entries_.size());
-        auto it = topic_length_buf_entries_.begin();
-        for (auto const& e : entries_) {
-            ret.emplace_back(as::buffer(it->data(), it->size()));
-            ret.emplace_back(as::buffer(e.all_topic()));
-            ret.emplace_back(as::buffer(&e.opts(), 1));
-            ++it;
-        }
-
-        return ret;
-    }
-
-    /**
-     * @brief Get packet size.
-     * @return packet size
-     */
-    std::size_t size() const {
-        return
-            1 +                            // fixed header
-            remaining_length_buf_.size() +
-            remaining_length_;
-    }
-
-    /**
-     * @brief Get number of element of const_buffer_sequence
-     * @return number of element of const_buffer_sequence
-     */
-    std::size_t num_of_const_buffer_sequence() const {
-        return
-            1 +                   // fixed header
-            1 +                   // remaining length
-            1 +                   // packet id
-            entries_.size() * 3;  // topic name length, topic name, qos
-    }
-
-    /**
-     * @brief Get packet_id.
-     * @return packet_id
-     */
-    packet_id_t packet_id() const {
-        return endian_load<packet_id_t>(packet_id_.data());
-    }
-
-    /**
-     * @brief Get entries
-     * @return entries
-     */
-    std::vector<topic_subopts> const& entries() const {
-        return entries_;
     }
 
 private:
@@ -289,6 +306,9 @@ private:
     static_vector<char, 4> remaining_length_buf_;
 };
 
+/**
+ * @brief stream output operator
+ */
 template <std::size_t PacketIdBytes>
 inline std::ostream& operator<<(std::ostream& o, basic_subscribe_packet<PacketIdBytes> const& v) {
     o <<

--- a/include/async_mqtt/packet/v3_1_1_unsuback.hpp
+++ b/include/async_mqtt/packet/v3_1_1_unsuback.hpp
@@ -12,6 +12,7 @@
 
 #include <boost/numeric/conversion/cast.hpp>
 
+#include <async_mqtt/buffer_to_packet_variant_fwd.hpp>
 #include <async_mqtt/exception.hpp>
 #include <async_mqtt/buffer.hpp>
 
@@ -52,6 +53,62 @@ public:
         endian_store(packet_id, &all_[2]);
     }
 
+    /**
+     * @brief Get MQTT control packet type
+     * @return control packet type
+     */
+    constexpr control_packet_type type() const {
+        return control_packet_type::unsuback;
+    }
+
+    /**
+     * @brief Create const buffer sequence
+     *        it is for boost asio APIs
+     * @return const buffer sequence
+     */
+    std::vector<as::const_buffer> const_buffer_sequence() const {
+        std::vector<as::const_buffer> ret;
+
+        ret.emplace_back(as::buffer(all_.data(), all_.size()));
+        return ret;
+    }
+
+    /**
+     * @brief Get packet size.
+     * @return packet size
+     */
+    std::size_t size() const {
+        return all_.size();
+    }
+
+    /**
+     * @brief Get number of element of const_buffer_sequence
+     * @return number of element of const_buffer_sequence
+     */
+    static constexpr std::size_t num_of_const_buffer_sequence() {
+        return 1; // all
+    }
+
+    /**
+     * @brief Get packet_id.
+     * @return packet_id
+     */
+    packet_id_t packet_id() const {
+        return endian_load<packet_id_t>(&all_[2]);
+    }
+
+private:
+
+    template <std::size_t PacketIdBytesArg>
+    friend basic_packet_variant<PacketIdBytesArg>
+    async_mqtt::buffer_to_basic_packet_variant(buffer buf, protocol_version ver);
+
+#if defined(ASYNC_MQTT_UNIT_TEST_FOR_PACKET)
+    friend struct ::ut_packet::v311_unsuback;
+    friend struct ::ut_packet::v311_unsuback_pid4;
+#endif // defined(ASYNC_MQTT_UNIT_TEST_FOR_PACKET)
+
+    // private constructor for internal use
     basic_unsuback_packet(buffer buf) {
         // fixed_header
         if (buf.empty()) {
@@ -96,50 +153,13 @@ public:
         std::copy(buf.begin(), buf.end(), std::back_inserter(all_));
     }
 
-    constexpr control_packet_type type() const {
-        return control_packet_type::unsuback;
-    }
-
-    /**
-     * @brief Create const buffer sequence
-     *        it is for boost asio APIs
-     * @return const buffer sequence
-     */
-    std::vector<as::const_buffer> const_buffer_sequence() const {
-        std::vector<as::const_buffer> ret;
-
-        ret.emplace_back(as::buffer(all_.data(), all_.size()));
-        return ret;
-    }
-
-    /**
-     * @brief Get packet size.
-     * @return packet size
-     */
-    std::size_t size() const {
-        return all_.size();
-    }
-
-    /**
-     * @brief Get number of element of const_buffer_sequence
-     * @return number of element of const_buffer_sequence
-     */
-    static constexpr std::size_t num_of_const_buffer_sequence() {
-        return 1; // all
-    }
-
-    /**
-     * @brief Get packet_id.
-     * @return packet_id
-     */
-    packet_id_t packet_id() const {
-        return endian_load<packet_id_t>(&all_[2]);
-    }
-
 private:
     static_vector<char, 2 + PacketIdBytes> all_;
 };
 
+/**
+ * @brief stream output operator
+ */
 template <std::size_t PacketIdBytes>
 inline std::ostream& operator<<(std::ostream& o, basic_unsuback_packet<PacketIdBytes> const& v) {
     o <<

--- a/include/async_mqtt/packet/v5_auth.hpp
+++ b/include/async_mqtt/packet/v5_auth.hpp
@@ -12,6 +12,7 @@
 
 #include <boost/numeric/conversion/cast.hpp>
 
+#include <async_mqtt/buffer_to_packet_variant_fwd.hpp>
 #include <async_mqtt/exception.hpp>
 #include <async_mqtt/buffer.hpp>
 
@@ -78,86 +79,10 @@ public:
         }
     {}
 
-    auth_packet(buffer buf) {
-        // fixed_header
-        if (buf.empty()) {
-            throw make_error(
-                errc::bad_message,
-                "v5::auth_packet fixed_header doesn't exist"
-            );
-        }
-        fixed_header_ = static_cast<std::uint8_t>(buf.front());
-        buf.remove_prefix(1);
-
-        // remaining_length
-        if (auto vl_opt = insert_advance_variable_length(buf, remaining_length_buf_)) {
-            remaining_length_ = *vl_opt;
-        }
-        else {
-            throw make_error(errc::bad_message, "v5::auth_packet remaining length is invalid");
-        }
-
-        if (remaining_length_ == 0) {
-            if (!buf.empty()) {
-                throw make_error(errc::bad_message, "v5::auth_packet remaining length is invalid");
-            }
-            return;
-        }
-
-        // connect_reason_code
-        reason_code_.emplace(static_cast<auth_reason_code>(buf.front()));
-        buf.remove_prefix(1);
-        switch (*reason_code_) {
-        case auth_reason_code::success:
-        case auth_reason_code::continue_authentication:
-        case auth_reason_code::re_authenticate:
-            break;
-        default:
-            throw make_error(
-                errc::bad_message,
-                "v5::auth_packet connect reason_code is invalid"
-            );
-            break;
-        }
-
-        if (remaining_length_ == 1) {
-            if (!buf.empty()) {
-                throw make_error(errc::bad_message, "v5::auth_packet remaining length is invalid");
-            }
-            return;
-        }
-
-        // property
-        auto it = buf.begin();
-        if (auto pl_opt = variable_bytes_to_val(it, buf.end())) {
-            property_length_ = *pl_opt;
-            std::copy(buf.begin(), it, std::back_inserter(property_length_buf_));
-            buf.remove_prefix(std::size_t(std::distance(buf.begin(), it)));
-            if (buf.size() < property_length_) {
-                throw make_error(
-                    errc::bad_message,
-                    "v5::auth_packet properties_don't match its length"
-                );
-            }
-            auto prop_buf = buf.substr(0, property_length_);
-            props_ = make_properties(prop_buf, property_location::auth);
-            buf.remove_prefix(property_length_);
-        }
-        else {
-            throw make_error(
-                errc::bad_message,
-                "v5::auth_packet property_length is invalid"
-            );
-        }
-
-        if (!buf.empty()) {
-            throw make_error(
-                errc::bad_message,
-                "v5::auth_packet properties don't match its length"
-            );
-        }
-    }
-
+    /**
+     * @brief Get MQTT control packet type
+     * @return control packet type
+     */
     constexpr control_packet_type type() const {
         return control_packet_type::auth;
     }
@@ -237,6 +162,9 @@ public:
         return props_;
     }
 
+    /**
+     * @brief stream output operator
+     */
     friend
     inline std::ostream& operator<<(std::ostream& o, auth_packet const& v) {
         o <<
@@ -298,6 +226,100 @@ private:
         }
 
         remaining_length_ += property_length_buf_.size() + property_length_;
+    }
+
+private:
+
+    template <std::size_t PacketIdBytesArg>
+    friend basic_packet_variant<PacketIdBytesArg>
+    async_mqtt::buffer_to_basic_packet_variant(buffer buf, protocol_version ver);
+
+#if defined(ASYNC_MQTT_UNIT_TEST_FOR_PACKET)
+    friend struct ::ut_packet::v5_auth;
+    friend struct ::ut_packet::v5_auth_no_arg;
+    friend struct ::ut_packet::v5_auth_pid_rc;
+    friend struct ::ut_packet::v5_auth_prop_len_last;
+#endif // defined(ASYNC_MQTT_UNIT_TEST_FOR_PACKET)
+
+    // private constructor for internal use
+    auth_packet(buffer buf) {
+        // fixed_header
+        if (buf.empty()) {
+            throw make_error(
+                errc::bad_message,
+                "v5::auth_packet fixed_header doesn't exist"
+            );
+        }
+        fixed_header_ = static_cast<std::uint8_t>(buf.front());
+        buf.remove_prefix(1);
+
+        // remaining_length
+        if (auto vl_opt = insert_advance_variable_length(buf, remaining_length_buf_)) {
+            remaining_length_ = *vl_opt;
+        }
+        else {
+            throw make_error(errc::bad_message, "v5::auth_packet remaining length is invalid");
+        }
+
+        if (remaining_length_ == 0) {
+            if (!buf.empty()) {
+                throw make_error(errc::bad_message, "v5::auth_packet remaining length is invalid");
+            }
+            return;
+        }
+
+        // connect_reason_code
+        reason_code_.emplace(static_cast<auth_reason_code>(buf.front()));
+        buf.remove_prefix(1);
+        switch (*reason_code_) {
+        case auth_reason_code::success:
+        case auth_reason_code::continue_authentication:
+        case auth_reason_code::re_authenticate:
+            break;
+        default:
+            throw make_error(
+                errc::bad_message,
+                "v5::auth_packet connect reason_code is invalid"
+            );
+            break;
+        }
+
+        if (remaining_length_ == 1) {
+            if (!buf.empty()) {
+                throw make_error(errc::bad_message, "v5::auth_packet remaining length is invalid");
+            }
+            return;
+        }
+
+        // property
+        auto it = buf.begin();
+        if (auto pl_opt = variable_bytes_to_val(it, buf.end())) {
+            property_length_ = *pl_opt;
+            std::copy(buf.begin(), it, std::back_inserter(property_length_buf_));
+            buf.remove_prefix(std::size_t(std::distance(buf.begin(), it)));
+            if (buf.size() < property_length_) {
+                throw make_error(
+                    errc::bad_message,
+                    "v5::auth_packet properties_don't match its length"
+                );
+            }
+            auto prop_buf = buf.substr(0, property_length_);
+            props_ = make_properties(prop_buf, property_location::auth);
+            buf.remove_prefix(property_length_);
+        }
+        else {
+            throw make_error(
+                errc::bad_message,
+                "v5::auth_packet property_length is invalid"
+            );
+        }
+
+        if (!buf.empty()) {
+            throw make_error(
+                errc::bad_message,
+                "v5::auth_packet properties don't match its length"
+            );
+        }
     }
 
 private:

--- a/include/async_mqtt/packet/v5_connect.hpp
+++ b/include/async_mqtt/packet/v5_connect.hpp
@@ -12,6 +12,7 @@
 
 #include <boost/numeric/conversion/cast.hpp>
 
+#include <async_mqtt/buffer_to_packet_variant_fwd.hpp>
 #include <async_mqtt/exception.hpp>
 #include <async_mqtt/buffer.hpp>
 #include <async_mqtt/variable_bytes.hpp>
@@ -68,9 +69,9 @@ public:
     connect_packet(
         bool clean_start,
         std::uint16_t keep_alive_sec,
-        buffer client_id,
-        std::optional<buffer> user_name = std::nullopt,
-        std::optional<buffer> password = std::nullopt,
+        std::string client_id,
+        std::optional<std::string> user_name = std::nullopt,
+        std::optional<std::string> password = std::nullopt,
         properties props = {}
     ):connect_packet(
         clean_start,
@@ -114,10 +115,10 @@ public:
     connect_packet(
         bool clean_start,
         std::uint16_t keep_alive_sec,
-        buffer client_id,
+        std::string client_id,
         std::optional<will> w,
-        std::optional<buffer> user_name = std::nullopt,
-        std::optional<buffer> password = std::nullopt,
+        std::optional<std::string> user_name = std::nullopt,
+        std::optional<std::string> password = std::nullopt,
         properties props = {}
     )
         : fixed_header_{
@@ -161,13 +162,13 @@ public:
                 );
             }
             connect_flags_ |= connect_flags::mask_user_name_flag;
-            user_name_ = force_move(*user_name);
+            user_name_ = buffer{force_move(*user_name)};
             user_name_length_buf_ = endian_static_vector(boost::numeric_cast<std::uint16_t>(user_name_.size()));
             remaining_length_ += 2 + user_name_.size();
         }
         if (password) {
             connect_flags_ |= connect_flags::mask_password_flag;
-            password_ = force_move(*password);
+            password_ = buffer{force_move(*password)};
             password_length_buf_ = endian_static_vector(boost::numeric_cast<std::uint16_t>(password_.size()));
             remaining_length_ += 2 + password_.size();
         }
@@ -199,7 +200,7 @@ public:
                     "v5::connect_packet will topic invalid utf8"
                 );
             }
-            will_topic_ = force_move(w->topic());
+            will_topic_ = force_move(w->topic_as_buffer());
             will_topic_length_buf_ = endian_static_vector(boost::numeric_cast<std::uint16_t>(will_topic_.size()));
             if (w->message().size() > 0xffffL) {
                 throw make_error(
@@ -207,7 +208,7 @@ public:
                     "v5::connect_packet will message too long"
                 );
             }
-            will_message_ = force_move(w->message());
+            will_message_ = force_move(w->message_as_buffer());
             will_message_length_buf_ = endian_static_vector(boost::numeric_cast<std::uint16_t>(will_message_.size()));
             will_props_ = force_move(w->props());
             will_property_length_ = boost::numeric_cast<std::uint32_t>(async_mqtt::size(will_props_));
@@ -238,6 +239,201 @@ public:
         }
     }
 
+    /**
+     * @brief Get MQTT control packet type
+     * @return control packet type
+     */
+    constexpr control_packet_type type() const {
+        return control_packet_type::connect;
+    }
+
+    /**
+     * @brief Create const buffer sequence
+     *        it is for boost asio APIs
+     * @return const buffer sequence
+     */
+    std::vector<as::const_buffer> const_buffer_sequence() const {
+        std::vector<as::const_buffer> ret;
+        ret.reserve(num_of_const_buffer_sequence());
+
+        ret.emplace_back(as::buffer(&fixed_header_, 1));
+        ret.emplace_back(as::buffer(remaining_length_buf_.data(), remaining_length_buf_.size()));
+        ret.emplace_back(as::buffer(protocol_name_and_level_.data(), protocol_name_and_level_.size()));
+        ret.emplace_back(as::buffer(&connect_flags_, 1));
+        ret.emplace_back(as::buffer(keep_alive_buf_.data(), keep_alive_buf_.size()));
+
+        ret.emplace_back(as::buffer(property_length_buf_.data(), property_length_buf_.size()));
+        auto props_cbs = async_mqtt::const_buffer_sequence(props_);
+        std::move(props_cbs.begin(), props_cbs.end(), std::back_inserter(ret));
+
+        ret.emplace_back(as::buffer(client_id_length_buf_.data(), client_id_length_buf_.size()));
+        ret.emplace_back(as::buffer(client_id_));
+
+        if (connect_flags::has_will_flag(connect_flags_)) {
+            ret.emplace_back(as::buffer(will_property_length_buf_.data(), will_property_length_buf_.size()));
+            auto will_props_cbs = async_mqtt::const_buffer_sequence(will_props_);
+            std::move(will_props_cbs.begin(), will_props_cbs.end(), std::back_inserter(ret));
+            ret.emplace_back(as::buffer(will_topic_length_buf_.data(), will_topic_length_buf_.size()));
+            ret.emplace_back(as::buffer(will_topic_));
+            ret.emplace_back(as::buffer(will_message_length_buf_.data(), will_message_length_buf_.size()));
+            ret.emplace_back(as::buffer(will_message_));
+        }
+
+        if (connect_flags::has_user_name_flag(connect_flags_)) {
+            ret.emplace_back(as::buffer(user_name_length_buf_.data(), user_name_length_buf_.size()));
+            ret.emplace_back(as::buffer(user_name_));
+        }
+
+        if (connect_flags::has_password_flag(connect_flags_)) {
+            ret.emplace_back(as::buffer(password_length_buf_.data(), password_length_buf_.size()));
+            ret.emplace_back(as::buffer(password_));
+        }
+
+        return ret;
+    }
+
+    /**
+     * @brief Get packet size.
+     * @return packet size
+     */
+    std::size_t size() const {
+        return
+            1 +                            // fixed header
+            remaining_length_buf_.size() +
+            remaining_length_;
+    }
+
+    /**
+     * @brief Get number of element of const_buffer_sequence
+     * @return number of element of const_buffer_sequence
+     */
+    std::size_t num_of_const_buffer_sequence() const {
+        return
+            1 +                   // fixed header
+            1 +                   // remaining length
+            1 +                   // protocol name and level
+            1 +                   // connect flags
+            1 +                   // keep alive
+            1 +                   // property length
+            async_mqtt::num_of_const_buffer_sequence(props_) +
+
+            2 +                   // client id length, client id
+
+            [&] () -> std::size_t {
+                if (connect_flags::has_will_flag(connect_flags_)) {
+                    return
+                        1 +       // will_property length
+                        async_mqtt::num_of_const_buffer_sequence(will_props_) +
+                        2 +       // will topic name length, will topic name
+                        2;        // will message length, will message
+                }
+                return 0;
+            } () +
+            [&] () -> std::size_t {
+                if (connect_flags::has_user_name_flag(connect_flags_)) {
+                    return 2;     // user name length, user name
+                }
+                return 0;
+            } () +
+            [&] () -> std::size_t {
+                if (connect_flags::has_password_flag(connect_flags_)) {
+                    return 2;     // password length, password
+                }
+                return 0;
+            } ();
+    }
+
+    /**
+     * @brief Get clean_start.
+     * @return clean_start
+     */
+    bool clean_start() const {
+        return connect_flags::has_clean_start(connect_flags_);
+    }
+
+    /**
+     * @brief Get keep_alive.
+     * @return keep_alive
+     */
+    std::uint16_t keep_alive() const {
+        return endian_load<std::uint16_t>(keep_alive_buf_.data());
+    }
+
+    /**
+     * @brief Get client_id
+     * @return client_id
+     */
+    std::string client_id() const {
+        return std::string{client_id_};
+    }
+
+    /**
+     * @brief Get user_name.
+     * @return user_name
+     */
+    std::optional<std::string> user_name() const {
+        if (connect_flags::has_user_name_flag(connect_flags_)) {
+            return std::string{user_name_};
+        }
+        else {
+            return std::nullopt;
+        }
+    }
+
+    /**
+     * @brief Get password.
+     * @return password
+     */
+    std::optional<std::string> password() const {
+        if (connect_flags::has_password_flag(connect_flags_)) {
+            return std::string{password_};
+        }
+        else {
+            return std::nullopt;
+        }
+    }
+
+    /**
+     * @brief Get will.
+     * @return will
+     */
+    std::optional<will> get_will() const {
+        if (connect_flags::has_will_flag(connect_flags_)) {
+            pub::opts opts =
+                connect_flags::will_retain(connect_flags_) |
+                connect_flags::will_qos(connect_flags_);
+            return
+                async_mqtt::will{
+                    will_topic_,
+                    will_message_,
+                    opts,
+                    will_props_
+                };
+        }
+        else {
+            return std::nullopt;
+        }
+    }
+
+    /**
+     * @breif Get properties
+     * @return properties
+     */
+    properties const& props() const {
+        return props_;
+    }
+
+private:
+
+    template <std::size_t PacketIdBytesArg>
+    friend basic_packet_variant<PacketIdBytesArg>
+    async_mqtt::buffer_to_basic_packet_variant(buffer buf, protocol_version ver);
+
+#if defined(ASYNC_MQTT_UNIT_TEST_FOR_PACKET)
+    friend struct ::ut_packet::v5_connect;
+#endif // defined(ASYNC_MQTT_UNIT_TEST_FOR_PACKET)
+
+    // private constructor for internal use
     connect_packet(buffer buf) {
         // fixed_header
         if (buf.empty()) {
@@ -503,186 +699,6 @@ public:
         }
     }
 
-    constexpr control_packet_type type() const {
-        return control_packet_type::connect;
-    }
-
-    /**
-     * @brief Create const buffer sequence
-     *        it is for boost asio APIs
-     * @return const buffer sequence
-     */
-    std::vector<as::const_buffer> const_buffer_sequence() const {
-        std::vector<as::const_buffer> ret;
-        ret.reserve(num_of_const_buffer_sequence());
-
-        ret.emplace_back(as::buffer(&fixed_header_, 1));
-        ret.emplace_back(as::buffer(remaining_length_buf_.data(), remaining_length_buf_.size()));
-        ret.emplace_back(as::buffer(protocol_name_and_level_.data(), protocol_name_and_level_.size()));
-        ret.emplace_back(as::buffer(&connect_flags_, 1));
-        ret.emplace_back(as::buffer(keep_alive_buf_.data(), keep_alive_buf_.size()));
-
-        ret.emplace_back(as::buffer(property_length_buf_.data(), property_length_buf_.size()));
-        auto props_cbs = async_mqtt::const_buffer_sequence(props_);
-        std::move(props_cbs.begin(), props_cbs.end(), std::back_inserter(ret));
-
-        ret.emplace_back(as::buffer(client_id_length_buf_.data(), client_id_length_buf_.size()));
-        ret.emplace_back(as::buffer(client_id_));
-
-        if (connect_flags::has_will_flag(connect_flags_)) {
-            ret.emplace_back(as::buffer(will_property_length_buf_.data(), will_property_length_buf_.size()));
-            auto will_props_cbs = async_mqtt::const_buffer_sequence(will_props_);
-            std::move(will_props_cbs.begin(), will_props_cbs.end(), std::back_inserter(ret));
-            ret.emplace_back(as::buffer(will_topic_length_buf_.data(), will_topic_length_buf_.size()));
-            ret.emplace_back(as::buffer(will_topic_));
-            ret.emplace_back(as::buffer(will_message_length_buf_.data(), will_message_length_buf_.size()));
-            ret.emplace_back(as::buffer(will_message_));
-        }
-
-        if (connect_flags::has_user_name_flag(connect_flags_)) {
-            ret.emplace_back(as::buffer(user_name_length_buf_.data(), user_name_length_buf_.size()));
-            ret.emplace_back(as::buffer(user_name_));
-        }
-
-        if (connect_flags::has_password_flag(connect_flags_)) {
-            ret.emplace_back(as::buffer(password_length_buf_.data(), password_length_buf_.size()));
-            ret.emplace_back(as::buffer(password_));
-        }
-
-        return ret;
-    }
-
-    /**
-     * @brief Get packet size.
-     * @return packet size
-     */
-    std::size_t size() const {
-        return
-            1 +                            // fixed header
-            remaining_length_buf_.size() +
-            remaining_length_;
-    }
-
-    /**
-     * @brief Get number of element of const_buffer_sequence
-     * @return number of element of const_buffer_sequence
-     */
-    std::size_t num_of_const_buffer_sequence() const {
-        return
-            1 +                   // fixed header
-            1 +                   // remaining length
-            1 +                   // protocol name and level
-            1 +                   // connect flags
-            1 +                   // keep alive
-            1 +                   // property length
-            async_mqtt::num_of_const_buffer_sequence(props_) +
-
-            2 +                   // client id length, client id
-
-            [&] () -> std::size_t {
-                if (connect_flags::has_will_flag(connect_flags_)) {
-                    return
-                        1 +       // will_property length
-                        async_mqtt::num_of_const_buffer_sequence(will_props_) +
-                        2 +       // will topic name length, will topic name
-                        2;        // will message length, will message
-                }
-                return 0;
-            } () +
-            [&] () -> std::size_t {
-                if (connect_flags::has_user_name_flag(connect_flags_)) {
-                    return 2;     // user name length, user name
-                }
-                return 0;
-            } () +
-            [&] () -> std::size_t {
-                if (connect_flags::has_password_flag(connect_flags_)) {
-                    return 2;     // password length, password
-                }
-                return 0;
-            } ();
-    }
-
-    /**
-     * @brief Get clean_start.
-     * @return clean_start
-     */
-    bool clean_start() const {
-        return connect_flags::has_clean_start(connect_flags_);
-    }
-
-    /**
-     * @brief Get keep_alive.
-     * @return keep_alive
-     */
-    std::uint16_t keep_alive() const {
-        return endian_load<std::uint16_t>(keep_alive_buf_.data());
-    }
-
-    /**
-     * @brief Get client_id
-     * @return client_id
-     */
-    buffer client_id() const {
-        return client_id_;
-    }
-
-    /**
-     * @brief Get user_name.
-     * @return user_name
-     */
-    std::optional<buffer> user_name() const {
-        if (connect_flags::has_user_name_flag(connect_flags_)) {
-            return user_name_;
-        }
-        else {
-            return std::nullopt;
-        }
-    }
-
-    /**
-     * @brief Get password.
-     * @return password
-     */
-    std::optional<buffer> password() const {
-        if (connect_flags::has_password_flag(connect_flags_)) {
-            return password_;
-        }
-        else {
-            return std::nullopt;
-        }
-    }
-
-    /**
-     * @brief Get will.
-     * @return will
-     */
-    std::optional<will> get_will() const {
-        if (connect_flags::has_will_flag(connect_flags_)) {
-            pub::opts opts =
-                connect_flags::will_retain(connect_flags_) |
-                connect_flags::will_qos(connect_flags_);
-            return
-                async_mqtt::will{
-                    will_topic_,
-                    will_message_,
-                    opts,
-                    will_props_
-                };
-        }
-        else {
-            return std::nullopt;
-        }
-    }
-
-    /**
-     * @breif Get properties
-     * @return properties
-     */
-    properties const& props() const {
-        return props_;
-    }
-
 private:
     std::uint8_t fixed_header_;
     char connect_flags_;
@@ -714,6 +730,9 @@ private:
     properties props_;
 };
 
+/**
+ * @brief stream output operator
+ */
 inline std::ostream& operator<<(std::ostream& o, connect_packet const& v) {
     o <<
         "v5::connect{" <<

--- a/include/async_mqtt/packet/v5_pingreq.hpp
+++ b/include/async_mqtt/packet/v5_pingreq.hpp
@@ -12,6 +12,7 @@
 
 #include <boost/numeric/conversion/cast.hpp>
 
+#include <async_mqtt/buffer_to_packet_variant_fwd.hpp>
 #include <async_mqtt/exception.hpp>
 #include <async_mqtt/buffer.hpp>
 
@@ -39,6 +40,10 @@ namespace as = boost::asio;
  */
 class pingreq_packet {
 public:
+
+    /**
+     * @brief Constructor
+     */
     pingreq_packet()
         : all_(all_.capacity())
     {
@@ -47,8 +52,52 @@ public:
     }
 
     /**
-     * @brief constructor
+     * @brief Get MQTT control packet type
+     * @return control packet type
      */
+    constexpr control_packet_type type() const {
+        return control_packet_type::pingreq;
+    }
+
+    /**
+     * @brief Create const buffer sequence
+     *        it is for boost asio APIs
+     * @return const buffer sequence
+     */
+    std::vector<as::const_buffer> const_buffer_sequence() const {
+        std::vector<as::const_buffer> ret;
+
+        ret.emplace_back(as::buffer(all_.data(), all_.size()));
+        return ret;
+    }
+
+    /**
+     * @brief Get packet size.
+     * @return packet size
+     */
+    std::size_t size() const {
+        return all_.size();
+    }
+
+    /**
+     * @brief Get number of element of const_buffer_sequence
+     * @return number of element of const_buffer_sequence
+     */
+    static constexpr std::size_t num_of_const_buffer_sequence() {
+        return 1; // all
+    }
+
+private:
+
+    template <std::size_t PacketIdBytesArg>
+    friend basic_packet_variant<PacketIdBytesArg>
+    async_mqtt::buffer_to_basic_packet_variant(buffer buf, protocol_version ver);
+
+#if defined(ASYNC_MQTT_UNIT_TEST_FOR_PACKET)
+    friend struct ::ut_packet::v5_pingreq;
+#endif // defined(ASYNC_MQTT_UNIT_TEST_FOR_PACKET)
+
+    // private constructor for internal use
     pingreq_packet(buffer buf) {
         // fixed_header
         if (buf.empty()) {
@@ -84,42 +133,13 @@ public:
         }
     }
 
-    constexpr control_packet_type type() const {
-        return control_packet_type::pingreq;
-    }
-
-    /**
-     * @brief Create const buffer sequence
-     *        it is for boost asio APIs
-     * @return const buffer sequence
-     */
-    std::vector<as::const_buffer> const_buffer_sequence() const {
-        std::vector<as::const_buffer> ret;
-
-        ret.emplace_back(as::buffer(all_.data(), all_.size()));
-        return ret;
-    }
-
-    /**
-     * @brief Get packet size.
-     * @return packet size
-     */
-    std::size_t size() const {
-        return all_.size();
-    }
-
-    /**
-     * @brief Get number of element of const_buffer_sequence
-     * @return number of element of const_buffer_sequence
-     */
-    static constexpr std::size_t num_of_const_buffer_sequence() {
-        return 1; // all
-    }
-
 private:
     static_vector<char, 2> all_;
 };
 
+/**
+ * @brief stream output operator
+ */
 inline std::ostream& operator<<(std::ostream& o, pingreq_packet const& /*v*/) {
     o <<
         "v5::pingreq{}";

--- a/include/async_mqtt/packet/v5_pingresp.hpp
+++ b/include/async_mqtt/packet/v5_pingresp.hpp
@@ -12,6 +12,7 @@
 
 #include <boost/numeric/conversion/cast.hpp>
 
+#include <async_mqtt/buffer_to_packet_variant_fwd.hpp>
 #include <async_mqtt/exception.hpp>
 #include <async_mqtt/buffer.hpp>
 
@@ -51,6 +52,53 @@ public:
         all_[1] = char(0);
     }
 
+    /**
+     * @brief Get MQTT control packet type
+     * @return control packet type
+     */
+    constexpr control_packet_type type() const {
+        return control_packet_type::pingresp;
+    }
+
+    /**
+     * @brief Create const buffer sequence
+     *        it is for boost asio APIs
+     * @return const buffer sequence
+     */
+    std::vector<as::const_buffer> const_buffer_sequence() const {
+        std::vector<as::const_buffer> ret;
+
+        ret.emplace_back(as::buffer(all_.data(), all_.size()));
+        return ret;
+    }
+
+    /**
+     * @brief Get packet size.
+     * @return packet size
+     */
+    std::size_t size() const {
+        return all_.size();
+    }
+
+    /**
+     * @brief Get number of element of const_buffer_sequence
+     * @return number of element of const_buffer_sequence
+     */
+    static constexpr std::size_t num_of_const_buffer_sequence() {
+        return 1; // all
+    }
+
+private:
+
+    template <std::size_t PacketIdBytesArg>
+    friend basic_packet_variant<PacketIdBytesArg>
+    async_mqtt::buffer_to_basic_packet_variant(buffer buf, protocol_version ver);
+
+#if defined(ASYNC_MQTT_UNIT_TEST_FOR_PACKET)
+    friend struct ::ut_packet::v5_pingresp;
+#endif // defined(ASYNC_MQTT_UNIT_TEST_FOR_PACKET)
+
+    // private constructor for internal use
     pingresp_packet(buffer buf) {
         // fixed_header
         if (buf.empty()) {
@@ -86,42 +134,13 @@ public:
         }
     }
 
-    constexpr control_packet_type type() const {
-        return control_packet_type::pingresp;
-    }
-
-    /**
-     * @brief Create const buffer sequence
-     *        it is for boost asio APIs
-     * @return const buffer sequence
-     */
-    std::vector<as::const_buffer> const_buffer_sequence() const {
-        std::vector<as::const_buffer> ret;
-
-        ret.emplace_back(as::buffer(all_.data(), all_.size()));
-        return ret;
-    }
-
-    /**
-     * @brief Get packet size.
-     * @return packet size
-     */
-    std::size_t size() const {
-        return all_.size();
-    }
-
-    /**
-     * @brief Get number of element of const_buffer_sequence
-     * @return number of element of const_buffer_sequence
-     */
-    static constexpr std::size_t num_of_const_buffer_sequence() {
-        return 1; // all
-    }
-
 private:
     static_vector<char, 2> all_;
 };
 
+/**
+ * @brief stream output operator
+ */
 inline std::ostream& operator<<(std::ostream& o, pingresp_packet const& /*v*/) {
     o <<
         "v5::pingresp{}";

--- a/include/async_mqtt/packet/v5_puback.hpp
+++ b/include/async_mqtt/packet/v5_puback.hpp
@@ -12,6 +12,7 @@
 
 #include <boost/numeric/conversion/cast.hpp>
 
+#include <async_mqtt/buffer_to_packet_variant_fwd.hpp>
 #include <async_mqtt/exception.hpp>
 #include <async_mqtt/buffer.hpp>
 
@@ -96,6 +97,184 @@ public:
         }
     {}
 
+    /**
+     * @brief Get MQTT control packet type
+     * @return control packet type
+     */
+    constexpr control_packet_type type() const {
+        return control_packet_type::puback;
+    }
+
+    /**
+     * @brief Create const buffer sequence
+     *        it is for boost asio APIs
+     * @return const buffer sequence
+     */
+    std::vector<as::const_buffer> const_buffer_sequence() const {
+        std::vector<as::const_buffer> ret;
+        ret.reserve(num_of_const_buffer_sequence());
+        ret.emplace_back(as::buffer(&fixed_header_, 1));
+        ret.emplace_back(as::buffer(remaining_length_buf_.data(), remaining_length_buf_.size()));
+
+        ret.emplace_back(as::buffer(packet_id_.data(), packet_id_.size()));
+
+        if (reason_code_) {
+            ret.emplace_back(as::buffer(&*reason_code_, 1));
+            if (property_length_buf_.size() != 0) {
+                ret.emplace_back(as::buffer(property_length_buf_.data(), property_length_buf_.size()));
+                auto props_cbs = async_mqtt::const_buffer_sequence(props_);
+                std::move(props_cbs.begin(), props_cbs.end(), std::back_inserter(ret));
+            }
+        }
+
+        return ret;
+    }
+
+    /**
+     * @brief Get packet size.
+     * @return packet size
+     */
+    std::size_t size() const {
+        return
+            1 +                            // fixed header
+            remaining_length_buf_.size() +
+            remaining_length_;
+    }
+
+    /**
+     * @brief Get number of element of const_buffer_sequence
+     * @return number of element of const_buffer_sequence
+     */
+    constexpr std::size_t num_of_const_buffer_sequence() const {
+        return
+            1 +                   // fixed header
+            1 +                   // remaining length
+            1 +                   // packet_id
+            [&] () -> std::size_t {
+                if (reason_code_) {
+                    return
+                        1 +       // reason_code
+                        [&] () -> std::size_t {
+                            if (property_length_buf_.size() == 0) return 0;
+                            return
+                                1 +                   // property length
+                                async_mqtt::num_of_const_buffer_sequence(props_);
+                        }();
+                }
+                return 0;
+            }();
+    }
+
+    /**
+     * @brief Get packet_id.
+     * @return packet_id
+     */
+    packet_id_t packet_id() const {
+        return endian_load<packet_id_t>(packet_id_.data());
+    }
+
+    /**
+     * @breif Get reason code
+     * @return reason_code
+     */
+    puback_reason_code code() const {
+        if (reason_code_) return *reason_code_;
+        return puback_reason_code::success;
+    }
+
+    /**
+     * @breif Get properties
+     * @return properties
+     */
+    properties const& props() const {
+        return props_;
+    }
+
+    /**
+     * @brief stream output operator
+     */
+    friend
+    inline std::ostream& operator<<(std::ostream& o, basic_puback_packet<PacketIdBytes> const& v) {
+        o <<
+            "v5::puback{" <<
+            "pid:" << v.packet_id();
+        if (v.reason_code_) {
+            o << ",rc:" << *v.reason_code_;
+        }
+        if (!v.props().empty()) {
+            o << ",ps:" << v.props();
+        };
+        o << "}";
+        return o;
+    }
+
+private:
+    basic_puback_packet(
+        packet_id_t packet_id,
+        std::optional<puback_reason_code> reason_code,
+        properties props
+    )
+        : fixed_header_{
+              make_fixed_header(control_packet_type::puback, 0b0000)
+          },
+          remaining_length_{
+              PacketIdBytes
+          },
+          packet_id_(packet_id_.capacity()),
+          reason_code_{reason_code},
+          property_length_(async_mqtt::size(props)),
+          props_(force_move(props))
+    {
+        using namespace std::literals;
+        endian_store(packet_id, packet_id_.data());
+
+        auto guard = unique_scope_guard(
+            [&] {
+                auto rb = val_to_variable_bytes(boost::numeric_cast<std::uint32_t>(remaining_length_));
+                for (auto e : rb) {
+                    remaining_length_buf_.push_back(e);
+                }
+            }
+        );
+
+        if (!reason_code_) return;
+        remaining_length_ += 1;
+
+        if (property_length_ == 0) return;
+
+        auto pb = val_to_variable_bytes(boost::numeric_cast<std::uint32_t>(property_length_));
+        for (auto e : pb) {
+            property_length_buf_.push_back(e);
+        }
+
+        for (auto const& prop : props_) {
+            auto id = prop.id();
+            if (!validate_property(property_location::puback, id)) {
+                throw make_error(
+                    errc::bad_message,
+                    "v5::puback_packet property "s + id_to_str(id) + " is not allowed"
+                );
+            }
+        }
+
+        remaining_length_ += property_length_buf_.size() + property_length_;
+    }
+
+private:
+
+    template <std::size_t PacketIdBytesArg>
+    friend basic_packet_variant<PacketIdBytesArg>
+    async_mqtt::buffer_to_basic_packet_variant(buffer buf, protocol_version ver);
+
+#if defined(ASYNC_MQTT_UNIT_TEST_FOR_PACKET)
+    friend struct ::ut_packet::v5_puback;
+    friend struct ::ut_packet::v5_puback_pid4;
+    friend struct ::ut_packet::v5_puback_pid_only;
+    friend struct ::ut_packet::v5_puback_pid_rc;
+    friend struct ::ut_packet::v5_puback_prop_len_last;
+#endif // defined(ASYNC_MQTT_UNIT_TEST_FOR_PACKET)
+
+    // private constructor for internal use
     basic_puback_packet(buffer buf) {
         // fixed_header
         if (buf.empty()) {
@@ -188,162 +367,6 @@ public:
                 "v5::puback_packet properties don't match its length"
             );
         }
-    }
-
-    constexpr control_packet_type type() const {
-        return control_packet_type::puback;
-    }
-
-    /**
-     * @brief Create const buffer sequence
-     *        it is for boost asio APIs
-     * @return const buffer sequence
-     */
-    std::vector<as::const_buffer> const_buffer_sequence() const {
-        std::vector<as::const_buffer> ret;
-        ret.reserve(num_of_const_buffer_sequence());
-        ret.emplace_back(as::buffer(&fixed_header_, 1));
-        ret.emplace_back(as::buffer(remaining_length_buf_.data(), remaining_length_buf_.size()));
-
-        ret.emplace_back(as::buffer(packet_id_.data(), packet_id_.size()));
-
-        if (reason_code_) {
-            ret.emplace_back(as::buffer(&*reason_code_, 1));
-            if (property_length_buf_.size() != 0) {
-                ret.emplace_back(as::buffer(property_length_buf_.data(), property_length_buf_.size()));
-                auto props_cbs = async_mqtt::const_buffer_sequence(props_);
-                std::move(props_cbs.begin(), props_cbs.end(), std::back_inserter(ret));
-            }
-        }
-
-        return ret;
-    }
-
-    /**
-     * @brief Get packet size.
-     * @return packet size
-     */
-    std::size_t size() const {
-        return
-            1 +                            // fixed header
-            remaining_length_buf_.size() +
-            remaining_length_;
-    }
-
-    /**
-     * @brief Get number of element of const_buffer_sequence
-     * @return number of element of const_buffer_sequence
-     */
-    constexpr std::size_t num_of_const_buffer_sequence() const {
-        return
-            1 +                   // fixed header
-            1 +                   // remaining length
-            1 +                   // packet_id
-            [&] () -> std::size_t {
-                if (reason_code_) {
-                    return
-                        1 +       // reason_code
-                        [&] () -> std::size_t {
-                            if (property_length_buf_.size() == 0) return 0;
-                            return
-                                1 +                   // property length
-                                async_mqtt::num_of_const_buffer_sequence(props_);
-                        }();
-                }
-                return 0;
-            }();
-    }
-
-    /**
-     * @brief Get packet_id.
-     * @return packet_id
-     */
-    packet_id_t packet_id() const {
-        return endian_load<packet_id_t>(packet_id_.data());
-    }
-
-    /**
-     * @breif Get reason code
-     * @return reason_code
-     */
-    puback_reason_code code() const {
-        if (reason_code_) return *reason_code_;
-        return puback_reason_code::success;
-    }
-
-    /**
-     * @breif Get properties
-     * @return properties
-     */
-    properties const& props() const {
-        return props_;
-    }
-
-    friend
-    inline std::ostream& operator<<(std::ostream& o, basic_puback_packet<PacketIdBytes> const& v) {
-        o <<
-            "v5::puback{" <<
-            "pid:" << v.packet_id();
-        if (v.reason_code_) {
-            o << ",rc:" << *v.reason_code_;
-        }
-        if (!v.props().empty()) {
-            o << ",ps:" << v.props();
-        };
-        o << "}";
-        return o;
-    }
-
-private:
-    basic_puback_packet(
-        packet_id_t packet_id,
-        std::optional<puback_reason_code> reason_code,
-        properties props
-    )
-        : fixed_header_{
-              make_fixed_header(control_packet_type::puback, 0b0000)
-          },
-          remaining_length_{
-              PacketIdBytes
-          },
-          packet_id_(packet_id_.capacity()),
-          reason_code_{reason_code},
-          property_length_(async_mqtt::size(props)),
-          props_(force_move(props))
-    {
-        using namespace std::literals;
-        endian_store(packet_id, packet_id_.data());
-
-        auto guard = unique_scope_guard(
-            [&] {
-                auto rb = val_to_variable_bytes(boost::numeric_cast<std::uint32_t>(remaining_length_));
-                for (auto e : rb) {
-                    remaining_length_buf_.push_back(e);
-                }
-            }
-        );
-
-        if (!reason_code_) return;
-        remaining_length_ += 1;
-
-        if (property_length_ == 0) return;
-
-        auto pb = val_to_variable_bytes(boost::numeric_cast<std::uint32_t>(property_length_));
-        for (auto e : pb) {
-            property_length_buf_.push_back(e);
-        }
-
-        for (auto const& prop : props_) {
-            auto id = prop.id();
-            if (!validate_property(property_location::puback, id)) {
-                throw make_error(
-                    errc::bad_message,
-                    "v5::puback_packet property "s + id_to_str(id) + " is not allowed"
-                );
-            }
-        }
-
-        remaining_length_ += property_length_buf_.size() + property_length_;
     }
 
 private:

--- a/include/async_mqtt/packet/v5_pubcomp.hpp
+++ b/include/async_mqtt/packet/v5_pubcomp.hpp
@@ -12,6 +12,7 @@
 
 #include <boost/numeric/conversion/cast.hpp>
 
+#include <async_mqtt/buffer_to_packet_variant_fwd.hpp>
 #include <async_mqtt/exception.hpp>
 #include <async_mqtt/buffer.hpp>
 
@@ -93,93 +94,10 @@ public:
         }
     {}
 
-    basic_pubcomp_packet(buffer buf) {
-        // fixed_header
-        if (buf.empty()) {
-            throw make_error(
-                errc::bad_message,
-                "v5::pubcomp_packet fixed_header doesn't exist"
-            );
-        }
-        fixed_header_ = static_cast<std::uint8_t>(buf.front());
-        buf.remove_prefix(1);
-
-        // remaining_length
-        if (auto vl_opt = insert_advance_variable_length(buf, remaining_length_buf_)) {
-            remaining_length_ = *vl_opt;
-        }
-        else {
-            throw make_error(errc::bad_message, "v5::pubcomp_packet remaining length is invalid");
-        }
-
-        // packet_id
-        if (!insert_advance(buf, packet_id_)) {
-            throw make_error(
-                errc::bad_message,
-                "v5::pubcomp_packet packet_id doesn't exist"
-            );
-        }
-
-        if (remaining_length_ == PacketIdBytes) {
-            if (!buf.empty()) {
-                throw make_error(errc::bad_message, "v5::pubcomp_packet remaining length is invalid");
-            }
-            return;
-        }
-
-        // reason_code
-        reason_code_.emplace(static_cast<pubcomp_reason_code>(buf.front()));
-        buf.remove_prefix(1);
-        switch (*reason_code_) {
-        case pubcomp_reason_code::success:
-        case pubcomp_reason_code::packet_identifier_not_found:
-            break;
-        default:
-            throw make_error(
-                errc::bad_message,
-                "v5::pubcomp_packet connect reason_code is invalid"
-            );
-            break;
-        }
-
-        if (remaining_length_ == 3) {
-            if (!buf.empty()) {
-                throw make_error(errc::bad_message, "v5::pubcomp_packet remaining length is invalid");
-            }
-            return;
-        }
-
-        // property
-        auto it = buf.begin();
-        if (auto pl_opt = variable_bytes_to_val(it, buf.end())) {
-            property_length_ = *pl_opt;
-            std::copy(buf.begin(), it, std::back_inserter(property_length_buf_));
-            buf.remove_prefix(std::size_t(std::distance(buf.begin(), it)));
-            if (buf.size() < property_length_) {
-                throw make_error(
-                    errc::bad_message,
-                    "v5::pubcomp_packet properties_don't match its length"
-                );
-            }
-            auto prop_buf = buf.substr(0, property_length_);
-            props_ = make_properties(prop_buf, property_location::pubcomp);
-            buf.remove_prefix(property_length_);
-        }
-        else {
-            throw make_error(
-                errc::bad_message,
-                "v5::pubcomp_packet property_length is invalid"
-            );
-        }
-
-        if (!buf.empty()) {
-            throw make_error(
-                errc::bad_message,
-                "v5::pubcomp_packet properties don't match its length"
-            );
-        }
-    }
-
+    /**
+     * @brief Get MQTT control packet type
+     * @return control packet type
+     */
     constexpr control_packet_type type() const {
         return control_packet_type::pubcomp;
     }
@@ -270,6 +188,9 @@ public:
         return props_;
     }
 
+    /**
+     * @brief stream output operator
+     */
     friend
     inline std::ostream& operator<<(std::ostream& o, basic_pubcomp_packet<PacketIdBytes> const& v) {
         o <<
@@ -335,6 +256,108 @@ private:
         }
 
         remaining_length_ += property_length_buf_.size() + property_length_;
+    }
+
+private:
+
+    template <std::size_t PacketIdBytesArg>
+    friend basic_packet_variant<PacketIdBytesArg>
+    async_mqtt::buffer_to_basic_packet_variant(buffer buf, protocol_version ver);
+
+#if defined(ASYNC_MQTT_UNIT_TEST_FOR_PACKET)
+    friend struct ::ut_packet::v5_pubcomp;
+    friend struct ::ut_packet::v5_pubcomp_pid4;
+    friend struct ::ut_packet::v5_pubcomp_pid_only;
+    friend struct ::ut_packet::v5_pubcomp_pid_rc;
+    friend struct ::ut_packet::v5_pubcomp_prop_len_last;
+#endif // defined(ASYNC_MQTT_UNIT_TEST_FOR_PACKET)
+
+    // private constructor for internal use
+    basic_pubcomp_packet(buffer buf) {
+        // fixed_header
+        if (buf.empty()) {
+            throw make_error(
+                errc::bad_message,
+                "v5::pubcomp_packet fixed_header doesn't exist"
+            );
+        }
+        fixed_header_ = static_cast<std::uint8_t>(buf.front());
+        buf.remove_prefix(1);
+
+        // remaining_length
+        if (auto vl_opt = insert_advance_variable_length(buf, remaining_length_buf_)) {
+            remaining_length_ = *vl_opt;
+        }
+        else {
+            throw make_error(errc::bad_message, "v5::pubcomp_packet remaining length is invalid");
+        }
+
+        // packet_id
+        if (!insert_advance(buf, packet_id_)) {
+            throw make_error(
+                errc::bad_message,
+                "v5::pubcomp_packet packet_id doesn't exist"
+            );
+        }
+
+        if (remaining_length_ == PacketIdBytes) {
+            if (!buf.empty()) {
+                throw make_error(errc::bad_message, "v5::pubcomp_packet remaining length is invalid");
+            }
+            return;
+        }
+
+        // reason_code
+        reason_code_.emplace(static_cast<pubcomp_reason_code>(buf.front()));
+        buf.remove_prefix(1);
+        switch (*reason_code_) {
+        case pubcomp_reason_code::success:
+        case pubcomp_reason_code::packet_identifier_not_found:
+            break;
+        default:
+            throw make_error(
+                errc::bad_message,
+                "v5::pubcomp_packet connect reason_code is invalid"
+            );
+            break;
+        }
+
+        if (remaining_length_ == 3) {
+            if (!buf.empty()) {
+                throw make_error(errc::bad_message, "v5::pubcomp_packet remaining length is invalid");
+            }
+            return;
+        }
+
+        // property
+        auto it = buf.begin();
+        if (auto pl_opt = variable_bytes_to_val(it, buf.end())) {
+            property_length_ = *pl_opt;
+            std::copy(buf.begin(), it, std::back_inserter(property_length_buf_));
+            buf.remove_prefix(std::size_t(std::distance(buf.begin(), it)));
+            if (buf.size() < property_length_) {
+                throw make_error(
+                    errc::bad_message,
+                    "v5::pubcomp_packet properties_don't match its length"
+                );
+            }
+            auto prop_buf = buf.substr(0, property_length_);
+            props_ = make_properties(prop_buf, property_location::pubcomp);
+            buf.remove_prefix(property_length_);
+        }
+        else {
+            throw make_error(
+                errc::bad_message,
+                "v5::pubcomp_packet property_length is invalid"
+            );
+        }
+
+        if (!buf.empty()) {
+            throw make_error(
+                errc::bad_message,
+                "v5::pubcomp_packet properties don't match its length"
+            );
+        }
     }
 
 private:

--- a/include/async_mqtt/packet/v5_publish.hpp
+++ b/include/async_mqtt/packet/v5_publish.hpp
@@ -12,6 +12,7 @@
 
 #include <boost/numeric/conversion/cast.hpp>
 
+#include <async_mqtt/buffer_to_packet_variant_fwd.hpp>
 #include <async_mqtt/exception.hpp>
 #include <async_mqtt/buffer.hpp>
 #include <async_mqtt/variable_bytes.hpp>
@@ -40,24 +41,48 @@ template <std::size_t PacketIdBytes>
 class basic_publish_packet {
 public:
     using packet_id_t = typename packet_id_type<PacketIdBytes>::type;
+
+    /**
+     * @brief constructor
+     * @tparam BufferSequence Type of the payload
+     * @param packet_id  MQTT PacketIdentifier. If QoS0 then it must be 0. You can use no packet_id version constructor.
+     *                   If QoS is 0 or 1 then, the packet_id must be acquired by
+     *                   basic_endpoint::acquire_unique_packet_id(), or must be registered by
+     *                   basic_endpoint::register_packet_id().
+     *                   \n If QoS0, the packet_id is not sent actually.
+     *                   \n See https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901108
+     * @param topic_name MQTT TopicName
+     *                   \n See https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901107
+     * @param payloads   The body message of the packet. It could be a single buffer of multiple buffer sequence.
+     *                   \n See https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901119
+     * @param pubopts    Publish Options. It contains the following elements:
+     *                   \n DUP See https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901102
+     *                   \n QoS See https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901103
+     *                   \n RETAIN See https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901104
+     */
     template <
+        typename StringViewLike,
         typename BufferSequence,
         std::enable_if_t<
-            is_buffer_sequence<std::decay_t<BufferSequence>>::value,
+            std::is_convertible_v<std::decay_t<StringViewLike>, std::string_view> &&
+            (
+                is_buffer_sequence<std::decay_t<BufferSequence>>::value ||
+                std::is_convertible_v<std::decay_t<BufferSequence>, std::string_view>
+            ),
             std::nullptr_t
         > = nullptr
     >
     basic_publish_packet(
         packet_id_t packet_id,
-        buffer topic_name,
-        BufferSequence payloads,
+        StringViewLike&& topic_name,
+        BufferSequence&& payloads,
         pub::opts pubopts,
         properties props = {}
     )
         : fixed_header_(
               make_fixed_header(control_packet_type::publish, 0b0000) | std::uint8_t(pubopts)
           ),
-          topic_name_{force_move(topic_name)},
+          topic_name_{std::string{std::forward<StringViewLike>(topic_name)}},
           packet_id_(PacketIdBytes),
           property_length_(async_mqtt::size(props)),
           props_(force_move(props)),
@@ -75,14 +100,21 @@ public:
             boost::numeric_cast<std::uint16_t>(topic_name_.size()),
             topic_name_length_buf_.data()
         );
-        auto b = buffer_sequence_begin(payloads);
-        auto e = buffer_sequence_end(payloads);
-        auto num_of_payloads = static_cast<std::size_t>(std::distance(b, e));
-        payloads_.reserve(num_of_payloads);
-        for (; b != e; ++b) {
-            auto const& payload = *b;
-            remaining_length_ += payload.size();
-            payloads_.push_back(payload);
+
+        if constexpr (std::is_convertible_v<std::decay_t<BufferSequence>, std::string_view>) {
+            remaining_length_ += std::string_view(payloads).size();
+            payloads_.emplace_back(buffer{std::string{payloads}});
+        }
+        else {
+            auto b = buffer_sequence_begin(payloads);
+            auto e = buffer_sequence_end(payloads);
+            auto num_of_payloads = static_cast<std::size_t>(std::distance(b, e));
+            payloads_.reserve(num_of_payloads);
+            for (; b != e; ++b) {
+                auto const& payload = *b;
+                remaining_length_ += payload.size();
+                payloads_.push_back(payload);
+            }
         }
 
         if (!utf8string_check(topic_name_)) {
@@ -135,21 +167,358 @@ public:
         }
     }
 
+    /**
+     * @brief constructor for QoS0
+     * @param topic_name MQTT TopicName
+     *                   \n See https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901107
+     * @param payloads   The body message of the packet. It could be a single buffer of multiple buffer sequence.
+     *                   \n See https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901119
+     * @param pubopts    Publish Options. It contains the following elements:
+     *                   \n DUP See https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901102
+     *                   \n QoS See https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901103
+     *                   \n RETAIN See https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901104
+     */
     template <
+        typename StringViewLike,
         typename BufferSequence,
-        typename std::enable_if<
-            is_buffer_sequence<std::decay_t<BufferSequence>>::value,
+        std::enable_if_t<
+            std::is_convertible_v<std::decay_t<StringViewLike>, std::string_view> &&
+            (
+                is_buffer_sequence<std::decay_t<BufferSequence>>::value ||
+                std::is_convertible_v<std::decay_t<BufferSequence>, std::string_view>
+            ),
             std::nullptr_t
-        >::type = nullptr
+        > = nullptr
     >
     basic_publish_packet(
-        buffer topic_name,
-        BufferSequence payloads,
+        StringViewLike&& topic_name,
+        BufferSequence&& payloads,
         pub::opts pubopts,
         properties props = {}
-    ) : basic_publish_packet(0, force_move(topic_name), force_move(payloads), pubopts, force_move(props)) {
+    ) : basic_publish_packet{
+            0,
+            std::forward<StringViewLike>(topic_name),
+            std::forward<BufferSequence>(payloads),
+            pubopts,
+            force_move(props)
+        }
+    {
     }
 
+    /**
+     * @brief Get MQTT control packet type
+     * @return control packet type
+     */
+    constexpr control_packet_type type() const {
+        return control_packet_type::publish;
+    }
+
+    /**
+     * @brief Create const buffer sequence
+     *        it is for boost asio APIs
+     * @return const buffer sequence
+     */
+    std::vector<as::const_buffer> const_buffer_sequence() const {
+        std::vector<as::const_buffer> ret;
+        ret.reserve(num_of_const_buffer_sequence());
+        ret.emplace_back(as::buffer(&fixed_header_, 1));
+        ret.emplace_back(as::buffer(remaining_length_buf_.data(), remaining_length_buf_.size()));
+        ret.emplace_back(as::buffer(topic_name_length_buf_.data(), topic_name_length_buf_.size()));
+        ret.emplace_back(as::buffer(topic_name_));
+        if (packet_id() != 0) {
+            ret.emplace_back(as::buffer(packet_id_.data(), packet_id_.size()));
+        }
+        ret.emplace_back(as::buffer(property_length_buf_.data(), property_length_buf_.size()));
+        auto props_cbs = async_mqtt::const_buffer_sequence(props_);
+        std::move(props_cbs.begin(), props_cbs.end(), std::back_inserter(ret));
+        for (auto const& payload : payloads_) {
+            ret.emplace_back(as::buffer(payload));
+        }
+        return ret;
+    }
+
+    /**
+     * @brief Get packet size.
+     * @return packet size
+     */
+    std::size_t size() const {
+        return
+            1 +                            // fixed header
+            remaining_length_buf_.size() +
+            remaining_length_;
+    }
+
+    /**
+     * @brief Get number of element of const_buffer_sequence
+     * @return number of element of const_buffer_sequence
+     */
+    std::size_t num_of_const_buffer_sequence() const {
+        return
+            1U +                   // fixed header
+            1U +                   // remaining length
+            2U +                   // topic name length, topic name
+            [&] {
+                if (packet_id() == 0) return 0U;
+                return 1U;
+            }() +
+            1U +                   // property length
+            async_mqtt::num_of_const_buffer_sequence(props_) +
+            payloads_.size();
+    }
+
+    /**
+     * @brief Get packet id
+     * @return packet_id
+     */
+    packet_id_t packet_id() const {
+        return endian_load<packet_id_t>(packet_id_.data());
+    }
+
+    /**
+     * @brief Get publish_options
+     * @return publish_options.
+     */
+    constexpr pub::opts opts() const {
+        return pub::opts(fixed_header_);
+    }
+
+    /**
+     * @brief Get topic name
+     * @return topic name
+     */
+    std::string topic() const {
+        return std::string{topic_name_};
+    }
+
+    /**
+     * @brief Get topic as a buffer
+     * @return topic name
+     */
+    buffer const& topic_as_buffer() const {
+        return topic_name_;
+    }
+
+    /**
+     * @brief Get payload
+     * @return payload
+     */
+    std::string payload() const {
+        return to_string(payloads_);
+    }
+
+    /**
+     * @brief Get payload range
+     * @return A pair of forward iterators
+     */
+    auto payload_range() const {
+        return make_packet_range(payloads_);
+    }
+
+    /**
+     * @brief Get payload as a sequence of buffer
+     * @return payload
+     */
+    std::vector<buffer> const& payload_as_buffer() const {
+        return payloads_;
+    }
+
+    /**
+     * @brief Set dup flag
+     * @param dup flag value to set
+     */
+    constexpr void set_dup(bool dup) {
+        pub::set_dup(fixed_header_, dup);
+    }
+
+    /**
+     * @breif Get properties
+     * @return properties
+     */
+    properties const& props() const {
+        return props_;
+    }
+
+    /**
+     * @breif Remove topic and add topic_alias
+     *
+     * This is for applying topic_alias.
+     * @param val topic_alias
+     */
+    void remove_topic_add_topic_alias(topic_alias_t val) {
+        // add topic_alias property
+        auto prop{property::topic_alias{val}};
+        auto prop_size = prop.size();
+        property_length_ += prop_size;
+        props_.push_back(force_move(prop));
+
+        // update property_length_buf
+        auto [old_property_length_buf_size, new_property_length_buf_size] =
+            update_property_length_buf();
+
+        // remove topic_name
+        auto old_topic_name_size = topic_name_.size();
+        topic_name_ = buffer{};
+        endian_store(
+            boost::numeric_cast<std::uint16_t>(topic_name_.size()),
+            topic_name_length_buf_.data()
+        );
+
+        // update remaining_length
+        remaining_length_ +=
+            prop_size +
+            (new_property_length_buf_size - old_property_length_buf_size) -
+            old_topic_name_size;
+        update_remaining_length_buf();
+    }
+
+    /**
+     * @breif Add topic_alias
+     *
+     * This is for registering topic_alias.
+     * @param val topic_alias
+     */
+    void add_topic_alias(topic_alias_t val) {
+        // add topic_alias property
+        auto prop{property::topic_alias{val}};
+        auto prop_size = prop.size();
+        property_length_ += prop_size;
+        props_.push_back(force_move(prop));
+
+        // update property_length_buf
+        auto [old_property_length_buf_size, new_property_length_buf_size] =
+            update_property_length_buf();
+
+        // update remaining_length
+        remaining_length_ +=
+            prop_size +
+            (new_property_length_buf_size - old_property_length_buf_size);
+        update_remaining_length_buf();
+    }
+
+    /**
+     * @breif Remove topic and add topic_alias
+     *
+     * This is for extracting topic from the topic_alias.
+     * @param val topic_alias
+     */
+    void add_topic(std::string topic) {
+        add_topic_impl(force_move(topic));
+        // update remaining_length
+        remaining_length_ += topic_name_.size();
+        update_remaining_length_buf();
+    }
+
+    void remove_topic_alias() {
+        auto prop_size = remove_topic_alias_impl();
+        property_length_ -= prop_size;
+        // update property_length_buf
+        auto [old_property_length_buf_size, new_property_length_buf_size] =
+            update_property_length_buf();
+
+        // update remaining_length
+        remaining_length_ +=
+            -prop_size +
+            (new_property_length_buf_size - old_property_length_buf_size);
+        update_remaining_length_buf();
+    }
+
+    void remove_topic_alias_add_topic(std::string topic) {
+        auto prop_size = remove_topic_alias_impl();
+        property_length_ -= prop_size;
+        add_topic_impl(force_move(topic));
+        // update property_length_buf
+        auto [old_property_length_buf_size, new_property_length_buf_size] =
+            update_property_length_buf();
+
+        // update remaining_length
+        remaining_length_ +=
+            topic_name_.size() -
+            prop_size +
+            (new_property_length_buf_size - old_property_length_buf_size);
+        update_remaining_length_buf();
+    }
+
+    /**
+     * @breif Update MessageExpiryInterval property
+     * @param val message_expiry_interval
+     */
+    void update_message_expiry_interval(std::uint32_t val) {
+        bool updated = false;
+        for (auto& prop : props_) {
+            prop.visit(
+                overload {
+                    [&](property::message_expiry_interval& p) {
+                        p = property::message_expiry_interval(val);
+                        updated = true;
+                    },
+                    [&](auto&){}
+                }
+            );
+            if (updated) return;
+        }
+    }
+
+private:
+    void update_remaining_length_buf() {
+        remaining_length_buf_.clear();
+        auto rb = val_to_variable_bytes(boost::numeric_cast<std::uint32_t>(remaining_length_));
+        for (auto e : rb) {
+            remaining_length_buf_.push_back(e);
+        }
+    }
+
+    std::tuple<std::size_t, std::size_t> update_property_length_buf() {
+        auto old_property_length_buf_size = property_length_buf_.size();
+        property_length_buf_.clear();
+        auto pb = val_to_variable_bytes(boost::numeric_cast<std::uint32_t>(property_length_));
+        for (auto e : pb) {
+            property_length_buf_.push_back(e);
+        }
+        auto new_property_length_buf_size = property_length_buf_.size();
+        return {old_property_length_buf_size, new_property_length_buf_size};
+    }
+
+    std::size_t remove_topic_alias_impl() {
+        auto it = props_.cbegin();
+        std::size_t size = 0;
+        while (it != props_.cend()) {
+            if (it->id() == property::id::topic_alias) {
+                size += it->size();
+                it = props_.erase(it);
+            }
+            else {
+                ++it;
+            }
+        }
+        return size;
+    }
+
+    void add_topic_impl(std::string topic) {
+        BOOST_ASSERT(topic_name_.empty());
+
+        // add topic
+        topic_name_ = buffer{force_move(topic)};
+        endian_store(
+            boost::numeric_cast<std::uint16_t>(topic_name_.size()),
+            topic_name_length_buf_.data()
+        );
+    }
+
+private:
+
+    template <std::size_t PacketIdBytesArg>
+    friend basic_packet_variant<PacketIdBytesArg>
+    async_mqtt::buffer_to_basic_packet_variant(buffer buf, protocol_version ver);
+
+#if defined(ASYNC_MQTT_UNIT_TEST_FOR_PACKET)
+    friend struct ::ut_packet::v5_publish;
+    friend struct ::ut_packet::v5_publish_qos0;
+    friend struct ::ut_packet::v5_publish_invalid;
+    friend struct ::ut_packet::v5_publish_pid4;
+    friend struct ::ut_packet::v5_publish_topic_alias;
+#endif // defined(ASYNC_MQTT_UNIT_TEST_FOR_PACKET)
+
+    // private constructor for internal use
     basic_publish_packet(buffer buf)
         : packet_id_(PacketIdBytes) {
         // fixed_header
@@ -247,286 +616,6 @@ public:
             payloads_.emplace_back(force_move(buf));
         }
     }
-
-    constexpr control_packet_type type() const {
-        return control_packet_type::publish;
-    }
-
-    /**
-     * @brief Create const buffer sequence
-     *        it is for boost asio APIs
-     * @return const buffer sequence
-     */
-    std::vector<as::const_buffer> const_buffer_sequence() const {
-        std::vector<as::const_buffer> ret;
-        ret.reserve(num_of_const_buffer_sequence());
-        ret.emplace_back(as::buffer(&fixed_header_, 1));
-        ret.emplace_back(as::buffer(remaining_length_buf_.data(), remaining_length_buf_.size()));
-        ret.emplace_back(as::buffer(topic_name_length_buf_.data(), topic_name_length_buf_.size()));
-        ret.emplace_back(as::buffer(topic_name_));
-        if (packet_id() != 0) {
-            ret.emplace_back(as::buffer(packet_id_.data(), packet_id_.size()));
-        }
-        ret.emplace_back(as::buffer(property_length_buf_.data(), property_length_buf_.size()));
-        auto props_cbs = async_mqtt::const_buffer_sequence(props_);
-        std::move(props_cbs.begin(), props_cbs.end(), std::back_inserter(ret));
-        for (auto const& payload : payloads_) {
-            ret.emplace_back(as::buffer(payload));
-        }
-        return ret;
-    }
-
-    /**
-     * @brief Get packet size.
-     * @return packet size
-     */
-    std::size_t size() const {
-        return
-            1 +                            // fixed header
-            remaining_length_buf_.size() +
-            remaining_length_;
-    }
-
-    /**
-     * @brief Get number of element of const_buffer_sequence
-     * @return number of element of const_buffer_sequence
-     */
-    std::size_t num_of_const_buffer_sequence() const {
-        return
-            1U +                   // fixed header
-            1U +                   // remaining length
-            2U +                   // topic name length, topic name
-            [&] {
-                if (packet_id() == 0) return 0U;
-                return 1U;
-            }() +
-            1U +                   // property length
-            async_mqtt::num_of_const_buffer_sequence(props_) +
-            payloads_.size();
-    }
-
-    /**
-     * @brief Get packet id
-     * @return packet_id
-     */
-    packet_id_t packet_id() const {
-        return endian_load<packet_id_t>(packet_id_.data());
-    }
-
-    /**
-     * @brief Get publish_options
-     * @return publish_options.
-     */
-    constexpr pub::opts opts() const {
-        return pub::opts(fixed_header_);
-    }
-
-    /**
-     * @brief Get topic name
-     * @return topic name
-     */
-    constexpr buffer const& topic() const {
-        return topic_name_;
-    }
-
-    /**
-     * @brief Get payload
-     * @return payload
-     */
-    std::vector<buffer> const& payload() const {
-        return payloads_;
-    }
-
-    /**
-     * @brief Get payload range
-     * @return A pair of forward iterators
-     */
-    auto payload_range() const {
-        return make_packet_range(payloads_);
-    }
-
-    /**
-     * @brief Set dup flag
-     * @param dup flag value to set
-     */
-    constexpr void set_dup(bool dup) {
-        pub::set_dup(fixed_header_, dup);
-    }
-
-    /**
-     * @breif Get properties
-     * @return properties
-     */
-    properties const& props() const {
-        return props_;
-    }
-
-    /**
-     * @breif Remove topic and add topic_alias
-     *
-     * This is for applying topic_alias.
-     * @param val topic_alias
-     */
-    void remove_topic_add_topic_alias(topic_alias_t val) {
-        // add topic_alias property
-        auto prop{property::topic_alias{val}};
-        auto prop_size = prop.size();
-        property_length_ += prop_size;
-        props_.push_back(force_move(prop));
-
-        // update property_length_buf
-        auto [old_property_length_buf_size, new_property_length_buf_size] =
-            update_property_length_buf();
-
-        // remove topic_name
-        auto old_topic_name_size = topic_name_.size();
-        topic_name_ = buffer{};
-        endian_store(
-            boost::numeric_cast<std::uint16_t>(topic_name_.size()),
-            topic_name_length_buf_.data()
-        );
-
-        // update remaining_length
-        remaining_length_ +=
-            prop_size +
-            (new_property_length_buf_size - old_property_length_buf_size) -
-            old_topic_name_size;
-        update_remaining_length_buf();
-    }
-
-    /**
-     * @breif Add topic_alias
-     *
-     * This is for registering topic_alias.
-     * @param val topic_alias
-     */
-    void add_topic_alias(topic_alias_t val) {
-        // add topic_alias property
-        auto prop{property::topic_alias{val}};
-        auto prop_size = prop.size();
-        property_length_ += prop_size;
-        props_.push_back(force_move(prop));
-
-        // update property_length_buf
-        auto [old_property_length_buf_size, new_property_length_buf_size] =
-            update_property_length_buf();
-
-        // update remaining_length
-        remaining_length_ +=
-            prop_size +
-            (new_property_length_buf_size - old_property_length_buf_size);
-        update_remaining_length_buf();
-    }
-
-    /**
-     * @breif Remove topic and add topic_alias
-     *
-     * This is for extracting topic from the topic_alias.
-     * @param val topic_alias
-     */
-    void add_topic(buffer topic) {
-        add_topic_impl(force_move(topic));
-        // update remaining_length
-        remaining_length_ += topic_name_.size();
-        update_remaining_length_buf();
-    }
-
-    void remove_topic_alias() {
-        auto prop_size = remove_topic_alias_impl();
-        property_length_ -= prop_size;
-        // update property_length_buf
-        auto [old_property_length_buf_size, new_property_length_buf_size] =
-            update_property_length_buf();
-
-        // update remaining_length
-        remaining_length_ +=
-            -prop_size +
-            (new_property_length_buf_size - old_property_length_buf_size);
-        update_remaining_length_buf();
-    }
-
-    void remove_topic_alias_add_topic(buffer topic) {
-        auto prop_size = remove_topic_alias_impl();
-        property_length_ -= prop_size;
-        add_topic_impl(force_move(topic));
-        // update property_length_buf
-        auto [old_property_length_buf_size, new_property_length_buf_size] =
-            update_property_length_buf();
-
-        // update remaining_length
-        remaining_length_ +=
-            topic_name_.size() -
-            prop_size +
-            (new_property_length_buf_size - old_property_length_buf_size);
-        update_remaining_length_buf();
-    }
-
-    /**
-     * @breif Update MessageExpiryInterval property
-     * @param val message_expiry_interval
-     */
-    void update_message_expiry_interval(std::uint32_t val) {
-        bool updated = false;
-        for (auto& prop : props_) {
-            prop.visit(
-                overload {
-                    [&](property::message_expiry_interval& p) {
-                        p = property::message_expiry_interval(val);
-                        updated = true;
-                    },
-                    [&](auto&){}
-                }
-            );
-            if (updated) return;
-        }
-    }
-
-private:
-    void update_remaining_length_buf() {
-        remaining_length_buf_.clear();
-        auto rb = val_to_variable_bytes(boost::numeric_cast<std::uint32_t>(remaining_length_));
-        for (auto e : rb) {
-            remaining_length_buf_.push_back(e);
-        }
-    }
-
-    std::tuple<std::size_t, std::size_t> update_property_length_buf() {
-        auto old_property_length_buf_size = property_length_buf_.size();
-        property_length_buf_.clear();
-        auto pb = val_to_variable_bytes(boost::numeric_cast<std::uint32_t>(property_length_));
-        for (auto e : pb) {
-            property_length_buf_.push_back(e);
-        }
-        auto new_property_length_buf_size = property_length_buf_.size();
-        return {old_property_length_buf_size, new_property_length_buf_size};
-    }
-
-    std::size_t remove_topic_alias_impl() {
-        auto it = props_.cbegin();
-        std::size_t size = 0;
-        while (it != props_.cend()) {
-            if (it->id() == property::id::topic_alias) {
-                size += it->size();
-                it = props_.erase(it);
-            }
-            else {
-                ++it;
-            }
-        }
-        return size;
-    }
-
-    void add_topic_impl(buffer topic) {
-        BOOST_ASSERT(topic_name_.empty());
-
-        // add topic
-        topic_name_ = force_move(topic);
-        endian_store(
-            boost::numeric_cast<std::uint16_t>(topic_name_.size()),
-            topic_name_length_buf_.data()
-        );
-    }
-
 private:
     std::uint8_t fixed_header_;
     buffer topic_name_;
@@ -540,6 +629,9 @@ private:
     static_vector<char, 4> remaining_length_buf_;
 };
 
+/**
+ * @brief stream output operator
+ */
 template <std::size_t PacketIdBytes>
 inline std::ostream& operator<<(std::ostream& o, basic_publish_packet<PacketIdBytes> const& v) {
     o << "v5::publish{" <<
@@ -553,7 +645,7 @@ inline std::ostream& operator<<(std::ostream& o, basic_publish_packet<PacketIdBy
     }
 #if defined(ASYNC_MQTT_PRINT_PAYLOAD)
     o << ",payload:";
-    for (auto const& e : v.payload()) {
+    for (auto const& e : v.payload_as_buffer()) {
         o << json_like_out(e);
     }
 #endif // defined(ASYNC_MQTT_PRINT_PAYLOAD)

--- a/include/async_mqtt/packet/v5_pubrec.hpp
+++ b/include/async_mqtt/packet/v5_pubrec.hpp
@@ -12,6 +12,7 @@
 
 #include <boost/numeric/conversion/cast.hpp>
 
+#include <async_mqtt/buffer_to_packet_variant_fwd.hpp>
 #include <async_mqtt/exception.hpp>
 #include <async_mqtt/buffer.hpp>
 
@@ -93,6 +94,185 @@ public:
         }
     {}
 
+    /**
+     * @brief Get MQTT control packet type
+     * @return control packet type
+     */
+    constexpr control_packet_type type() const {
+        return control_packet_type::pubrec;
+    }
+
+    /**
+     * @brief Create const buffer sequence
+     *        it is for boost asio APIs
+     * @return const buffer sequence
+     */
+    std::vector<as::const_buffer> const_buffer_sequence() const {
+        std::vector<as::const_buffer> ret;
+        ret.reserve(num_of_const_buffer_sequence());
+        ret.emplace_back(as::buffer(&fixed_header_, 1));
+        ret.emplace_back(as::buffer(remaining_length_buf_.data(), remaining_length_buf_.size()));
+
+        ret.emplace_back(as::buffer(packet_id_.data(), packet_id_.size()));
+
+        if (reason_code_) {
+            ret.emplace_back(as::buffer(&*reason_code_, 1));
+
+            if (property_length_buf_.size() != 0) {
+                ret.emplace_back(as::buffer(property_length_buf_.data(), property_length_buf_.size()));
+                auto props_cbs = async_mqtt::const_buffer_sequence(props_);
+                std::move(props_cbs.begin(), props_cbs.end(), std::back_inserter(ret));
+            }
+        }
+
+        return ret;
+    }
+
+    /**
+     * @brief Get packet size.
+     * @return packet size
+     */
+    std::size_t size() const {
+        return
+            1 +                            // fixed header
+            remaining_length_buf_.size() +
+            remaining_length_;
+    }
+
+    /**
+     * @brief Get number of element of const_buffer_sequence
+     * @return number of element of const_buffer_sequence
+     */
+    constexpr std::size_t num_of_const_buffer_sequence() const {
+        return
+            1 +                   // fixed header
+            1 +                   // remaining length
+            1 +                   // packet_id
+            [&] () -> std::size_t {
+                if (reason_code_) {
+                    return
+                        1 +       // reason_code
+                        [&] () -> std::size_t {
+                            if (property_length_buf_.size() == 0) return 0;
+                            return
+                                1 +                   // property length
+                                async_mqtt::num_of_const_buffer_sequence(props_);
+                        }();
+                }
+                return 0;
+            }();
+    }
+
+    /**
+     * @brief Get packet_id.
+     * @return packet_id
+     */
+    packet_id_t packet_id() const {
+        return endian_load<packet_id_t>(packet_id_.data());
+    }
+
+    /**
+     * @breif Get reason code
+     * @return reason_code
+     */
+    pubrec_reason_code code() const {
+        if (reason_code_) return *reason_code_;
+        return pubrec_reason_code::success;
+    }
+
+    /**
+     * @breif Get properties
+     * @return properties
+     */
+    properties const& props() const {
+        return props_;
+    }
+
+    /**
+     * @brief stream output operator
+     */
+    friend
+    inline std::ostream& operator<<(std::ostream& o, basic_pubrec_packet<PacketIdBytes> const& v) {
+        o <<
+            "v5::pubrec{" <<
+            "pid:" << v.packet_id();
+        if (v.reason_code_) {
+            o << ",rc:" << *v.reason_code_;
+        }
+        if (!v.props().empty()) {
+            o << ",ps:" << v.props();
+        };
+        o << "}";
+        return o;
+    }
+
+private:
+    basic_pubrec_packet(
+        packet_id_t packet_id,
+        std::optional<pubrec_reason_code> reason_code,
+        properties props
+    )
+        : fixed_header_{
+              make_fixed_header(control_packet_type::pubrec, 0b0000)
+          },
+          remaining_length_{
+              PacketIdBytes
+          },
+          packet_id_(packet_id_.capacity()),
+          reason_code_{reason_code},
+          property_length_(async_mqtt::size(props)),
+          props_(force_move(props))
+    {
+        using namespace std::literals;
+        endian_store(packet_id, packet_id_.data());
+
+        auto guard = unique_scope_guard(
+            [&] {
+                auto rb = val_to_variable_bytes(boost::numeric_cast<std::uint32_t>(remaining_length_));
+                for (auto e : rb) {
+                    remaining_length_buf_.push_back(e);
+                }
+            }
+        );
+
+        if (!reason_code_) return;
+        remaining_length_ += 1;
+
+        if (property_length_ == 0) return;
+
+        auto pb = val_to_variable_bytes(boost::numeric_cast<std::uint32_t>(property_length_));
+        for (auto e : pb) {
+            property_length_buf_.push_back(e);
+        }
+
+        for (auto const& prop : props_) {
+            auto id = prop.id();
+            if (!validate_property(property_location::pubrec, id)) {
+                throw make_error(
+                    errc::bad_message,
+                    "v5::pubrec_packet property "s + id_to_str(id) + " is not allowed"
+                );
+            }
+        }
+
+        remaining_length_ += property_length_buf_.size() + property_length_;
+    }
+
+private:
+
+    template <std::size_t PacketIdBytesArg>
+    friend basic_packet_variant<PacketIdBytesArg>
+    async_mqtt::buffer_to_basic_packet_variant(buffer buf, protocol_version ver);
+
+#if defined(ASYNC_MQTT_UNIT_TEST_FOR_PACKET)
+    friend struct ::ut_packet::v5_pubrec;
+    friend struct ::ut_packet::v5_pubrec_pid4;
+    friend struct ::ut_packet::v5_pubrec_pid_only;
+    friend struct ::ut_packet::v5_pubrec_pid_rc;
+    friend struct ::ut_packet::v5_pubrec_prop_len_last;
+#endif // defined(ASYNC_MQTT_UNIT_TEST_FOR_PACKET)
+
+    // private constructor for internal use
     basic_pubrec_packet(buffer buf) {
         // fixed_header
         if (buf.empty()) {
@@ -185,163 +365,6 @@ public:
                 "v5::pubrec_packet properties don't match its length"
             );
         }
-    }
-
-    constexpr control_packet_type type() const {
-        return control_packet_type::pubrec;
-    }
-
-    /**
-     * @brief Create const buffer sequence
-     *        it is for boost asio APIs
-     * @return const buffer sequence
-     */
-    std::vector<as::const_buffer> const_buffer_sequence() const {
-        std::vector<as::const_buffer> ret;
-        ret.reserve(num_of_const_buffer_sequence());
-        ret.emplace_back(as::buffer(&fixed_header_, 1));
-        ret.emplace_back(as::buffer(remaining_length_buf_.data(), remaining_length_buf_.size()));
-
-        ret.emplace_back(as::buffer(packet_id_.data(), packet_id_.size()));
-
-        if (reason_code_) {
-            ret.emplace_back(as::buffer(&*reason_code_, 1));
-
-            if (property_length_buf_.size() != 0) {
-                ret.emplace_back(as::buffer(property_length_buf_.data(), property_length_buf_.size()));
-                auto props_cbs = async_mqtt::const_buffer_sequence(props_);
-                std::move(props_cbs.begin(), props_cbs.end(), std::back_inserter(ret));
-            }
-        }
-
-        return ret;
-    }
-
-    /**
-     * @brief Get packet size.
-     * @return packet size
-     */
-    std::size_t size() const {
-        return
-            1 +                            // fixed header
-            remaining_length_buf_.size() +
-            remaining_length_;
-    }
-
-    /**
-     * @brief Get number of element of const_buffer_sequence
-     * @return number of element of const_buffer_sequence
-     */
-    constexpr std::size_t num_of_const_buffer_sequence() const {
-        return
-            1 +                   // fixed header
-            1 +                   // remaining length
-            1 +                   // packet_id
-            [&] () -> std::size_t {
-                if (reason_code_) {
-                    return
-                        1 +       // reason_code
-                        [&] () -> std::size_t {
-                            if (property_length_buf_.size() == 0) return 0;
-                            return
-                                1 +                   // property length
-                                async_mqtt::num_of_const_buffer_sequence(props_);
-                        }();
-                }
-                return 0;
-            }();
-    }
-
-    /**
-     * @brief Get packet_id.
-     * @return packet_id
-     */
-    packet_id_t packet_id() const {
-        return endian_load<packet_id_t>(packet_id_.data());
-    }
-
-    /**
-     * @breif Get reason code
-     * @return reason_code
-     */
-    pubrec_reason_code code() const {
-        if (reason_code_) return *reason_code_;
-        return pubrec_reason_code::success;
-    }
-
-    /**
-     * @breif Get properties
-     * @return properties
-     */
-    properties const& props() const {
-        return props_;
-    }
-
-    friend
-    inline std::ostream& operator<<(std::ostream& o, basic_pubrec_packet<PacketIdBytes> const& v) {
-        o <<
-            "v5::pubrec{" <<
-            "pid:" << v.packet_id();
-        if (v.reason_code_) {
-            o << ",rc:" << *v.reason_code_;
-        }
-        if (!v.props().empty()) {
-            o << ",ps:" << v.props();
-        };
-        o << "}";
-        return o;
-    }
-
-private:
-    basic_pubrec_packet(
-        packet_id_t packet_id,
-        std::optional<pubrec_reason_code> reason_code,
-        properties props
-    )
-        : fixed_header_{
-              make_fixed_header(control_packet_type::pubrec, 0b0000)
-          },
-          remaining_length_{
-              PacketIdBytes
-          },
-          packet_id_(packet_id_.capacity()),
-          reason_code_{reason_code},
-          property_length_(async_mqtt::size(props)),
-          props_(force_move(props))
-    {
-        using namespace std::literals;
-        endian_store(packet_id, packet_id_.data());
-
-        auto guard = unique_scope_guard(
-            [&] {
-                auto rb = val_to_variable_bytes(boost::numeric_cast<std::uint32_t>(remaining_length_));
-                for (auto e : rb) {
-                    remaining_length_buf_.push_back(e);
-                }
-            }
-        );
-
-        if (!reason_code_) return;
-        remaining_length_ += 1;
-
-        if (property_length_ == 0) return;
-
-        auto pb = val_to_variable_bytes(boost::numeric_cast<std::uint32_t>(property_length_));
-        for (auto e : pb) {
-            property_length_buf_.push_back(e);
-        }
-
-        for (auto const& prop : props_) {
-            auto id = prop.id();
-            if (!validate_property(property_location::pubrec, id)) {
-                throw make_error(
-                    errc::bad_message,
-                    "v5::pubrec_packet property "s + id_to_str(id) + " is not allowed"
-                );
-            }
-        }
-
-        remaining_length_ += property_length_buf_.size() + property_length_;
     }
 
 private:

--- a/include/async_mqtt/packet/v5_suback.hpp
+++ b/include/async_mqtt/packet/v5_suback.hpp
@@ -7,6 +7,7 @@
 #if !defined(ASYNC_MQTT_PACKET_V5_SUBACK_HPP)
 #define ASYNC_MQTT_PACKET_V5_SUBACK_HPP
 
+#include <async_mqtt/buffer_to_packet_variant_fwd.hpp>
 #include <async_mqtt/exception.hpp>
 #include <async_mqtt/buffer.hpp>
 
@@ -77,84 +78,10 @@ public:
         remaining_length_buf_ = val_to_variable_bytes(boost::numeric_cast<std::uint32_t>(remaining_length_));
     }
 
-    basic_suback_packet(buffer buf) {
-        // fixed_header
-        if (buf.empty()) {
-            throw make_error(
-                errc::bad_message,
-                "v5::suback_packet fixed_header doesn't exist"
-            );
-        }
-        fixed_header_ = static_cast<std::uint8_t>(buf.front());
-        buf.remove_prefix(1);
-        auto cpt_opt = get_control_packet_type_with_check(static_cast<std::uint8_t>(fixed_header_));
-        if (!cpt_opt || *cpt_opt != control_packet_type::suback) {
-            throw make_error(
-                errc::bad_message,
-                "v5::suback_packet fixed_header is invalid"
-            );
-        }
-
-        // remaining_length
-        if (auto vl_opt = insert_advance_variable_length(buf, remaining_length_buf_)) {
-            remaining_length_ = *vl_opt;
-        }
-        else {
-            throw make_error(errc::bad_message, "v5::suback_packet remaining length is invalid");
-        }
-        if (remaining_length_ != buf.size()) {
-            throw make_error(errc::bad_message, "v5::suback_packet remaining length doesn't match buf.size()");
-        }
-
-        // packet_id
-        if (!copy_advance(buf, packet_id_)) {
-            throw make_error(
-                errc::bad_message,
-                "v5::suback_packet packet_id doesn't exist"
-            );
-        }
-
-        // property
-        auto it = buf.begin();
-        if (auto pl_opt = variable_bytes_to_val(it, buf.end())) {
-            property_length_ = *pl_opt;
-            std::copy(buf.begin(), it, std::back_inserter(property_length_buf_));
-            buf.remove_prefix(std::size_t(std::distance(buf.begin(), it)));
-            if (buf.size() < property_length_) {
-                throw make_error(
-                    errc::bad_message,
-                    "v5::suback_packet properties_don't match its length"
-                );
-            }
-            auto prop_buf = buf.substr(0, property_length_);
-            props_ = make_properties(prop_buf, property_location::suback);
-            buf.remove_prefix(property_length_);
-        }
-        else {
-            throw make_error(
-                errc::bad_message,
-                "v5::suback_packet property_length is invalid"
-            );
-        }
-
-        if (remaining_length_ == 0) {
-            throw make_error(errc::bad_message, "v5::suback_packet doesn't have entries");
-        }
-
-        while (!buf.empty()) {
-            // reason_code
-            if (buf.empty()) {
-                throw make_error(
-                    errc::bad_message,
-                    "v5::suback_packet suback_reason_code  doesn't exist"
-                );
-            }
-            auto rc = static_cast<suback_reason_code>(buf.front());
-            entries_.emplace_back(rc);
-            buf.remove_prefix(1);
-        }
-    }
-
+    /**
+     * @brief Get MQTT control packet type
+     * @return control packet type
+     */
     constexpr control_packet_type type() const {
         return control_packet_type::suback;
     }
@@ -237,6 +164,96 @@ public:
     }
 
 private:
+
+    template <std::size_t PacketIdBytesArg>
+    friend basic_packet_variant<PacketIdBytesArg>
+    async_mqtt::buffer_to_basic_packet_variant(buffer buf, protocol_version ver);
+
+#if defined(ASYNC_MQTT_UNIT_TEST_FOR_PACKET)
+    friend struct ::ut_packet::v5_suback;
+    friend struct ::ut_packet::v5_suback_pid4;
+#endif // defined(ASYNC_MQTT_UNIT_TEST_FOR_PACKET)
+
+    // private constructor for internal use
+    basic_suback_packet(buffer buf) {
+        // fixed_header
+        if (buf.empty()) {
+            throw make_error(
+                errc::bad_message,
+                "v5::suback_packet fixed_header doesn't exist"
+            );
+        }
+        fixed_header_ = static_cast<std::uint8_t>(buf.front());
+        buf.remove_prefix(1);
+        auto cpt_opt = get_control_packet_type_with_check(static_cast<std::uint8_t>(fixed_header_));
+        if (!cpt_opt || *cpt_opt != control_packet_type::suback) {
+            throw make_error(
+                errc::bad_message,
+                "v5::suback_packet fixed_header is invalid"
+            );
+        }
+
+        // remaining_length
+        if (auto vl_opt = insert_advance_variable_length(buf, remaining_length_buf_)) {
+            remaining_length_ = *vl_opt;
+        }
+        else {
+            throw make_error(errc::bad_message, "v5::suback_packet remaining length is invalid");
+        }
+        if (remaining_length_ != buf.size()) {
+            throw make_error(errc::bad_message, "v5::suback_packet remaining length doesn't match buf.size()");
+        }
+
+        // packet_id
+        if (!copy_advance(buf, packet_id_)) {
+            throw make_error(
+                errc::bad_message,
+                "v5::suback_packet packet_id doesn't exist"
+            );
+        }
+
+        // property
+        auto it = buf.begin();
+        if (auto pl_opt = variable_bytes_to_val(it, buf.end())) {
+            property_length_ = *pl_opt;
+            std::copy(buf.begin(), it, std::back_inserter(property_length_buf_));
+            buf.remove_prefix(std::size_t(std::distance(buf.begin(), it)));
+            if (buf.size() < property_length_) {
+                throw make_error(
+                    errc::bad_message,
+                    "v5::suback_packet properties_don't match its length"
+                );
+            }
+            auto prop_buf = buf.substr(0, property_length_);
+            props_ = make_properties(prop_buf, property_location::suback);
+            buf.remove_prefix(property_length_);
+        }
+        else {
+            throw make_error(
+                errc::bad_message,
+                "v5::suback_packet property_length is invalid"
+            );
+        }
+
+        if (remaining_length_ == 0) {
+            throw make_error(errc::bad_message, "v5::suback_packet doesn't have entries");
+        }
+
+        while (!buf.empty()) {
+            // reason_code
+            if (buf.empty()) {
+                throw make_error(
+                    errc::bad_message,
+                    "v5::suback_packet suback_reason_code  doesn't exist"
+                );
+            }
+            auto rc = static_cast<suback_reason_code>(buf.front());
+            entries_.emplace_back(rc);
+            buf.remove_prefix(1);
+        }
+    }
+
+private:
     std::uint8_t fixed_header_;
     std::vector<suback_reason_code> entries_;
     static_vector<char, PacketIdBytes> packet_id_ = static_vector<char, PacketIdBytes>(PacketIdBytes);
@@ -248,6 +265,9 @@ private:
     properties props_;
 };
 
+/**
+ * @brief stream output operator
+ */
 template <std::size_t PacketIdBytes>
 inline std::ostream& operator<<(std::ostream& o, basic_suback_packet<PacketIdBytes> const& v) {
     o <<

--- a/include/async_mqtt/packet/v5_subscribe.hpp
+++ b/include/async_mqtt/packet/v5_subscribe.hpp
@@ -9,6 +9,7 @@
 
 #include <boost/numeric/conversion/cast.hpp>
 
+#include <async_mqtt/buffer_to_packet_variant_fwd.hpp>
 #include <async_mqtt/exception.hpp>
 #include <async_mqtt/buffer.hpp>
 
@@ -144,6 +145,110 @@ public:
         remaining_length_buf_ = val_to_variable_bytes(boost::numeric_cast<std::uint32_t>(remaining_length_));
     }
 
+    /**
+     * @brief Get MQTT control packet type
+     * @return control packet type
+     */
+    constexpr control_packet_type type() const {
+        return control_packet_type::subscribe;
+    }
+
+    /**
+     * @brief Create const buffer sequence
+     *        it is for boost asio APIs
+     * @return const buffer sequence
+     */
+    std::vector<as::const_buffer> const_buffer_sequence() const {
+        std::vector<as::const_buffer> ret;
+        ret.reserve(num_of_const_buffer_sequence());
+
+        ret.emplace_back(as::buffer(&fixed_header_, 1));
+
+        ret.emplace_back(as::buffer(remaining_length_buf_.data(), remaining_length_buf_.size()));
+
+        ret.emplace_back(as::buffer(packet_id_.data(), packet_id_.size()));
+
+        ret.emplace_back(as::buffer(property_length_buf_.data(), property_length_buf_.size()));
+        auto props_cbs = async_mqtt::const_buffer_sequence(props_);
+        std::move(props_cbs.begin(), props_cbs.end(), std::back_inserter(ret));
+
+            BOOST_ASSERT(entries_.size() == topic_length_buf_entries_.size());
+        auto it = topic_length_buf_entries_.begin();
+        for (auto const& e : entries_) {
+            ret.emplace_back(as::buffer(it->data(), it->size()));
+            ret.emplace_back(as::buffer(e.all_topic()));
+            ret.emplace_back(as::buffer(&e.opts(), 1));
+            ++it;
+        }
+
+        return ret;
+    }
+
+    /**
+     * @brief Get packet size.
+     * @return packet size
+     */
+    std::size_t size() const {
+        return
+            1 +                            // fixed header
+            remaining_length_buf_.size() +
+            remaining_length_;
+    }
+
+    /**
+     * @brief Get number of element of const_buffer_sequence
+     * @return number of element of const_buffer_sequence
+     */
+    std::size_t num_of_const_buffer_sequence() const {
+        return
+            1 +                   // fixed header
+            1 +                   // remaining length
+            1 +                   // packet id
+            [&] () -> std::size_t {
+                if (property_length_buf_.size() == 0) return 0;
+                return
+                    1 +                   // property length
+                    async_mqtt::num_of_const_buffer_sequence(props_);
+            }() +
+            entries_.size() * 3;  // topic name length, topic name, opts
+    }
+
+    /**
+     * @brief Get packet_id.
+     * @return packet_id
+     */
+    packet_id_t packet_id() const {
+        return endian_load<packet_id_t>(packet_id_.data());
+    }
+
+    /**
+     * @brief Get entries
+     * @return entries
+     */
+    std::vector<topic_subopts> const& entries() const {
+        return entries_;
+    }
+
+    /**
+     * @breif Get properties
+     * @return properties
+     */
+    properties const& props() const {
+        return props_;
+    }
+
+private:
+
+    template <std::size_t PacketIdBytesArg>
+    friend basic_packet_variant<PacketIdBytesArg>
+    async_mqtt::buffer_to_basic_packet_variant(buffer buf, protocol_version ver);
+
+#if defined(ASYNC_MQTT_UNIT_TEST_FOR_PACKET)
+    friend struct ::ut_packet::v5_subscribe;
+    friend struct ::ut_packet::v5_subscribe_pid4;
+#endif // defined(ASYNC_MQTT_UNIT_TEST_FOR_PACKET)
+
+    // private constructor for internal use
     basic_subscribe_packet(buffer buf) {
         // fixed_header
         if (buf.empty()) {
@@ -277,97 +382,9 @@ public:
                 );
                 break;
             }
-            entries_.emplace_back(force_move(topic), opts);
+            entries_.emplace_back(std::string{topic}, opts);
             buf.remove_prefix(1);
         }
-    }
-
-    constexpr control_packet_type type() const {
-        return control_packet_type::subscribe;
-    }
-
-    /**
-     * @brief Create const buffer sequence
-     *        it is for boost asio APIs
-     * @return const buffer sequence
-     */
-    std::vector<as::const_buffer> const_buffer_sequence() const {
-        std::vector<as::const_buffer> ret;
-        ret.reserve(num_of_const_buffer_sequence());
-
-        ret.emplace_back(as::buffer(&fixed_header_, 1));
-
-        ret.emplace_back(as::buffer(remaining_length_buf_.data(), remaining_length_buf_.size()));
-
-        ret.emplace_back(as::buffer(packet_id_.data(), packet_id_.size()));
-
-        ret.emplace_back(as::buffer(property_length_buf_.data(), property_length_buf_.size()));
-        auto props_cbs = async_mqtt::const_buffer_sequence(props_);
-        std::move(props_cbs.begin(), props_cbs.end(), std::back_inserter(ret));
-
-            BOOST_ASSERT(entries_.size() == topic_length_buf_entries_.size());
-        auto it = topic_length_buf_entries_.begin();
-        for (auto const& e : entries_) {
-            ret.emplace_back(as::buffer(it->data(), it->size()));
-            ret.emplace_back(as::buffer(e.all_topic()));
-            ret.emplace_back(as::buffer(&e.opts(), 1));
-            ++it;
-        }
-
-        return ret;
-    }
-
-    /**
-     * @brief Get packet size.
-     * @return packet size
-     */
-    std::size_t size() const {
-        return
-            1 +                            // fixed header
-            remaining_length_buf_.size() +
-            remaining_length_;
-    }
-
-    /**
-     * @brief Get number of element of const_buffer_sequence
-     * @return number of element of const_buffer_sequence
-     */
-    std::size_t num_of_const_buffer_sequence() const {
-        return
-            1 +                   // fixed header
-            1 +                   // remaining length
-            1 +                   // packet id
-            [&] () -> std::size_t {
-                if (property_length_buf_.size() == 0) return 0;
-                return
-                    1 +                   // property length
-                    async_mqtt::num_of_const_buffer_sequence(props_);
-            }() +
-            entries_.size() * 3;  // topic name length, topic name, opts
-    }
-
-    /**
-     * @brief Get packet_id.
-     * @return packet_id
-     */
-    packet_id_t packet_id() const {
-        return endian_load<packet_id_t>(packet_id_.data());
-    }
-
-    /**
-     * @brief Get entries
-     * @return entries
-     */
-    std::vector<topic_subopts> const& entries() const {
-        return entries_;
-    }
-
-    /**
-     * @breif Get properties
-     * @return properties
-     */
-    properties const& props() const {
-        return props_;
     }
 
 private:
@@ -383,6 +400,9 @@ private:
     properties props_;
 };
 
+/**
+ * @brief stream output operator
+ */
 template <std::size_t PacketIdBytes>
 inline std::ostream& operator<<(std::ostream& o, basic_subscribe_packet<PacketIdBytes> const& v) {
     o <<

--- a/include/async_mqtt/packet/v5_unsubscribe.hpp
+++ b/include/async_mqtt/packet/v5_unsubscribe.hpp
@@ -9,6 +9,7 @@
 
 #include <boost/numeric/conversion/cast.hpp>
 
+#include <async_mqtt/buffer_to_packet_variant_fwd.hpp>
 #include <async_mqtt/exception.hpp>
 #include <async_mqtt/buffer.hpp>
 
@@ -111,6 +112,109 @@ public:
         remaining_length_buf_ = val_to_variable_bytes(boost::numeric_cast<std::uint32_t>(remaining_length_));
     }
 
+    /**
+     * @brief Get MQTT control packet type
+     * @return control packet type
+     */
+    constexpr control_packet_type type() const {
+        return control_packet_type::unsubscribe;
+    }
+
+    /**
+     * @brief Create const buffer sequence
+     *        it is for boost asio APIs
+     * @return const buffer sequence
+     */
+    std::vector<as::const_buffer> const_buffer_sequence() const {
+        std::vector<as::const_buffer> ret;
+        ret.reserve(num_of_const_buffer_sequence());
+
+        ret.emplace_back(as::buffer(&fixed_header_, 1));
+
+        ret.emplace_back(as::buffer(remaining_length_buf_.data(), remaining_length_buf_.size()));
+
+        ret.emplace_back(as::buffer(packet_id_.data(), packet_id_.size()));
+
+        ret.emplace_back(as::buffer(property_length_buf_.data(), property_length_buf_.size()));
+        auto props_cbs = async_mqtt::const_buffer_sequence(props_);
+        std::move(props_cbs.begin(), props_cbs.end(), std::back_inserter(ret));
+
+            BOOST_ASSERT(entries_.size() == topic_length_buf_entries_.size());
+        auto it = topic_length_buf_entries_.begin();
+        for (auto const& e : entries_) {
+            ret.emplace_back(as::buffer(it->data(), it->size()));
+            ret.emplace_back(as::buffer(e.all_topic()));
+            ++it;
+        }
+
+        return ret;
+    }
+
+    /**
+     * @brief Get packet size.
+     * @return packet size
+     */
+    std::size_t size() const {
+        return
+            1 +                            // fixed header
+            remaining_length_buf_.size() +
+            remaining_length_;
+    }
+
+    /**
+     * @brief Get number of element of const_buffer_sequence
+     * @return number of element of const_buffer_sequence
+     */
+    std::size_t num_of_const_buffer_sequence() const {
+        return
+            1 +                   // fixed header
+            1 +                   // remaining length
+            1 +                   // packet id
+            [&] () -> std::size_t {
+                if (property_length_buf_.size() == 0) return 0;
+                return
+                    1 +                   // property length
+                    async_mqtt::num_of_const_buffer_sequence(props_);
+            }() +
+            entries_.size() * 2;  // topic name length, topic name
+    }
+
+    /**
+     * @brief Get packet_id.
+     * @return packet_id
+     */
+    packet_id_t packet_id() const {
+        return endian_load<packet_id_t>(packet_id_.data());
+    }
+
+    /**
+     * @brief Get entries
+     * @return entries
+     */
+    std::vector<topic_sharename> const& entries() const {
+        return entries_;
+    }
+
+    /**
+     * @breif Get properties
+     * @return properties
+     */
+    properties const& props() const {
+        return props_;
+    }
+
+private:
+
+    template <std::size_t PacketIdBytesArg>
+    friend basic_packet_variant<PacketIdBytesArg>
+    async_mqtt::buffer_to_basic_packet_variant(buffer buf, protocol_version ver);
+
+#if defined(ASYNC_MQTT_UNIT_TEST_FOR_PACKET)
+    friend struct ::ut_packet::v5_unsubscribe;
+    friend struct ::ut_packet::v5_unsubscribe_pid4;
+#endif // defined(ASYNC_MQTT_UNIT_TEST_FOR_PACKET)
+
+    // private constructor for internal use
     basic_unsubscribe_packet(buffer buf) {
         // fixed_header
         if (buf.empty()) {
@@ -202,95 +306,8 @@ public:
                 );
             }
             buf.remove_prefix(topic_length);
-            entries_.emplace_back(force_move(topic));
+            entries_.emplace_back(std::string{topic});
         }
-    }
-
-    constexpr control_packet_type type() const {
-        return control_packet_type::unsubscribe;
-    }
-
-    /**
-     * @brief Create const buffer sequence
-     *        it is for boost asio APIs
-     * @return const buffer sequence
-     */
-    std::vector<as::const_buffer> const_buffer_sequence() const {
-        std::vector<as::const_buffer> ret;
-        ret.reserve(num_of_const_buffer_sequence());
-
-        ret.emplace_back(as::buffer(&fixed_header_, 1));
-
-        ret.emplace_back(as::buffer(remaining_length_buf_.data(), remaining_length_buf_.size()));
-
-        ret.emplace_back(as::buffer(packet_id_.data(), packet_id_.size()));
-
-        ret.emplace_back(as::buffer(property_length_buf_.data(), property_length_buf_.size()));
-        auto props_cbs = async_mqtt::const_buffer_sequence(props_);
-        std::move(props_cbs.begin(), props_cbs.end(), std::back_inserter(ret));
-
-            BOOST_ASSERT(entries_.size() == topic_length_buf_entries_.size());
-        auto it = topic_length_buf_entries_.begin();
-        for (auto const& e : entries_) {
-            ret.emplace_back(as::buffer(it->data(), it->size()));
-            ret.emplace_back(as::buffer(e.all_topic()));
-            ++it;
-        }
-
-        return ret;
-    }
-
-    /**
-     * @brief Get packet size.
-     * @return packet size
-     */
-    std::size_t size() const {
-        return
-            1 +                            // fixed header
-            remaining_length_buf_.size() +
-            remaining_length_;
-    }
-
-    /**
-     * @brief Get number of element of const_buffer_sequence
-     * @return number of element of const_buffer_sequence
-     */
-    std::size_t num_of_const_buffer_sequence() const {
-        return
-            1 +                   // fixed header
-            1 +                   // remaining length
-            1 +                   // packet id
-            [&] () -> std::size_t {
-                if (property_length_buf_.size() == 0) return 0;
-                return
-                    1 +                   // property length
-                    async_mqtt::num_of_const_buffer_sequence(props_);
-            }() +
-            entries_.size() * 2;  // topic name length, topic name
-    }
-
-    /**
-     * @brief Get packet_id.
-     * @return packet_id
-     */
-    packet_id_t packet_id() const {
-        return endian_load<packet_id_t>(packet_id_.data());
-    }
-
-    /**
-     * @brief Get entries
-     * @return entries
-     */
-    std::vector<topic_sharename> const& entries() const {
-        return entries_;
-    }
-
-    /**
-     * @breif Get properties
-     * @return properties
-     */
-    properties const& props() const {
-        return props_;
     }
 
 private:
@@ -306,6 +323,9 @@ private:
     properties props_;
 };
 
+/**
+ * @brief stream output operator
+ */
 template <std::size_t PacketIdBytes>
 inline std::ostream& operator<<(std::ostream& o, basic_unsubscribe_packet<PacketIdBytes> const& v) {
     o <<

--- a/include/async_mqtt/packet/will.hpp
+++ b/include/async_mqtt/packet/will.hpp
@@ -27,42 +27,110 @@ public:
      * @param qos
      *        qos
      */
-    will(buffer topic,
-         buffer message,
-         pub::opts pubopts = {},
-         properties props = {}
-    )
-        :topic_{force_move(topic)},
-         message_{force_move(message)},
-         pubopts_{pubopts},
-         props_(force_move(props))
+    template <
+        typename StringViewLikeTopic,
+        typename StringViewLikeMessage,
+        std::enable_if_t<
+            std::is_convertible_v<std::decay_t<StringViewLikeTopic>, std::string_view> &&
+            std::is_convertible_v<std::decay_t<StringViewLikeMessage>, std::string_view>,
+            std::nullptr_t
+        > = nullptr
+    >
+    will(
+        StringViewLikeTopic&& topic,
+        StringViewLikeMessage&& message,
+        pub::opts pubopts = {},
+        properties props = {}
+    ) :
+        topic_{std::string{std::forward<StringViewLikeTopic>(topic)}},
+        message_{std::string{std::forward<StringViewLikeMessage>(message)}},
+        pubopts_{pubopts},
+        props_(force_move(props))
     {}
 
-    constexpr buffer const& topic() const {
+    /**
+     * @brief Get topic
+     * @return topic
+     */
+    std::string topic() const {
+        return std::string{topic_};
+    }
+
+    /**
+     * @brief Get topic as a buffer
+     * @return topic
+     */
+    buffer const& topic_as_buffer() const {
         return topic_;
     }
-    constexpr buffer& topic() {
+
+    /**
+     * @brief Get topic as a buffer
+     * @return topic
+     */
+    buffer& topic_as_buffer() {
         return topic_;
     }
-    constexpr buffer const& message() const {
+
+    /**
+     * @brief Get message
+     * @return message
+     */
+    std::string message() const {
+        return std::string{message_};
+    }
+
+    /**
+     * @brief Get message as a buffer
+     * @return message
+     */
+    buffer const& message_as_buffer() const {
         return message_;
     }
-    constexpr buffer& message() {
+
+    /**
+     * @brief Get message as a buffer
+     * @return message
+     */
+    buffer& message_as_buffer() {
         return message_;
     }
+
+    /**
+     * @brief Get retain
+     * @return retain
+     */
     constexpr pub::retain get_retain() const {
         return pubopts_.get_retain();
     }
+
+    /**
+     * @brief Get QoS
+     * @return QoS
+     */
     constexpr qos get_qos() const {
         return pubopts_.get_qos();
     }
+
+    /**
+     * @brief Get properties
+     * @return properties
+     */
     constexpr properties const& props() const {
         return props_;
     }
+
+    /**
+     * @brief Get properties
+     * @return properties
+     */
     constexpr properties& props() {
         return props_;
     }
 
+    /**
+     * @brief equality comparison operator
+     */
     friend
     bool operator==(will const& lhs, will const& rhs) {
         return
@@ -70,6 +138,9 @@ public:
             std::tie(rhs.topic_, rhs.message_, rhs.pubopts_, rhs.props_);
     }
 
+    /**
+     * @brief less than comparison operator
+     */
     friend
     bool operator<(will const& lhs, will const& rhs) {
         return
@@ -84,10 +155,13 @@ private:
     properties props_;
 };
 
+/**
+ * @brief stream output operator
+ */
 inline std::ostream& operator<<(std::ostream& o, will const& val) {
     o << "{" <<
-        "topic:" << val.topic() << "," <<
-        "message:" << json_like_out(val.message()) << "," <<
+        "topic:" << val.topic_as_buffer() << "," <<
+        "message:" << json_like_out(val.message_as_buffer()) << "," <<
         "qos:" << val.get_qos() << "," <<
         "retain:" << val.get_retain();
     if (!val.props().empty()) {

--- a/include/async_mqtt/util/json_like_out.hpp
+++ b/include/async_mqtt/util/json_like_out.hpp
@@ -15,56 +15,72 @@
 namespace async_mqtt {
 
 struct json_like_out_t {
-    json_like_out_t(buffer const& buf): buf{buf} {}
+    template <
+        typename StringViewLike,
+        std::enable_if_t<
+            std::is_convertible_v<std::decay_t<StringViewLike>, std::string_view>,
+            std::nullptr_t
+        > = nullptr
+    >
+    json_like_out_t(StringViewLike const& sv): sv {sv} {}
 
-    buffer const& buf;
+    friend std::ostream& operator<<(std::ostream& o, json_like_out_t const& v) {
+        for (char c : v.sv) {
+            switch (c) {
+            case '\\':
+                o << "\\\\";
+                break;
+            case '"':
+                o << "\\\"";
+                break;
+            case '/':
+                o << "\\/";
+                break;
+            case '\b':
+                o << "\\b";
+                break;
+            case '\f':
+                o << "\\f";
+                break;
+            case '\n':
+                o << "\\n";
+                break;
+            case '\r':
+                o << "\\r";
+                break;
+            case '\t':
+                o << "\\t";
+                break;
+            default: {
+                unsigned int code = static_cast<unsigned int>(c);
+                if (code < 0x20 || code >= 0x7f) {
+                    std::ios::fmtflags flags(o.flags());
+                    o << "\\u" << std::hex << std::setw(4) << std::setfill('0') << (code & 0xff);
+                    o.flags(flags);
+                }
+                else {
+                    o << c;
+                }
+            } break;
+            }
+        }
+        return o;
+    }
+
+private:
+    std::string_view sv;
 };
 
-inline std::ostream& operator<<(std::ostream& o, json_like_out_t const& v) {
-    for (char c : v.buf) {
-        switch (c) {
-        case '\\':
-            o << "\\\\";
-            break;
-        case '"':
-            o << "\\\"";
-            break;
-        case '/':
-            o << "\\/";
-            break;
-        case '\b':
-            o << "\\b";
-            break;
-        case '\f':
-            o << "\\f";
-            break;
-        case '\n':
-            o << "\\n";
-            break;
-        case '\r':
-            o << "\\r";
-            break;
-        case '\t':
-            o << "\\t";
-            break;
-        default: {
-            unsigned int code = static_cast<unsigned int>(c);
-            if (code < 0x20 || code >= 0x7f) {
-                std::ios::fmtflags flags(o.flags());
-                o << "\\u" << std::hex << std::setw(4) << std::setfill('0') << (code & 0xff);
-                o.flags(flags);
-            }
-            else {
-                o << c;
-            }
-        } break;
-        }
-    }
-    return o;
-}
 
-inline json_like_out_t json_like_out(buffer const& buf) {
-    return json_like_out_t{buf};
+template <
+    typename StringViewLike,
+    std::enable_if_t<
+        std::is_convertible_v<std::decay_t<StringViewLike>, std::string_view>,
+        std::nullptr_t
+    > = nullptr
+>
+inline json_like_out_t json_like_out(StringViewLike const& sv) {
+    return json_like_out_t{sv};
 }
 
 } // namespace async_mqtt

--- a/test/system/coro_base.hpp
+++ b/test/system/coro_base.hpp
@@ -16,7 +16,6 @@
 
 namespace as = boost::asio;
 namespace am = async_mqtt;
-using namespace am::literals;
 
 template <typename Ep, std::size_t PidBytes = 2>
 struct coro_base : as::coroutine {

--- a/test/system/st_auth.cpp
+++ b/test/system/st_auth.cpp
@@ -15,7 +15,6 @@
 BOOST_AUTO_TEST_SUITE(st_auth)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 namespace as = boost::asio;
 
 BOOST_AUTO_TEST_CASE(fail_plain) {
@@ -46,10 +45,10 @@ BOOST_AUTO_TEST_CASE(fail_plain) {
                     am::v3_1_1::connect_packet{
                         true,   // clean_session
                         0x1234, // keep_alive
-                        "cid1"_mb,
+                        "cid1",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "invalid_pass"_mb
+                        "u1",
+                        "invalid_pass"
                     },
                     *this
                 );
@@ -106,10 +105,10 @@ BOOST_AUTO_TEST_CASE(success_digest) {
                     am::v3_1_1::connect_packet{
                         true,   // clean_session
                         0x1234, // keep_alive
-                        "cid1"_mb,
+                        "cid1",
                         std::nullopt, // will
-                        "u3"_mb,
-                        "passforu3"_mb // plain
+                        "u3",
+                        "passforu3" // plain
                     },
                     *this
                 );
@@ -166,10 +165,10 @@ BOOST_AUTO_TEST_CASE(fail_digest) {
                     am::v3_1_1::connect_packet{
                         true,   // clean_session
                         0x1234, // keep_alive
-                        "cid1"_mb,
+                        "cid1",
                         std::nullopt, // will
-                        "u3"_mb,
-                        "invalid_pass"_mb
+                        "u3",
+                        "invalid_pass"
                     },
                     *this
                 );
@@ -226,10 +225,10 @@ BOOST_AUTO_TEST_CASE(send_auth) {
                     am::v5::connect_packet{
                         true,   // clean_start
                         0, // keep_alive
-                        "cid1"_mb,
+                        "cid1",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );

--- a/test/system/st_conflict_cid.cpp
+++ b/test/system/st_conflict_cid.cpp
@@ -15,7 +15,6 @@
 BOOST_AUTO_TEST_SUITE(st_conflict_cid)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 namespace as = boost::asio;
 
 BOOST_AUTO_TEST_CASE(v311_cs1to1) {
@@ -54,10 +53,10 @@ BOOST_AUTO_TEST_CASE(v311_cs1to1) {
                     am::v3_1_1::connect_packet{
                         true,   // clean_session
                         0,
-                        "cid1"_mb,
+                        "cid1",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -83,10 +82,10 @@ BOOST_AUTO_TEST_CASE(v311_cs1to1) {
                     am::v3_1_1::connect_packet{
                         true,   // clean_session
                         0,
-                        "cid1"_mb,
+                        "cid1",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -151,10 +150,10 @@ BOOST_AUTO_TEST_CASE(v311_cs0to1) {
                     am::v3_1_1::connect_packet{
                         false,   // clean_session
                         0,
-                        "cid1"_mb,
+                        "cid1",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -180,10 +179,10 @@ BOOST_AUTO_TEST_CASE(v311_cs0to1) {
                     am::v3_1_1::connect_packet{
                         true,   // clean_session
                         0,
-                        "cid1"_mb,
+                        "cid1",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -248,10 +247,10 @@ BOOST_AUTO_TEST_CASE(v311_cs0to0) {
                     am::v3_1_1::connect_packet{
                         false,   // clean_session
                         0,
-                        "cid1"_mb,
+                        "cid1",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -277,10 +276,10 @@ BOOST_AUTO_TEST_CASE(v311_cs0to0) {
                     am::v3_1_1::connect_packet{
                         false,   // clean_session
                         0,
-                        "cid1"_mb,
+                        "cid1",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -345,10 +344,10 @@ BOOST_AUTO_TEST_CASE(v311_cs0offto1) {
                     am::v3_1_1::connect_packet{
                         false,   // clean_session
                         0,
-                        "cid1"_mb,
+                        "cid1",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -375,10 +374,10 @@ BOOST_AUTO_TEST_CASE(v311_cs0offto1) {
                     am::v3_1_1::connect_packet{
                         true,   // clean_session
                         0,
-                        "cid1"_mb,
+                        "cid1",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );

--- a/test/system/st_cpp20coro_client.cpp
+++ b/test/system/st_cpp20coro_client.cpp
@@ -14,7 +14,6 @@
 BOOST_AUTO_TEST_SUITE(st_cpp20coro_client)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 namespace as = boost::asio;
 
 using namespace am;
@@ -49,10 +48,10 @@ BOOST_AUTO_TEST_CASE(v311) {
                 am::v3_1_1::connect_packet{
                     true,   // clean_session
                     0,      // keep_alive
-                    "cid1"_mb,
+                    "cid1",
                     std::nullopt, // will
-                    "u1"_mb,
-                    "passforu1"_mb
+                    "u1",
+                    "passforu1"
                 },
                 as::as_tuple(as::use_awaitable)
             );
@@ -64,9 +63,9 @@ BOOST_AUTO_TEST_CASE(v311) {
 
             // MQTT send subscribe and wait suback
             std::vector<am::topic_subopts> sub_entry{
-                {"topic1"_mb, am::qos::at_most_once},
-                {"topic2"_mb, am::qos::at_least_once},
-                {"topic3"_mb, am::qos::exactly_once},
+                {"topic1", am::qos::at_most_once},
+                {"topic2", am::qos::at_least_once},
+                {"topic3", am::qos::exactly_once},
             };
             auto pid_sub_opt = amcl.acquire_unique_packet_id();
             BOOST_CHECK(pid_sub_opt);
@@ -94,8 +93,8 @@ BOOST_AUTO_TEST_CASE(v311) {
             // MQTT publish QoS0 and wait response (socket write complete)
             auto [ec_pub0, pubres0] = co_await amcl.publish(
                 am::v3_1_1::publish_packet{
-                    "topic1"_mb,
-                    "payload1"_mb,
+                    "topic1",
+                    "payload1",
                     am::qos::at_most_once
                 },
                 as::as_tuple(as::use_awaitable)
@@ -110,8 +109,8 @@ BOOST_AUTO_TEST_CASE(v311) {
             auto [ec_pub1, pubres1] = co_await amcl.publish(
                 am::v3_1_1::publish_packet{
                     *pid_pub1_opt,
-                    "topic1"_mb,
-                    "payload1"_mb,
+                    "topic1",
+                    "payload1",
                     am::qos::at_least_once
                 },
                 as::as_tuple(as::use_awaitable)
@@ -129,8 +128,8 @@ BOOST_AUTO_TEST_CASE(v311) {
             auto [ec_pub2, pubres2] = co_await amcl.publish(
                 am::v3_1_1::publish_packet{
                     pid_pub2,
-                    "topic1"_mb,
-                    "payload1"_mb,
+                    "topic1",
+                    "payload1",
                     am::qos::exactly_once
                 },
                 as::as_tuple(as::use_awaitable)
@@ -148,9 +147,9 @@ BOOST_AUTO_TEST_CASE(v311) {
 
             // MQTT send unsubscribe and wait unsuback
             std::vector<am::topic_sharename> unsub_entry{
-                {"topic1"_mb},
-                {"topic2"_mb},
-                {"topic3"_mb},
+                {"topic1"},
+                {"topic2"},
+                {"topic3"},
             };
             auto pid_unsub_opt = amcl.acquire_unique_packet_id();
             BOOST_CHECK(pid_unsub_opt);
@@ -217,10 +216,10 @@ BOOST_AUTO_TEST_CASE(v5) {
                 am::v5::connect_packet{
                     true,   // clean_session
                     0,      // keep_alive
-                    "cid1"_mb,
+                    "cid1",
                     std::nullopt, // will
-                    "u1"_mb,
-                    "passforu1"_mb
+                    "u1",
+                    "passforu1"
                 },
                 as::as_tuple(as::use_awaitable)
             );
@@ -239,9 +238,9 @@ BOOST_AUTO_TEST_CASE(v5) {
 
             // MQTT send subscribe and wait suback
             std::vector<am::topic_subopts> sub_entry{
-                {"topic1"_mb, am::qos::at_most_once},
-                {"topic2"_mb, am::qos::at_least_once},
-                {"topic3"_mb, am::qos::exactly_once},
+                {"topic1", am::qos::at_most_once},
+                {"topic2", am::qos::at_least_once},
+                {"topic3", am::qos::exactly_once},
             };
             auto pid_sub_opt = amcl.acquire_unique_packet_id();
             BOOST_CHECK(pid_sub_opt);
@@ -269,8 +268,8 @@ BOOST_AUTO_TEST_CASE(v5) {
             // MQTT publish QoS0 and wait response (socket write complete)
             auto [ec_pub0, pubres0] = co_await amcl.publish(
                 am::v5::publish_packet{
-                    "topic1"_mb,
-                    "payload1"_mb,
+                    "topic1",
+                    "payload1",
                     am::qos::at_most_once
                 },
                 as::as_tuple(as::use_awaitable)
@@ -285,8 +284,8 @@ BOOST_AUTO_TEST_CASE(v5) {
             auto [ec_pub1, pubres1] = co_await amcl.publish(
                 am::v5::publish_packet{
                     *pid_pub1_opt,
-                    "topic2"_mb,
-                    "payload2"_mb,
+                    "topic2",
+                    "payload2",
                     am::qos::at_least_once
                 },
                 as::as_tuple(as::use_awaitable)
@@ -304,8 +303,8 @@ BOOST_AUTO_TEST_CASE(v5) {
             auto [ec_pub2, pubres2] = co_await amcl.publish(
                 am::v5::publish_packet{
                     pid_pub2,
-                    "topic3"_mb,
-                    "payload3"_mb,
+                    "topic3",
+                    "payload3",
                     am::qos::exactly_once
                 },
                 as::as_tuple(as::use_awaitable)
@@ -323,9 +322,9 @@ BOOST_AUTO_TEST_CASE(v5) {
 
             // MQTT send unsubscribe and wait unsuback
             std::vector<am::topic_sharename> unsub_entry{
-                {"topic1"_mb},
-                {"topic2"_mb},
-                {"topic3"_mb},
+                {"topic1"},
+                {"topic2"},
+                {"topic3"},
             };
             auto pid_unsub_opt = amcl.acquire_unique_packet_id();
             BOOST_CHECK(pid_unsub_opt);

--- a/test/system/st_gencid.cpp
+++ b/test/system/st_gencid.cpp
@@ -15,7 +15,6 @@
 BOOST_AUTO_TEST_SUITE(st_gencid)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 namespace as = boost::asio;
 
 BOOST_AUTO_TEST_CASE(v311_cs1) {
@@ -46,10 +45,10 @@ BOOST_AUTO_TEST_CASE(v311_cs1) {
                     am::v3_1_1::connect_packet{
                         true,   // clean_session
                         0,
-                        ""_mb,
+                        "",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -105,10 +104,10 @@ BOOST_AUTO_TEST_CASE(v311_cs0) {
                     am::v3_1_1::connect_packet{
                         false,   // clean_session
                         0,
-                        ""_mb,
+                        "",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -165,10 +164,10 @@ BOOST_AUTO_TEST_CASE(v5_cs1) {
                     am::v5::connect_packet{
                         true,   // clean_start
                         0,
-                        ""_mb,
+                        "",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb,
+                        "u1",
+                        "passforu1",
                         am::properties{}
                     },
                     *this
@@ -240,10 +239,10 @@ BOOST_AUTO_TEST_CASE(v5_cs0) {
                     am::v5::connect_packet{
                         true,   // clean_start
                         0,
-                        ""_mb,
+                        "",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb,
+                        "u1",
+                        "passforu1",
                         {am::property::session_expiry_interval{am::session_never_expire}}
                     },
                     *this
@@ -282,10 +281,10 @@ BOOST_AUTO_TEST_CASE(v5_cs0) {
                     am::v5::connect_packet{
                         false,   // clean_start
                         0,
-                        am::allocate_buffer(v5_cs0_aci),
+                        v5_cs0_aci,
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );

--- a/test/system/st_inflight.cpp
+++ b/test/system/st_inflight.cpp
@@ -43,10 +43,10 @@ BOOST_AUTO_TEST_CASE(v311_to_broker) {
                     am::v3_1_1::connect_packet{
                         false,   // clean_session
                         0, // keep_alive
-                        "cid1"_mb,
+                        "cid1",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -66,8 +66,8 @@ BOOST_AUTO_TEST_CASE(v311_to_broker) {
                 yield ep().send(
                     am::v3_1_1::publish_packet{
                         *ep().acquire_unique_packet_id(),
-                        "topic1"_mb,
-                        "payload1"_mb,
+                        "topic1",
+                        "payload1",
                         am::qos::at_least_once | am::pub::retain::yes | am::pub::dup::no
                     },
                     *this
@@ -78,8 +78,8 @@ BOOST_AUTO_TEST_CASE(v311_to_broker) {
                 yield ep().send(
                     am::v3_1_1::publish_packet{
                         *ep().acquire_unique_packet_id(),
-                        "topic1"_mb,
-                        "payload1"_mb,
+                        "topic1",
+                        "payload1",
                         am::qos::exactly_once | am::pub::retain::no | am::pub::dup::no
                     },
                     *this
@@ -98,10 +98,10 @@ BOOST_AUTO_TEST_CASE(v311_to_broker) {
                     am::v3_1_1::connect_packet{
                         false,   // clean_session
                         0, // keep_alive
-                        "cid1"_mb,
+                        "cid1",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -138,10 +138,10 @@ BOOST_AUTO_TEST_CASE(v311_to_broker) {
                     am::v3_1_1::connect_packet{
                         false,   // clean_session
                         0, // keep_alive
-                        "cid1"_mb,
+                        "cid1",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -202,10 +202,10 @@ BOOST_AUTO_TEST_CASE(v5_to_broker) {
                     am::v5::connect_packet{
                         false,   // clean_start
                         0, // keep_alive
-                        "cid1"_mb,
+                        "cid1",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb,
+                        "u1",
+                        "passforu1",
                         {am::property::session_expiry_interval{am::session_never_expire}}
                     },
                     *this
@@ -226,8 +226,8 @@ BOOST_AUTO_TEST_CASE(v5_to_broker) {
                 yield ep().send(
                     am::v5::publish_packet{
                         *ep().acquire_unique_packet_id(),
-                        "topic1"_mb,
-                        "payload1"_mb,
+                        "topic1",
+                        "payload1",
                         am::qos::at_least_once | am::pub::retain::yes | am::pub::dup::no
                     },
                     *this
@@ -238,8 +238,8 @@ BOOST_AUTO_TEST_CASE(v5_to_broker) {
                 yield ep().send(
                     am::v5::publish_packet{
                         *ep().acquire_unique_packet_id(),
-                        "topic1"_mb,
-                        "payload1"_mb,
+                        "topic1",
+                        "payload1",
                         am::qos::exactly_once | am::pub::retain::no | am::pub::dup::no
                     },
                     *this
@@ -258,10 +258,10 @@ BOOST_AUTO_TEST_CASE(v5_to_broker) {
                     am::v5::connect_packet{
                         false,   // clean_start
                         0, // keep_alive
-                        "cid1"_mb,
+                        "cid1",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb,
+                        "u1",
+                        "passforu1",
                         {am::property::session_expiry_interval{am::session_never_expire}}
                     },
                     *this
@@ -303,10 +303,10 @@ BOOST_AUTO_TEST_CASE(v5_to_broker) {
                     am::v5::connect_packet{
                         false,   // clean_start
                         0, // keep_alive
-                        "cid1"_mb,
+                        "cid1",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -377,10 +377,10 @@ BOOST_AUTO_TEST_CASE(v311_from_broker) {
                     am::v3_1_1::connect_packet{
                         false,   // clean_session
                         0, // keep_alive
-                        "sub"_mb,
+                        "sub",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -401,7 +401,7 @@ BOOST_AUTO_TEST_CASE(v311_from_broker) {
                     am::v3_1_1::subscribe_packet{
                         *ep(sub).acquire_unique_packet_id(),
                         {
-                            {"topic1"_mb, am::qos::exactly_once},
+                            {"topic1", am::qos::exactly_once},
                         }
                     },
                     *this
@@ -421,10 +421,10 @@ BOOST_AUTO_TEST_CASE(v311_from_broker) {
                     am::v3_1_1::connect_packet{
                         true,   // clean_session
                         0, // keep_alive
-                        "pub"_mb,
+                        "pub",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -436,8 +436,8 @@ BOOST_AUTO_TEST_CASE(v311_from_broker) {
                 yield ep(pub).send(
                     am::v3_1_1::publish_packet{
                         *ep(pub).acquire_unique_packet_id(),
-                        "topic1"_mb,
-                        "payload1"_mb,
+                        "topic1",
+                        "payload1",
                         am::qos::at_least_once
                     },
                     *this
@@ -448,8 +448,8 @@ BOOST_AUTO_TEST_CASE(v311_from_broker) {
                 yield ep(pub).send(
                     am::v3_1_1::publish_packet{
                         *ep(pub).acquire_unique_packet_id(),
-                        "topic1"_mb,
-                        "payload2"_mb,
+                        "topic1",
+                        "payload2",
                         am::qos::exactly_once
                     },
                     *this
@@ -475,10 +475,10 @@ BOOST_AUTO_TEST_CASE(v311_from_broker) {
                     am::v3_1_1::connect_packet{
                         false,   // clean_session
                         0, // keep_alive
-                        "sub"_mb,
+                        "sub",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -501,8 +501,8 @@ BOOST_AUTO_TEST_CASE(v311_from_broker) {
                     ==
                     (am::v3_1_1::publish_packet{
                         1,
-                        "topic1"_mb,
-                        "payload1"_mb,
+                        "topic1",
+                        "payload1",
                         am::qos::at_least_once | am::pub::dup::yes
                     })
                 );
@@ -513,8 +513,8 @@ BOOST_AUTO_TEST_CASE(v311_from_broker) {
                     ==
                     (am::v3_1_1::publish_packet{
                         2,
-                        "topic1"_mb,
-                        "payload2"_mb,
+                        "topic1",
+                        "payload2",
                         am::qos::exactly_once | am::pub::dup::yes
                     })
                 );
@@ -572,10 +572,10 @@ BOOST_AUTO_TEST_CASE(v5_from_broker) {
                     am::v5::connect_packet{
                         false,   // clean_start
                         0, // keep_alive
-                        "sub"_mb,
+                        "sub",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb,
+                        "u1",
+                        "passforu1",
                         {am::property::session_expiry_interval{am::session_never_expire}}
                     },
                     *this
@@ -597,7 +597,7 @@ BOOST_AUTO_TEST_CASE(v5_from_broker) {
                     am::v5::subscribe_packet{
                         *ep(sub).acquire_unique_packet_id(),
                         {
-                            {"topic1"_mb, am::qos::exactly_once},
+                            {"topic1", am::qos::exactly_once},
                         }
                     },
                     *this
@@ -617,10 +617,10 @@ BOOST_AUTO_TEST_CASE(v5_from_broker) {
                     am::v5::connect_packet{
                         true,   // clean_start
                         0, // keep_alive
-                        "pub"_mb,
+                        "pub",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -632,8 +632,8 @@ BOOST_AUTO_TEST_CASE(v5_from_broker) {
                 yield ep(pub).send(
                     am::v5::publish_packet{
                         *ep(pub).acquire_unique_packet_id(),
-                        "topic1"_mb,
-                        "payload1"_mb,
+                        "topic1",
+                        "payload1",
                         am::qos::at_least_once
                     },
                     *this
@@ -644,8 +644,8 @@ BOOST_AUTO_TEST_CASE(v5_from_broker) {
                 yield ep(pub).send(
                     am::v5::publish_packet{
                         *ep(pub).acquire_unique_packet_id(),
-                        "topic1"_mb,
-                        "payload2"_mb,
+                        "topic1",
+                        "payload2",
                         am::qos::exactly_once
                     },
                     *this
@@ -671,10 +671,10 @@ BOOST_AUTO_TEST_CASE(v5_from_broker) {
                     am::v5::connect_packet{
                         false,   // clean_start
                         0, // keep_alive
-                        "sub"_mb,
+                        "sub",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -697,8 +697,8 @@ BOOST_AUTO_TEST_CASE(v5_from_broker) {
                     ==
                     (am::v5::publish_packet{
                         1,
-                        "topic1"_mb,
-                        "payload1"_mb,
+                        "topic1",
+                        "payload1",
                         am::qos::at_least_once | am::pub::dup::yes
                     })
                 );
@@ -709,8 +709,8 @@ BOOST_AUTO_TEST_CASE(v5_from_broker) {
                     ==
                     (am::v5::publish_packet{
                         2,
-                        "topic1"_mb,
-                        "payload2"_mb,
+                        "topic1",
+                        "payload2",
                         am::qos::exactly_once | am::pub::dup::yes
                     })
                 );
@@ -768,10 +768,10 @@ BOOST_AUTO_TEST_CASE(v5_from_broker_mei) {
                     am::v5::connect_packet{
                         false,   // clean_start
                         0, // keep_alive
-                        "sub"_mb,
+                        "sub",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb,
+                        "u1",
+                        "passforu1",
                         {am::property::session_expiry_interval{am::session_never_expire}}
                     },
                     *this
@@ -793,7 +793,7 @@ BOOST_AUTO_TEST_CASE(v5_from_broker_mei) {
                     am::v5::subscribe_packet{
                         *ep(sub).acquire_unique_packet_id(),
                         {
-                            {"topic1"_mb, am::qos::exactly_once},
+                            {"topic1", am::qos::exactly_once},
                         }
                     },
                     *this
@@ -813,10 +813,10 @@ BOOST_AUTO_TEST_CASE(v5_from_broker_mei) {
                     am::v5::connect_packet{
                         true,   // clean_start
                         0, // keep_alive
-                        "pub"_mb,
+                        "pub",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -828,8 +828,8 @@ BOOST_AUTO_TEST_CASE(v5_from_broker_mei) {
                 yield ep(pub).send(
                     am::v5::publish_packet{
                         *ep(pub).acquire_unique_packet_id(),
-                        "topic1"_mb,
-                        "payload1"_mb,
+                        "topic1",
+                        "payload1",
                         am::qos::at_least_once,
                         {am::property::message_expiry_interval{1}}
                     },
@@ -841,8 +841,8 @@ BOOST_AUTO_TEST_CASE(v5_from_broker_mei) {
                 yield ep(pub).send(
                     am::v5::publish_packet{
                         *ep(pub).acquire_unique_packet_id(),
-                        "topic1"_mb,
-                        "payload2"_mb,
+                        "topic1",
+                        "payload2",
                         am::qos::exactly_once,
                         {am::property::message_expiry_interval{10}}
                     },
@@ -867,10 +867,10 @@ BOOST_AUTO_TEST_CASE(v5_from_broker_mei) {
                     am::v5::connect_packet{
                         false,   // clean_start
                         0, // keep_alive
-                        "sub"_mb,
+                        "sub",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -893,8 +893,8 @@ BOOST_AUTO_TEST_CASE(v5_from_broker_mei) {
                     ==
                     (am::v5::publish_packet{
                         2,
-                        "topic1"_mb,
-                        "payload2"_mb,
+                        "topic1",
+                        "payload2",
                         am::qos::exactly_once | am::pub::dup::yes,
                         {am::property::message_expiry_interval{9}}
                     })

--- a/test/system/st_invalid.cpp
+++ b/test/system/st_invalid.cpp
@@ -15,7 +15,6 @@
 BOOST_AUTO_TEST_SUITE(st_invalid)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 namespace as = boost::asio;
 
 char invalid_remaining_length_packet[] { 0x10, char(0xff), char(0xff), char(0xff), char(0xff)};

--- a/test/system/st_keep_alive.cpp
+++ b/test/system/st_keep_alive.cpp
@@ -15,7 +15,6 @@
 BOOST_AUTO_TEST_SUITE(st_keep_alive)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 namespace as = boost::asio;
 
 BOOST_AUTO_TEST_CASE(v311_timeout) {
@@ -46,10 +45,10 @@ BOOST_AUTO_TEST_CASE(v311_timeout) {
                     am::v3_1_1::connect_packet{
                         true,   // clean_session
                         1,  // 1sec
-                        "cid1"_mb,
+                        "cid1",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -98,10 +97,10 @@ BOOST_AUTO_TEST_CASE(v5_timeout) {
                     am::v5::connect_packet{
                         true,   // clean_session
                         1,  // 1sec
-                        "cid1"_mb,
+                        "cid1",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb,
+                        "u1",
+                        "passforu1",
                         am::properties{}
                     },
                     *this

--- a/test/system/st_mqtt_connect.cpp
+++ b/test/system/st_mqtt_connect.cpp
@@ -15,7 +15,6 @@
 BOOST_AUTO_TEST_SUITE(st_mqtt_connect)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 namespace as = boost::asio;
 
 BOOST_AUTO_TEST_CASE(cb) {
@@ -37,10 +36,10 @@ BOOST_AUTO_TEST_CASE(cb) {
                 am::v3_1_1::connect_packet{
                     true,   // clean_session
                     0x1234, // keep_alive
-                    "cid1"_mb,
+                    "cid1",
                     std::nullopt, // will
-                    "u1"_mb,
-                    "passforu1"_mb
+                    "u1",
+                    "passforu1"
                 },
                 [&](am::system_error const& se) {
                     BOOST_TEST(!se);
@@ -109,10 +108,10 @@ BOOST_AUTO_TEST_CASE(fut) {
                 am::v3_1_1::connect_packet{
                     true,   // clean_session
                     0x1234, // keep_alive
-                    "cid1"_mb,
+                    "cid1",
                     std::nullopt, // will
-                    "u1"_mb,
-                    "passforu1"_mb
+                    "u1",
+                    "passforu1"
                 },
                 as::use_future
             );
@@ -168,10 +167,10 @@ BOOST_AUTO_TEST_CASE(coro) {
                     am::v3_1_1::connect_packet{
                         true,   // clean_session
                         0x1234, // keep_alive
-                        "cid1"_mb,
+                        "cid1",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );

--- a/test/system/st_mqtts_connect.cpp
+++ b/test/system/st_mqtts_connect.cpp
@@ -17,7 +17,6 @@
 BOOST_AUTO_TEST_SUITE(st_connect)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 namespace as = boost::asio;
 
 BOOST_AUTO_TEST_CASE(cb) {
@@ -49,10 +48,10 @@ BOOST_AUTO_TEST_CASE(cb) {
                         am::v3_1_1::connect_packet{
                             true,   // clean_session
                             0x1234, // keep_alive
-                            "cid1"_mb,
+                            "cid1",
                             std::nullopt, // will
-                            "u1"_mb,
-                            "passforu1"_mb
+                            "u1",
+                            "passforu1"
                         },
                         [&](am::system_error const& se) {
                             BOOST_TEST(!se);
@@ -141,10 +140,10 @@ BOOST_AUTO_TEST_CASE(fut) {
                 am::v3_1_1::connect_packet{
                     true,   // clean_session
                     0x1234, // keep_alive
-                    "cid1"_mb,
+                    "cid1",
                     std::nullopt, // will
-                    "u1"_mb,
-                    "passforu1"_mb
+                    "u1",
+                    "passforu1"
                 },
                 as::use_future
             );
@@ -210,10 +209,10 @@ BOOST_AUTO_TEST_CASE(coro) {
                     am::v3_1_1::connect_packet{
                         true,   // clean_session
                         0x1234, // keep_alive
-                        "cid1"_mb,
+                        "cid1",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -281,9 +280,9 @@ BOOST_AUTO_TEST_CASE(coro_client_cert) {
                     am::v3_1_1::connect_packet{
                         true,   // clean_session
                         0x1234, // keep_alive
-                        "cidxxx"_mb,
+                        "cidxxx",
                         std::nullopt, // will
-                        "cid1"_mb,
+                        "cid1",
                         std::nullopt // no password
                     },
                     *this

--- a/test/system/st_offline.cpp
+++ b/test/system/st_offline.cpp
@@ -15,7 +15,6 @@
 BOOST_AUTO_TEST_SUITE(st_offline)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 namespace as = boost::asio;
 
 BOOST_AUTO_TEST_CASE(v311_cs1_sp0) {
@@ -40,8 +39,8 @@ BOOST_AUTO_TEST_CASE(v311_cs1_sp0) {
                 // publish QoS0
                 yield ep().send(
                     am::v3_1_1::publish_packet{
-                        "topic1"_mb,
-                        "payload1"_mb,
+                        "topic1",
+                        "payload1",
                         am::qos::at_most_once | am::pub::retain::no | am::pub::dup::no
                     },
                     *this
@@ -52,8 +51,8 @@ BOOST_AUTO_TEST_CASE(v311_cs1_sp0) {
                 yield ep().send(
                     am::v3_1_1::publish_packet{
                         *ep().acquire_unique_packet_id(),
-                        "topic1"_mb,
-                        "payload1"_mb,
+                        "topic1",
+                        "payload1",
                         am::qos::at_least_once | am::pub::retain::yes | am::pub::dup::no
                     },
                     *this
@@ -64,8 +63,8 @@ BOOST_AUTO_TEST_CASE(v311_cs1_sp0) {
                 yield ep().send(
                     am::v3_1_1::publish_packet{
                         *ep().acquire_unique_packet_id(),
-                        "topic1"_mb,
-                        "payload1"_mb,
+                        "topic1",
+                        "payload1",
                         am::qos::exactly_once | am::pub::retain::no | am::pub::dup::yes
                     },
                     *this
@@ -81,10 +80,10 @@ BOOST_AUTO_TEST_CASE(v311_cs1_sp0) {
                     am::v3_1_1::connect_packet{
                         true,   // clean_session
                         0,
-                        "cid1"_mb,
+                        "cid1",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -159,8 +158,8 @@ BOOST_AUTO_TEST_CASE(v311_cs0_sp0) {
                 // publish QoS0
                 yield ep().send(
                     am::v3_1_1::publish_packet{
-                        "topic1"_mb,
-                        "payload1"_mb,
+                        "topic1",
+                        "payload1",
                         am::qos::at_most_once | am::pub::retain::no | am::pub::dup::no
                     },
                     *this
@@ -171,8 +170,8 @@ BOOST_AUTO_TEST_CASE(v311_cs0_sp0) {
                 yield ep().send(
                     am::v3_1_1::publish_packet{
                         *ep().acquire_unique_packet_id(),
-                        "topic1"_mb,
-                        "payload1"_mb,
+                        "topic1",
+                        "payload1",
                         am::qos::at_least_once | am::pub::retain::yes | am::pub::dup::no
                     },
                     *this
@@ -183,8 +182,8 @@ BOOST_AUTO_TEST_CASE(v311_cs0_sp0) {
                 yield ep().send(
                     am::v3_1_1::publish_packet{
                         *ep().acquire_unique_packet_id(),
-                        "topic1"_mb,
-                        "payload1"_mb,
+                        "topic1",
+                        "payload1",
                         am::qos::exactly_once | am::pub::retain::no | am::pub::dup::yes
                     },
                     *this
@@ -200,10 +199,10 @@ BOOST_AUTO_TEST_CASE(v311_cs0_sp0) {
                     am::v3_1_1::connect_packet{
                         false,   // clean_session
                         0,
-                        "cid1"_mb,
+                        "cid1",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -285,10 +284,10 @@ BOOST_AUTO_TEST_CASE(v311_cs0_sp1) {
                     am::v3_1_1::connect_packet{
                         false,   // clean_session
                         0,
-                        "cid1"_mb,
+                        "cid1",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -310,8 +309,8 @@ BOOST_AUTO_TEST_CASE(v311_cs0_sp1) {
                 // publish QoS0
                 yield ep().send(
                     am::v3_1_1::publish_packet{
-                        "topic1"_mb,
-                        "payload1"_mb,
+                        "topic1",
+                        "payload1",
                         am::qos::at_most_once | am::pub::retain::no | am::pub::dup::no
                     },
                     *this
@@ -322,8 +321,8 @@ BOOST_AUTO_TEST_CASE(v311_cs0_sp1) {
                 yield ep().send(
                     am::v3_1_1::publish_packet{
                         *ep().acquire_unique_packet_id(),
-                        "topic1"_mb,
-                        "payload1"_mb,
+                        "topic1",
+                        "payload1",
                         am::qos::at_least_once | am::pub::retain::yes | am::pub::dup::no
                     },
                     *this
@@ -334,8 +333,8 @@ BOOST_AUTO_TEST_CASE(v311_cs0_sp1) {
                 yield ep().send(
                     am::v3_1_1::publish_packet{
                         *ep().acquire_unique_packet_id(),
-                        "topic1"_mb,
-                        "payload1"_mb,
+                        "topic1",
+                        "payload1",
                         am::qos::exactly_once | am::pub::retain::no | am::pub::dup::yes
                     },
                     *this
@@ -351,10 +350,10 @@ BOOST_AUTO_TEST_CASE(v311_cs0_sp1) {
                     am::v3_1_1::connect_packet{
                         false,   // clean_session
                         0,
-                        "cid1"_mb,
+                        "cid1",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -427,10 +426,10 @@ BOOST_AUTO_TEST_CASE(v311_cs0_sp1_from_broker) {
                     am::v3_1_1::connect_packet{
                         false,   // clean_session
                         0, // keep_alive
-                        "sub"_mb,
+                        "sub",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -451,7 +450,7 @@ BOOST_AUTO_TEST_CASE(v311_cs0_sp1_from_broker) {
                     am::v3_1_1::subscribe_packet{
                         *ep(sub).acquire_unique_packet_id(),
                         {
-                            {"topic1"_mb, am::qos::exactly_once},
+                            {"topic1", am::qos::exactly_once},
                         }
                     },
                     *this
@@ -474,10 +473,10 @@ BOOST_AUTO_TEST_CASE(v311_cs0_sp1_from_broker) {
                     am::v3_1_1::connect_packet{
                         true,   // clean_session
                         0, // keep_alive
-                        "pub"_mb,
+                        "pub",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -488,8 +487,8 @@ BOOST_AUTO_TEST_CASE(v311_cs0_sp1_from_broker) {
                 // publish QoS0
                 yield ep(pub).send(
                     am::v3_1_1::publish_packet{
-                        "topic1"_mb,
-                        "payload0"_mb,
+                        "topic1",
+                        "payload0",
                         am::qos::at_most_once
                     },
                     *this
@@ -500,8 +499,8 @@ BOOST_AUTO_TEST_CASE(v311_cs0_sp1_from_broker) {
                 yield ep(pub).send(
                     am::v3_1_1::publish_packet{
                         *ep(pub).acquire_unique_packet_id(),
-                        "topic1"_mb,
-                        "payload1"_mb,
+                        "topic1",
+                        "payload1",
                         am::qos::at_least_once
                     },
                     *this
@@ -512,8 +511,8 @@ BOOST_AUTO_TEST_CASE(v311_cs0_sp1_from_broker) {
                 yield ep(pub).send(
                     am::v3_1_1::publish_packet{
                         *ep(pub).acquire_unique_packet_id(),
-                        "topic1"_mb,
-                        "payload2"_mb,
+                        "topic1",
+                        "payload2",
                         am::qos::exactly_once
                     },
                     *this
@@ -534,10 +533,10 @@ BOOST_AUTO_TEST_CASE(v311_cs0_sp1_from_broker) {
                     am::v3_1_1::connect_packet{
                         false,   // clean_session
                         0, // keep_alive
-                        "sub"_mb,
+                        "sub",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -559,8 +558,8 @@ BOOST_AUTO_TEST_CASE(v311_cs0_sp1_from_broker) {
                     *pv
                     ==
                     (am::v3_1_1::publish_packet{
-                        "topic1"_mb,
-                        "payload0"_mb,
+                        "topic1",
+                        "payload0",
                         am::qos::at_most_once
                     })
                 );
@@ -570,8 +569,8 @@ BOOST_AUTO_TEST_CASE(v311_cs0_sp1_from_broker) {
                     ==
                     (am::v3_1_1::publish_packet{
                         1,
-                        "topic1"_mb,
-                        "payload1"_mb,
+                        "topic1",
+                        "payload1",
                         am::qos::at_least_once | am::pub::dup::no
                     })
                 );
@@ -581,8 +580,8 @@ BOOST_AUTO_TEST_CASE(v311_cs0_sp1_from_broker) {
                     ==
                     (am::v3_1_1::publish_packet{
                         2,
-                        "topic1"_mb,
-                        "payload2"_mb,
+                        "topic1",
+                        "payload2",
                         am::qos::exactly_once | am::pub::dup::no
                     })
                 );
@@ -635,10 +634,10 @@ BOOST_AUTO_TEST_CASE(v5_cs0_sp1_from_broker_mei) {
                     am::v5::connect_packet{
                         true,   // clean_start
                         0, // keep_alive
-                        "sub"_mb,
+                        "sub",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb,
+                        "u1",
+                        "passforu1",
                         {am::property::session_expiry_interval{am::session_never_expire}}
                     },
                     *this
@@ -660,7 +659,7 @@ BOOST_AUTO_TEST_CASE(v5_cs0_sp1_from_broker_mei) {
                     am::v5::subscribe_packet{
                         *ep(sub).acquire_unique_packet_id(),
                         {
-                            {"topic1"_mb, am::qos::exactly_once},
+                            {"topic1", am::qos::exactly_once},
                         }
                     },
                     *this
@@ -683,10 +682,10 @@ BOOST_AUTO_TEST_CASE(v5_cs0_sp1_from_broker_mei) {
                     am::v5::connect_packet{
                         true,   // clean_start
                         0, // keep_alive
-                        "pub"_mb,
+                        "pub",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -697,8 +696,8 @@ BOOST_AUTO_TEST_CASE(v5_cs0_sp1_from_broker_mei) {
                 // publish QoS0
                 yield ep(pub).send(
                     am::v5::publish_packet{
-                        "topic1"_mb,
-                        "payload0"_mb,
+                        "topic1",
+                        "payload0",
                         am::qos::at_most_once
                     },
                     *this
@@ -709,8 +708,8 @@ BOOST_AUTO_TEST_CASE(v5_cs0_sp1_from_broker_mei) {
                 yield ep(pub).send(
                     am::v5::publish_packet{
                         *ep(pub).acquire_unique_packet_id(),
-                        "topic1"_mb,
-                        "payload1"_mb,
+                        "topic1",
+                        "payload1",
                         am::qos::at_least_once,
                         {am::property::message_expiry_interval{1}}
                     },
@@ -722,8 +721,8 @@ BOOST_AUTO_TEST_CASE(v5_cs0_sp1_from_broker_mei) {
                 yield ep(pub).send(
                     am::v5::publish_packet{
                         *ep(pub).acquire_unique_packet_id(),
-                        "topic1"_mb,
-                        "payload2"_mb,
+                        "topic1",
+                        "payload2",
                         am::qos::exactly_once,
                         {am::property::message_expiry_interval{10}}
                     },
@@ -748,10 +747,10 @@ BOOST_AUTO_TEST_CASE(v5_cs0_sp1_from_broker_mei) {
                     am::v5::connect_packet{
                         false,   // clean_start
                         0, // keep_alive
-                        "sub"_mb,
+                        "sub",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -773,8 +772,8 @@ BOOST_AUTO_TEST_CASE(v5_cs0_sp1_from_broker_mei) {
                     *pv
                     ==
                     (am::v5::publish_packet{
-                        "topic1"_mb,
-                        "payload0"_mb,
+                        "topic1",
+                        "payload0",
                         am::qos::at_most_once
                     })
                 );
@@ -784,8 +783,8 @@ BOOST_AUTO_TEST_CASE(v5_cs0_sp1_from_broker_mei) {
                     ==
                     (am::v5::publish_packet{
                         1,
-                        "topic1"_mb,
-                        "payload2"_mb,
+                        "topic1",
+                        "payload2",
                         am::qos::exactly_once | am::pub::dup::no,
                         {am::property::message_expiry_interval{7}}
                     })

--- a/test/system/st_order.cpp
+++ b/test/system/st_order.cpp
@@ -15,7 +15,6 @@
 BOOST_AUTO_TEST_SUITE(st_order)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 namespace as = boost::asio;
 
 BOOST_AUTO_TEST_CASE(v311_qos0) {
@@ -57,10 +56,10 @@ BOOST_AUTO_TEST_CASE(v311_qos0) {
                     am::v3_1_1::connect_packet{
                         true,   // clean_session
                         0, // keep_alive
-                        "sub"_mb,
+                        "sub",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -81,7 +80,7 @@ BOOST_AUTO_TEST_CASE(v311_qos0) {
                     am::v3_1_1::subscribe_packet{
                         *ep(sub).acquire_unique_packet_id(),
                         {
-                            {"topic1"_mb, am::qos::exactly_once},
+                            {"topic1", am::qos::exactly_once},
                         }
                     },
                     *this
@@ -101,10 +100,10 @@ BOOST_AUTO_TEST_CASE(v311_qos0) {
                     am::v3_1_1::connect_packet{
                         true,   // clean_session
                         0, // keep_alive
-                        "pub"_mb,
+                        "pub",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -117,8 +116,8 @@ BOOST_AUTO_TEST_CASE(v311_qos0) {
                 while (true) {
                     yield ep(pub).send(
                         am::v3_1_1::publish_packet{
-                            "topic1"_mb,
-                            am::allocate_buffer("payload" + std::to_string(++count)),
+                            "topic1",
+                            "payload" + std::to_string(++count),
                             am::qos::at_most_once
                         },
                         *this
@@ -135,8 +134,8 @@ BOOST_AUTO_TEST_CASE(v311_qos0) {
                         *pv
                         ==
                         (am::v3_1_1::publish_packet{
-                            "topic1"_mb,
-                            am::allocate_buffer("payload" + std::to_string(++count)),
+                            "topic1",
+                            "payload" + std::to_string(++count),
                             am::qos::at_most_once
                         })
                     );
@@ -196,10 +195,10 @@ BOOST_AUTO_TEST_CASE(v311_qos1) {
                     am::v3_1_1::connect_packet{
                         true,   // clean_session
                         0, // keep_alive
-                        "sub"_mb,
+                        "sub",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -220,7 +219,7 @@ BOOST_AUTO_TEST_CASE(v311_qos1) {
                     am::v3_1_1::subscribe_packet{
                         *ep(sub).acquire_unique_packet_id(),
                         {
-                            {"topic1"_mb, am::qos::exactly_once},
+                            {"topic1", am::qos::exactly_once},
                         }
                     },
                     *this
@@ -240,10 +239,10 @@ BOOST_AUTO_TEST_CASE(v311_qos1) {
                     am::v3_1_1::connect_packet{
                         true,   // clean_session
                         0, // keep_alive
-                        "pub"_mb,
+                        "pub",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -257,8 +256,8 @@ BOOST_AUTO_TEST_CASE(v311_qos1) {
                     yield ep(pub).send(
                         am::v3_1_1::publish_packet{
                             *ep(pub).acquire_unique_packet_id(),
-                            "topic1"_mb,
-                            am::allocate_buffer("payload" + std::to_string(++count)),
+                            "topic1",
+                            "payload" + std::to_string(++count),
                             am::qos::at_least_once
                         },
                         *this
@@ -275,7 +274,7 @@ BOOST_AUTO_TEST_CASE(v311_qos1) {
                     BOOST_ASSERT(pv->get_if<am::v3_1_1::publish_packet>());
                     BOOST_TEST(pv->get_if<am::v3_1_1::publish_packet>()->opts().get_qos() == am::qos::at_least_once);
                     BOOST_TEST(
-                        am::to_string(pv->get_if<am::v3_1_1::publish_packet>()->payload())
+                        pv->get_if<am::v3_1_1::publish_packet>()->payload()
                         ==
                         "payload" + std::to_string(++count)
                     );
@@ -335,10 +334,10 @@ BOOST_AUTO_TEST_CASE(v311_qos2) {
                     am::v3_1_1::connect_packet{
                         true,   // clean_session
                         0, // keep_alive
-                        "sub"_mb,
+                        "sub",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -359,7 +358,7 @@ BOOST_AUTO_TEST_CASE(v311_qos2) {
                     am::v3_1_1::subscribe_packet{
                         *ep(sub).acquire_unique_packet_id(),
                         {
-                            {"topic1"_mb, am::qos::exactly_once},
+                            {"topic1", am::qos::exactly_once},
                         }
                     },
                     *this
@@ -379,10 +378,10 @@ BOOST_AUTO_TEST_CASE(v311_qos2) {
                     am::v3_1_1::connect_packet{
                         true,   // clean_session
                         0, // keep_alive
-                        "pub"_mb,
+                        "pub",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -396,8 +395,8 @@ BOOST_AUTO_TEST_CASE(v311_qos2) {
                     yield ep(pub).send(
                         am::v3_1_1::publish_packet{
                             *ep(pub).acquire_unique_packet_id(),
-                            "topic1"_mb,
-                            am::allocate_buffer("payload" + std::to_string(++count)),
+                            "topic1",
+                            "payload" + std::to_string(++count),
                             am::qos::exactly_once
                         },
                         *this
@@ -414,7 +413,7 @@ BOOST_AUTO_TEST_CASE(v311_qos2) {
                     BOOST_ASSERT(pv->get_if<am::v3_1_1::publish_packet>());
                     BOOST_TEST(pv->get_if<am::v3_1_1::publish_packet>()->opts().get_qos() == am::qos::exactly_once);
                     BOOST_TEST(
-                        am::to_string(pv->get_if<am::v3_1_1::publish_packet>()->payload())
+                        pv->get_if<am::v3_1_1::publish_packet>()->payload()
                         ==
                         "payload" + std::to_string(++count)
                     );
@@ -474,10 +473,10 @@ BOOST_AUTO_TEST_CASE(v5_qos0) {
                     am::v3_1_1::connect_packet{
                         true,   // clean_session
                         0, // keep_alive
-                        "sub"_mb,
+                        "sub",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -498,7 +497,7 @@ BOOST_AUTO_TEST_CASE(v5_qos0) {
                     am::v3_1_1::subscribe_packet{
                         *ep(sub).acquire_unique_packet_id(),
                         {
-                            {"topic1"_mb, am::qos::exactly_once},
+                            {"topic1", am::qos::exactly_once},
                         }
                     },
                     *this
@@ -518,10 +517,10 @@ BOOST_AUTO_TEST_CASE(v5_qos0) {
                     am::v3_1_1::connect_packet{
                         true,   // clean_session
                         0, // keep_alive
-                        "pub"_mb,
+                        "pub",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -534,8 +533,8 @@ BOOST_AUTO_TEST_CASE(v5_qos0) {
                 while (true) {
                     yield ep(pub).send(
                         am::v3_1_1::publish_packet{
-                            "topic1"_mb,
-                            am::allocate_buffer("payload" + std::to_string(++count)),
+                            "topic1",
+                            "payload" + std::to_string(++count),
                             am::qos::at_most_once
                         },
                         *this
@@ -552,8 +551,8 @@ BOOST_AUTO_TEST_CASE(v5_qos0) {
                         *pv
                         ==
                         (am::v3_1_1::publish_packet{
-                            "topic1"_mb,
-                            am::allocate_buffer("payload" + std::to_string(++count)),
+                            "topic1",
+                            "payload" + std::to_string(++count),
                             am::qos::at_most_once
                         })
                     );
@@ -613,10 +612,10 @@ BOOST_AUTO_TEST_CASE(v5_qos1) {
                     am::v5::connect_packet{
                         true,   // clean_session
                         0, // keep_alive
-                        "sub"_mb,
+                        "sub",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -637,7 +636,7 @@ BOOST_AUTO_TEST_CASE(v5_qos1) {
                     am::v5::subscribe_packet{
                         *ep(sub).acquire_unique_packet_id(),
                         {
-                            {"topic1"_mb, am::qos::exactly_once},
+                            {"topic1", am::qos::exactly_once},
                         }
                     },
                     *this
@@ -657,10 +656,10 @@ BOOST_AUTO_TEST_CASE(v5_qos1) {
                     am::v5::connect_packet{
                         true,   // clean_session
                         0, // keep_alive
-                        "pub"_mb,
+                        "pub",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -674,8 +673,8 @@ BOOST_AUTO_TEST_CASE(v5_qos1) {
                     yield ep(pub).send(
                         am::v5::publish_packet{
                             *ep(pub).acquire_unique_packet_id(),
-                            "topic1"_mb,
-                            am::allocate_buffer("payload" + std::to_string(++count)),
+                            "topic1",
+                            "payload" + std::to_string(++count),
                             am::qos::at_least_once
                         },
                         *this
@@ -692,7 +691,7 @@ BOOST_AUTO_TEST_CASE(v5_qos1) {
                     BOOST_ASSERT(pv->get_if<am::v5::publish_packet>());
                     BOOST_TEST(pv->get_if<am::v5::publish_packet>()->opts().get_qos() == am::qos::at_least_once);
                     BOOST_TEST(
-                        am::to_string(pv->get_if<am::v5::publish_packet>()->payload())
+                        pv->get_if<am::v5::publish_packet>()->payload()
                         ==
                         "payload" + std::to_string(++count)
                     );
@@ -752,10 +751,10 @@ BOOST_AUTO_TEST_CASE(v5_qos2) {
                     am::v5::connect_packet{
                         true,   // clean_session
                         0, // keep_alive
-                        "sub"_mb,
+                        "sub",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -776,7 +775,7 @@ BOOST_AUTO_TEST_CASE(v5_qos2) {
                     am::v5::subscribe_packet{
                         *ep(sub).acquire_unique_packet_id(),
                         {
-                            {"topic1"_mb, am::qos::exactly_once},
+                            {"topic1", am::qos::exactly_once},
                         }
                     },
                     *this
@@ -796,10 +795,10 @@ BOOST_AUTO_TEST_CASE(v5_qos2) {
                     am::v5::connect_packet{
                         true,   // clean_session
                         0, // keep_alive
-                        "pub"_mb,
+                        "pub",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -813,8 +812,8 @@ BOOST_AUTO_TEST_CASE(v5_qos2) {
                     yield ep(pub).send(
                         am::v5::publish_packet{
                             *ep(pub).acquire_unique_packet_id(),
-                            "topic1"_mb,
-                            am::allocate_buffer("payload" + std::to_string(++count)),
+                            "topic1",
+                            "payload" + std::to_string(++count),
                             am::qos::exactly_once
                         },
                         *this
@@ -831,7 +830,7 @@ BOOST_AUTO_TEST_CASE(v5_qos2) {
                     BOOST_ASSERT(pv->get_if<am::v5::publish_packet>());
                     BOOST_TEST(pv->get_if<am::v5::publish_packet>()->opts().get_qos() == am::qos::exactly_once);
                     BOOST_TEST(
-                        am::to_string(pv->get_if<am::v5::publish_packet>()->payload())
+                        pv->get_if<am::v5::publish_packet>()->payload()
                         ==
                         "payload" + std::to_string(++count)
                     );

--- a/test/system/st_pub.cpp
+++ b/test/system/st_pub.cpp
@@ -15,7 +15,6 @@
 BOOST_AUTO_TEST_SUITE(st_sub)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 namespace as = boost::asio;
 
 BOOST_AUTO_TEST_CASE(v311_pub_to_broker) {
@@ -48,10 +47,10 @@ BOOST_AUTO_TEST_CASE(v311_pub_to_broker) {
                     am::v3_1_1::connect_packet{
                         true,   // clean_session
                         0,      // keep_alive none
-                        "cid1"_mb,
+                        "cid1",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -62,8 +61,8 @@ BOOST_AUTO_TEST_CASE(v311_pub_to_broker) {
                 // publish QoS0
                 yield ep().send(
                     am::v3_1_1::publish_packet{
-                        "topic1"_mb,
-                        "payload1"_mb,
+                        "topic1",
+                        "payload1",
                         am::qos::at_most_once | am::pub::retain::no | am::pub::dup::no
                     },
                     *this
@@ -75,8 +74,8 @@ BOOST_AUTO_TEST_CASE(v311_pub_to_broker) {
                 yield ep().send(
                     am::v3_1_1::publish_packet{
                         pid,
-                        "topic1"_mb,
-                        "payload1"_mb,
+                        "topic1",
+                        "payload1",
                         am::qos::at_least_once | am::pub::retain::yes | am::pub::dup::no
                     },
                     *this
@@ -91,8 +90,8 @@ BOOST_AUTO_TEST_CASE(v311_pub_to_broker) {
                 yield ep().send(
                     am::v3_1_1::publish_packet{
                         pid,
-                        "topic1"_mb,
-                        "payload1"_mb,
+                        "topic1",
+                        "payload1",
                         am::qos::exactly_once | am::pub::retain::no | am::pub::dup::yes
                     },
                     *this
@@ -147,10 +146,10 @@ BOOST_AUTO_TEST_CASE(v5_pub_to_broker) {
                     am::v5::connect_packet{
                         true,   // clean_start
                         0,      // keep_alive none
-                        "cid1"_mb,
+                        "cid1",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -162,8 +161,8 @@ BOOST_AUTO_TEST_CASE(v5_pub_to_broker) {
                 yield ep().send(
                     am::v5::publish_packet{
                         0, // packet_id
-                        "topic1"_mb,
-                        "payload1"_mb,
+                        "topic1",
+                        "payload1",
                         am::qos::at_most_once | am::pub::retain::no | am::pub::dup::no
                     },
                     *this
@@ -175,8 +174,8 @@ BOOST_AUTO_TEST_CASE(v5_pub_to_broker) {
                 yield ep().send(
                     am::v5::publish_packet{
                         pid,
-                        "topic1"_mb,
-                        "payload1"_mb,
+                        "topic1",
+                        "payload1",
                         am::qos::at_least_once | am::pub::retain::yes | am::pub::dup::no
                     },
                     *this
@@ -191,8 +190,8 @@ BOOST_AUTO_TEST_CASE(v5_pub_to_broker) {
                 yield ep().send(
                     am::v5::publish_packet{
                         pid,
-                        "topic1"_mb,
-                        "payload1"_mb,
+                        "topic1",
+                        "payload1",
                         am::qos::exactly_once | am::pub::retain::no | am::pub::dup::yes
                     },
                     *this
@@ -260,10 +259,10 @@ BOOST_AUTO_TEST_CASE(v311_from_broker) {
                     am::v3_1_1::connect_packet{
                         true,   // clean_session
                         0, // keep_alive
-                        "sub"_mb,
+                        "sub",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -284,7 +283,7 @@ BOOST_AUTO_TEST_CASE(v311_from_broker) {
                     am::v3_1_1::subscribe_packet{
                         *ep(sub).acquire_unique_packet_id(),
                         {
-                            {"topic1"_mb, am::qos::exactly_once},
+                            {"topic1", am::qos::exactly_once},
                         }
                     },
                     *this
@@ -304,10 +303,10 @@ BOOST_AUTO_TEST_CASE(v311_from_broker) {
                     am::v3_1_1::connect_packet{
                         true,   // clean_session
                         0, // keep_alive
-                        "pub"_mb,
+                        "pub",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -318,8 +317,8 @@ BOOST_AUTO_TEST_CASE(v311_from_broker) {
                 // publish QoS0
                 yield ep(pub).send(
                     am::v3_1_1::publish_packet{
-                        "topic1"_mb,
-                        "payload1"_mb,
+                        "topic1",
+                        "payload1",
                         am::qos::at_most_once
                     },
                     *this
@@ -330,8 +329,8 @@ BOOST_AUTO_TEST_CASE(v311_from_broker) {
                 yield ep(pub).send(
                     am::v3_1_1::publish_packet{
                         *ep(pub).acquire_unique_packet_id(),
-                        "topic1"_mb,
-                        "payload2"_mb,
+                        "topic1",
+                        "payload2",
                         am::qos::at_least_once
                     },
                     *this
@@ -342,8 +341,8 @@ BOOST_AUTO_TEST_CASE(v311_from_broker) {
                 yield ep(pub).send(
                     am::v3_1_1::publish_packet{
                         *ep(pub).acquire_unique_packet_id(),
-                        "topic1"_mb,
-                        "payload3"_mb,
+                        "topic1",
+                        "payload3",
                         am::qos::exactly_once
                     },
                     *this
@@ -362,8 +361,8 @@ BOOST_AUTO_TEST_CASE(v311_from_broker) {
                     *pv
                     ==
                     (am::v3_1_1::publish_packet{
-                        "topic1"_mb,
-                        "payload1"_mb,
+                        "topic1",
+                        "payload1",
                         am::qos::at_most_once
                     })
                 );
@@ -373,8 +372,8 @@ BOOST_AUTO_TEST_CASE(v311_from_broker) {
                     ==
                     (am::v3_1_1::publish_packet{
                         1,
-                        "topic1"_mb,
-                        "payload2"_mb,
+                        "topic1",
+                        "payload2",
                         am::qos::at_least_once
                     })
                 );
@@ -384,8 +383,8 @@ BOOST_AUTO_TEST_CASE(v311_from_broker) {
                     ==
                     (am::v3_1_1::publish_packet{
                         2,
-                        "topic1"_mb,
-                        "payload3"_mb,
+                        "topic1",
+                        "payload3",
                         am::qos::exactly_once
                     })
                 );
@@ -448,10 +447,10 @@ BOOST_AUTO_TEST_CASE(v5_from_broker) {
                     am::v5::connect_packet{
                         true,   // clean_start
                         0, // keep_alive
-                        "sub"_mb,
+                        "sub",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -472,7 +471,7 @@ BOOST_AUTO_TEST_CASE(v5_from_broker) {
                     am::v5::subscribe_packet{
                         *ep(sub).acquire_unique_packet_id(),
                         {
-                            {"topic1"_mb, am::qos::exactly_once},
+                            {"topic1", am::qos::exactly_once},
                         }
                     },
                     *this
@@ -492,10 +491,10 @@ BOOST_AUTO_TEST_CASE(v5_from_broker) {
                     am::v5::connect_packet{
                         true,   // clean_start
                         0, // keep_alive
-                        "pub"_mb,
+                        "pub",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -506,8 +505,8 @@ BOOST_AUTO_TEST_CASE(v5_from_broker) {
                 // publish QoS0
                 yield ep(pub).send(
                     am::v5::publish_packet{
-                        "topic1"_mb,
-                        "payload1"_mb,
+                        "topic1",
+                        "payload1",
                         am::qos::at_most_once
                     },
                     *this
@@ -518,8 +517,8 @@ BOOST_AUTO_TEST_CASE(v5_from_broker) {
                 yield ep(pub).send(
                     am::v5::publish_packet{
                         *ep(pub).acquire_unique_packet_id(),
-                        "topic1"_mb,
-                        "payload2"_mb,
+                        "topic1",
+                        "payload2",
                         am::qos::at_least_once
                     },
                     *this
@@ -530,8 +529,8 @@ BOOST_AUTO_TEST_CASE(v5_from_broker) {
                 yield ep(pub).send(
                     am::v5::publish_packet{
                         *ep(pub).acquire_unique_packet_id(),
-                        "topic1"_mb,
-                        "payload3"_mb,
+                        "topic1",
+                        "payload3",
                         am::qos::exactly_once
                     },
                     *this
@@ -550,8 +549,8 @@ BOOST_AUTO_TEST_CASE(v5_from_broker) {
                     *pv
                     ==
                     (am::v5::publish_packet{
-                        "topic1"_mb,
-                        "payload1"_mb,
+                        "topic1",
+                        "payload1",
                         am::qos::at_most_once
                     })
                 );
@@ -561,8 +560,8 @@ BOOST_AUTO_TEST_CASE(v5_from_broker) {
                     ==
                     (am::v5::publish_packet{
                         1,
-                        "topic1"_mb,
-                        "payload2"_mb,
+                        "topic1",
+                        "payload2",
                         am::qos::at_least_once
                     })
                 );
@@ -572,8 +571,8 @@ BOOST_AUTO_TEST_CASE(v5_from_broker) {
                     ==
                     (am::v5::publish_packet{
                         2,
-                        "topic1"_mb,
-                        "payload3"_mb,
+                        "topic1",
+                        "payload3",
                         am::qos::exactly_once
                     })
                 );

--- a/test/system/st_reqres.cpp
+++ b/test/system/st_reqres.cpp
@@ -15,7 +15,6 @@
 BOOST_AUTO_TEST_SUITE(st_reqres)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 namespace as = boost::asio;
 
 BOOST_AUTO_TEST_CASE(generate_reuse_renew) {
@@ -46,10 +45,10 @@ BOOST_AUTO_TEST_CASE(generate_reuse_renew) {
                     am::v5::connect_packet{
                         true,   // clean_start
                         0, // keep_alive
-                        "cid1"_mb,
+                        "cid1",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb,
+                        "u1",
+                        "passforu1",
                         {
                             am::property::request_response_information{true},
                             am::property::session_expiry_interval{am::session_never_expire}
@@ -93,10 +92,10 @@ BOOST_AUTO_TEST_CASE(generate_reuse_renew) {
                     am::v5::connect_packet{
                         false,   // clean_start
                         0, // keep_alive
-                        "cid1"_mb,
+                        "cid1",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb,
+                        "u1",
+                        "passforu1",
                         {
                             am::property::request_response_information{true},
                             am::property::session_expiry_interval{am::session_never_expire}
@@ -141,10 +140,10 @@ BOOST_AUTO_TEST_CASE(generate_reuse_renew) {
                     am::v5::connect_packet{
                         true,   // clean_start
                         0, // keep_alive
-                        "cid1"_mb,
+                        "cid1",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb,
+                        "u1",
+                        "passforu1",
                         {
                             am::property::request_response_information{true}
                         }

--- a/test/system/st_retain.cpp
+++ b/test/system/st_retain.cpp
@@ -15,7 +15,6 @@
 BOOST_AUTO_TEST_SUITE(st_retain)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 namespace as = boost::asio;
 
 BOOST_AUTO_TEST_CASE(v5_mei_none) {
@@ -58,10 +57,10 @@ BOOST_AUTO_TEST_CASE(v5_mei_none) {
                     am::v5::connect_packet{
                         true,   // clean_start
                         0, // keep_alive
-                        "pub"_mb,
+                        "pub",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -72,8 +71,8 @@ BOOST_AUTO_TEST_CASE(v5_mei_none) {
                 // publish QoS0
                 yield ep(pub).send(
                     am::v5::publish_packet{
-                        "topic1"_mb,
-                        "payload1"_mb,
+                        "topic1",
+                        "payload1",
                         am::qos::at_most_once | am::pub::retain::yes
                     },
                     *this
@@ -84,8 +83,8 @@ BOOST_AUTO_TEST_CASE(v5_mei_none) {
                 yield ep(pub).send(
                     am::v5::publish_packet{
                         *ep(pub).acquire_unique_packet_id(),
-                        "topic1"_mb,
-                        "payload2"_mb,
+                        "topic1",
+                        "payload2",
                         am::qos::at_least_once | am::pub::retain::yes
                     },
                     *this
@@ -96,8 +95,8 @@ BOOST_AUTO_TEST_CASE(v5_mei_none) {
                 yield ep(pub).send(
                     am::v5::publish_packet{
                         *ep(pub).acquire_unique_packet_id(),
-                        "topic1"_mb,
-                        "payload3"_mb,
+                        "topic1",
+                        "payload3",
                         am::qos::exactly_once | am::pub::retain::yes
                     },
                     *this
@@ -115,10 +114,10 @@ BOOST_AUTO_TEST_CASE(v5_mei_none) {
                     am::v5::connect_packet{
                         true,   // clean_start
                         0, // keep_alive
-                        "sub"_mb,
+                        "sub",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -139,7 +138,7 @@ BOOST_AUTO_TEST_CASE(v5_mei_none) {
                     am::v5::subscribe_packet{
                         *ep(sub).acquire_unique_packet_id(),
                         {
-                            {"topic1"_mb, am::qos::exactly_once},
+                            {"topic1", am::qos::exactly_once},
                         }
                     },
                     *this
@@ -154,8 +153,8 @@ BOOST_AUTO_TEST_CASE(v5_mei_none) {
                     ==
                     (am::v5::publish_packet{
                         1,
-                        "topic1"_mb,
-                        "payload3"_mb,
+                        "topic1",
+                        "payload3",
                         am::qos::exactly_once | am::pub::retain::yes
                     })
                 );
@@ -213,10 +212,10 @@ BOOST_AUTO_TEST_CASE(v5_mei_no_exp) {
                     am::v5::connect_packet{
                         true,   // clean_start
                         0, // keep_alive
-                        "pub"_mb,
+                        "pub",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -227,8 +226,8 @@ BOOST_AUTO_TEST_CASE(v5_mei_no_exp) {
                 // publish QoS0
                 yield ep(pub).send(
                     am::v5::publish_packet{
-                        "topic1"_mb,
-                        "payload1"_mb,
+                        "topic1",
+                        "payload1",
                         am::qos::at_most_once | am::pub::retain::yes
                     },
                     *this
@@ -239,8 +238,8 @@ BOOST_AUTO_TEST_CASE(v5_mei_no_exp) {
                 yield ep(pub).send(
                     am::v5::publish_packet{
                         *ep(pub).acquire_unique_packet_id(),
-                        "topic1"_mb,
-                        "payload2"_mb,
+                        "topic1",
+                        "payload2",
                         am::qos::at_least_once | am::pub::retain::yes
                     },
                     *this
@@ -251,8 +250,8 @@ BOOST_AUTO_TEST_CASE(v5_mei_no_exp) {
                 yield ep(pub).send(
                     am::v5::publish_packet{
                         *ep(pub).acquire_unique_packet_id(),
-                        "topic1"_mb,
-                        "payload3"_mb,
+                        "topic1",
+                        "payload3",
                         am::qos::exactly_once | am::pub::retain::yes,
                         {am::property::message_expiry_interval{1}}
                     },
@@ -271,10 +270,10 @@ BOOST_AUTO_TEST_CASE(v5_mei_no_exp) {
                     am::v5::connect_packet{
                         true,   // clean_start
                         0, // keep_alive
-                        "sub"_mb,
+                        "sub",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -295,7 +294,7 @@ BOOST_AUTO_TEST_CASE(v5_mei_no_exp) {
                     am::v5::subscribe_packet{
                         *ep(sub).acquire_unique_packet_id(),
                         {
-                            {"topic1"_mb, am::qos::exactly_once},
+                            {"topic1", am::qos::exactly_once},
                         }
                     },
                     *this
@@ -310,8 +309,8 @@ BOOST_AUTO_TEST_CASE(v5_mei_no_exp) {
                     ==
                     (am::v5::publish_packet{
                         1,
-                        "topic1"_mb,
-                        "payload3"_mb,
+                        "topic1",
+                        "payload3",
                         am::qos::exactly_once | am::pub::retain::yes,
                         {am::property::message_expiry_interval{0}}
                     })
@@ -370,10 +369,10 @@ BOOST_AUTO_TEST_CASE(v5_mei_exp) {
                     am::v5::connect_packet{
                         true,   // clean_start
                         0, // keep_alive
-                        "pub"_mb,
+                        "pub",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -384,8 +383,8 @@ BOOST_AUTO_TEST_CASE(v5_mei_exp) {
                 // publish QoS0
                 yield ep(pub).send(
                     am::v5::publish_packet{
-                        "topic1"_mb,
-                        "payload1"_mb,
+                        "topic1",
+                        "payload1",
                         am::qos::at_most_once | am::pub::retain::yes
                     },
                     *this
@@ -396,8 +395,8 @@ BOOST_AUTO_TEST_CASE(v5_mei_exp) {
                 yield ep(pub).send(
                     am::v5::publish_packet{
                         *ep(pub).acquire_unique_packet_id(),
-                        "topic1"_mb,
-                        "payload2"_mb,
+                        "topic1",
+                        "payload2",
                         am::qos::at_least_once | am::pub::retain::yes
                     },
                     *this
@@ -408,8 +407,8 @@ BOOST_AUTO_TEST_CASE(v5_mei_exp) {
                 yield ep(pub).send(
                     am::v5::publish_packet{
                         *ep(pub).acquire_unique_packet_id(),
-                        "topic1"_mb,
-                        "payload3"_mb,
+                        "topic1",
+                        "payload3",
                         am::qos::exactly_once | am::pub::retain::yes,
                         {am::property::message_expiry_interval{1}}
                     },
@@ -431,10 +430,10 @@ BOOST_AUTO_TEST_CASE(v5_mei_exp) {
                     am::v5::connect_packet{
                         true,   // clean_start
                         0, // keep_alive
-                        "sub"_mb,
+                        "sub",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -455,7 +454,7 @@ BOOST_AUTO_TEST_CASE(v5_mei_exp) {
                     am::v5::subscribe_packet{
                         *ep(sub).acquire_unique_packet_id(),
                         {
-                            {"topic1"_mb, am::qos::exactly_once},
+                            {"topic1", am::qos::exactly_once},
                         }
                     },
                     *this
@@ -540,10 +539,10 @@ BOOST_AUTO_TEST_CASE(v5_clear) {
                     am::v5::connect_packet{
                         true,   // clean_start
                         0, // keep_alive
-                        "pub"_mb,
+                        "pub",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -554,8 +553,8 @@ BOOST_AUTO_TEST_CASE(v5_clear) {
                 // publish QoS0
                 yield ep(pub).send(
                     am::v5::publish_packet{
-                        "topic1"_mb,
-                        "payload1"_mb,
+                        "topic1",
+                        "payload1",
                         am::qos::at_most_once | am::pub::retain::yes
                     },
                     *this
@@ -566,8 +565,8 @@ BOOST_AUTO_TEST_CASE(v5_clear) {
                 yield ep(pub).send(
                     am::v5::publish_packet{
                         *ep(pub).acquire_unique_packet_id(),
-                        "topic1"_mb,
-                        ""_mb,
+                        "topic1",
+                        "",
                         am::qos::exactly_once | am::pub::retain::yes
                     },
                     *this
@@ -585,10 +584,10 @@ BOOST_AUTO_TEST_CASE(v5_clear) {
                     am::v5::connect_packet{
                         true,   // clean_start
                         0, // keep_alive
-                        "sub"_mb,
+                        "sub",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -609,7 +608,7 @@ BOOST_AUTO_TEST_CASE(v5_clear) {
                     am::v5::subscribe_packet{
                         *ep(sub).acquire_unique_packet_id(),
                         {
-                            {"topic1"_mb, am::qos::exactly_once},
+                            {"topic1", am::qos::exactly_once},
                         }
                     },
                     *this

--- a/test/system/st_shared_sub.cpp
+++ b/test/system/st_shared_sub.cpp
@@ -15,7 +15,6 @@
 BOOST_AUTO_TEST_SUITE(st_shared_sub)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 namespace as = boost::asio;
 
 BOOST_AUTO_TEST_CASE(v5_from_broker) {
@@ -70,10 +69,10 @@ BOOST_AUTO_TEST_CASE(v5_from_broker) {
                     am::v5::connect_packet{
                         true,   // clean_start
                         0, // keep_alive
-                        "sub1"_mb,
+                        "sub1",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -84,7 +83,7 @@ BOOST_AUTO_TEST_CASE(v5_from_broker) {
                     am::v5::subscribe_packet{
                         *ep(sub1).acquire_unique_packet_id(),
                         {
-                            {"$share/sn1/topic1"_mb, am::qos::at_most_once},
+                            {"$share/sn1/topic1", am::qos::at_most_once},
                         }
                     },
                     *this
@@ -103,10 +102,10 @@ BOOST_AUTO_TEST_CASE(v5_from_broker) {
                     am::v5::connect_packet{
                         true,   // clean_start
                         0, // keep_alive
-                        "sub2"_mb,
+                        "sub2",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -117,7 +116,7 @@ BOOST_AUTO_TEST_CASE(v5_from_broker) {
                     am::v5::subscribe_packet{
                         *ep(sub2).acquire_unique_packet_id(),
                         {
-                            {"$share/sn1/topic1"_mb, am::qos::at_least_once},
+                            {"$share/sn1/topic1", am::qos::at_least_once},
                         }
                     },
                     *this
@@ -136,10 +135,10 @@ BOOST_AUTO_TEST_CASE(v5_from_broker) {
                     am::v5::connect_packet{
                         true,   // clean_start
                         0, // keep_alive
-                        "sub3"_mb,
+                        "sub3",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -150,7 +149,7 @@ BOOST_AUTO_TEST_CASE(v5_from_broker) {
                     am::v5::subscribe_packet{
                         *ep(sub3).acquire_unique_packet_id(),
                         {
-                            {"$share/sn1/topic1"_mb, am::qos::exactly_once},
+                            {"$share/sn1/topic1", am::qos::exactly_once},
                         }
                     },
                     *this
@@ -169,10 +168,10 @@ BOOST_AUTO_TEST_CASE(v5_from_broker) {
                     am::v5::connect_packet{
                         true,   // clean_start
                         0, // keep_alive
-                        "pub"_mb,
+                        "pub",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -183,8 +182,8 @@ BOOST_AUTO_TEST_CASE(v5_from_broker) {
                 // publish 1
                 yield ep(pub).send(
                     am::v5::publish_packet{
-                        "topic1"_mb,
-                        "payload1"_mb,
+                        "topic1",
+                        "payload1",
                         am::qos::at_most_once
                     },
                     *this
@@ -195,8 +194,8 @@ BOOST_AUTO_TEST_CASE(v5_from_broker) {
                 yield ep(pub).send(
                     am::v5::publish_packet{
                         *ep(pub).acquire_unique_packet_id(),
-                        "topic1"_mb,
-                        "payload2"_mb,
+                        "topic1",
+                        "payload2",
                         am::qos::at_least_once
                     },
                     *this
@@ -208,8 +207,8 @@ BOOST_AUTO_TEST_CASE(v5_from_broker) {
                 yield ep(pub).send(
                     am::v5::publish_packet{
                         *ep(pub).acquire_unique_packet_id(),
-                        "topic1"_mb,
-                        "payload3"_mb,
+                        "topic1",
+                        "payload3",
                         am::qos::exactly_once
                     },
                     *this
@@ -220,8 +219,8 @@ BOOST_AUTO_TEST_CASE(v5_from_broker) {
                 // publish 4
                 yield ep(pub).send(
                     am::v5::publish_packet{
-                        "topic1"_mb,
-                        "payload4"_mb,
+                        "topic1",
+                        "payload4",
                         am::qos::at_most_once
                     },
                     *this
@@ -232,8 +231,8 @@ BOOST_AUTO_TEST_CASE(v5_from_broker) {
                 yield ep(pub).send(
                     am::v5::publish_packet{
                         *ep(pub).acquire_unique_packet_id(),
-                        "topic1"_mb,
-                        "payload5"_mb,
+                        "topic1",
+                        "payload5",
                         am::qos::at_least_once
                     },
                     *this
@@ -245,8 +244,8 @@ BOOST_AUTO_TEST_CASE(v5_from_broker) {
                 yield ep(pub).send(
                     am::v5::publish_packet{
                         *ep(pub).acquire_unique_packet_id(),
-                        "topic1"_mb,
-                        "payload6"_mb,
+                        "topic1",
+                        "payload6",
                         am::qos::exactly_once
                     },
                     *this
@@ -259,8 +258,8 @@ BOOST_AUTO_TEST_CASE(v5_from_broker) {
                     *pv
                     ==
                     (am::v5::publish_packet{
-                        "topic1"_mb,
-                        "payload1"_mb,
+                        "topic1",
+                        "payload1",
                         am::qos::at_most_once
                     })
                 );
@@ -270,8 +269,8 @@ BOOST_AUTO_TEST_CASE(v5_from_broker) {
                     ==
                     (am::v5::publish_packet{
                         1,
-                        "topic1"_mb,
-                        "payload2"_mb,
+                        "topic1",
+                        "payload2",
                         am::qos::at_least_once
                     })
                 );
@@ -281,8 +280,8 @@ BOOST_AUTO_TEST_CASE(v5_from_broker) {
                     ==
                     (am::v5::publish_packet{
                         1,
-                        "topic1"_mb,
-                        "payload3"_mb,
+                        "topic1",
+                        "payload3",
                         am::qos::exactly_once
                     })
                 );
@@ -292,8 +291,8 @@ BOOST_AUTO_TEST_CASE(v5_from_broker) {
                     *pv
                     ==
                     (am::v5::publish_packet{
-                        "topic1"_mb,
-                        "payload4"_mb,
+                        "topic1",
+                        "payload4",
                         am::qos::at_most_once
                     })
                 );
@@ -303,8 +302,8 @@ BOOST_AUTO_TEST_CASE(v5_from_broker) {
                     ==
                     (am::v5::publish_packet{
                         2,
-                        "topic1"_mb,
-                        "payload5"_mb,
+                        "topic1",
+                        "payload5",
                         am::qos::at_least_once
                     })
                 );
@@ -314,8 +313,8 @@ BOOST_AUTO_TEST_CASE(v5_from_broker) {
                     ==
                     (am::v5::publish_packet{
                         2,
-                        "topic1"_mb,
-                        "payload6"_mb,
+                        "topic1",
+                        "payload6",
                         am::qos::exactly_once
                     })
                 );
@@ -388,10 +387,10 @@ BOOST_AUTO_TEST_CASE(v5_unsub_from_broker) {
                     am::v5::connect_packet{
                         true,   // clean_start
                         0, // keep_alive
-                        "sub1"_mb,
+                        "sub1",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -402,7 +401,7 @@ BOOST_AUTO_TEST_CASE(v5_unsub_from_broker) {
                     am::v5::subscribe_packet{
                         *ep(sub1).acquire_unique_packet_id(),
                         {
-                            {"$share/sn1/topic1"_mb, am::qos::at_most_once},
+                            {"$share/sn1/topic1", am::qos::at_most_once},
                         },
                         {am::property::subscription_identifier{1}}
                     },
@@ -422,10 +421,10 @@ BOOST_AUTO_TEST_CASE(v5_unsub_from_broker) {
                     am::v5::connect_packet{
                         true,   // clean_start
                         0, // keep_alive
-                        "sub2"_mb,
+                        "sub2",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -436,7 +435,7 @@ BOOST_AUTO_TEST_CASE(v5_unsub_from_broker) {
                     am::v5::subscribe_packet{
                         *ep(sub2).acquire_unique_packet_id(),
                         {
-                            {"$share/sn1/topic1"_mb, am::qos::at_least_once},
+                            {"$share/sn1/topic1", am::qos::at_least_once},
                         },
                         {am::property::subscription_identifier{1}}
                     },
@@ -456,10 +455,10 @@ BOOST_AUTO_TEST_CASE(v5_unsub_from_broker) {
                     am::v5::connect_packet{
                         true,   // clean_start
                         0, // keep_alive
-                        "sub3"_mb,
+                        "sub3",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -470,7 +469,7 @@ BOOST_AUTO_TEST_CASE(v5_unsub_from_broker) {
                     am::v5::subscribe_packet{
                         *ep(sub3).acquire_unique_packet_id(),
                         {
-                            {"$share/sn1/topic1"_mb, am::qos::exactly_once},
+                            {"$share/sn1/topic1", am::qos::exactly_once},
                         },
                         {am::property::subscription_identifier{10}}
                     },
@@ -490,10 +489,10 @@ BOOST_AUTO_TEST_CASE(v5_unsub_from_broker) {
                     am::v5::connect_packet{
                         true,   // clean_start
                         0, // keep_alive
-                        "pub"_mb,
+                        "pub",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -504,8 +503,8 @@ BOOST_AUTO_TEST_CASE(v5_unsub_from_broker) {
                 // publish 1
                 yield ep(pub).send(
                     am::v5::publish_packet{
-                        "topic1"_mb,
-                        "payload1"_mb,
+                        "topic1",
+                        "payload1",
                         am::qos::at_most_once
                     },
                     *this
@@ -516,8 +515,8 @@ BOOST_AUTO_TEST_CASE(v5_unsub_from_broker) {
                 yield ep(pub).send(
                     am::v5::publish_packet{
                         *ep(pub).acquire_unique_packet_id(),
-                        "topic1"_mb,
-                        "payload2"_mb,
+                        "topic1",
+                        "payload2",
                         am::qos::at_least_once
                     },
                     *this
@@ -529,8 +528,8 @@ BOOST_AUTO_TEST_CASE(v5_unsub_from_broker) {
                 yield ep(pub).send(
                     am::v5::publish_packet{
                         *ep(pub).acquire_unique_packet_id(),
-                        "topic1"_mb,
-                        "payload3"_mb,
+                        "topic1",
+                        "payload3",
                         am::qos::exactly_once
                     },
                     *this
@@ -544,8 +543,8 @@ BOOST_AUTO_TEST_CASE(v5_unsub_from_broker) {
                     *pv
                     ==
                     (am::v5::publish_packet{
-                        "topic1"_mb,
-                        "payload1"_mb,
+                        "topic1",
+                        "payload1",
                         am::qos::at_most_once,
                         {am::property::subscription_identifier{1}}
                     })
@@ -556,8 +555,8 @@ BOOST_AUTO_TEST_CASE(v5_unsub_from_broker) {
                     ==
                     (am::v5::publish_packet{
                         1,
-                        "topic1"_mb,
-                        "payload2"_mb,
+                        "topic1",
+                        "payload2",
                         am::qos::at_least_once,
                         {am::property::subscription_identifier{1}}
                     })
@@ -568,8 +567,8 @@ BOOST_AUTO_TEST_CASE(v5_unsub_from_broker) {
                     ==
                     (am::v5::publish_packet{
                         1,
-                        "topic1"_mb,
-                        "payload3"_mb,
+                        "topic1",
+                        "payload3",
                         am::qos::exactly_once,
                         {am::property::subscription_identifier{10}}
                     })
@@ -581,7 +580,7 @@ BOOST_AUTO_TEST_CASE(v5_unsub_from_broker) {
                     am::v5::unsubscribe_packet{
                         *pid,
                         {
-                            "$share/sn1/topic1"_mb
+                            "$share/sn1/topic1"
                         }
                     },
                     *this
@@ -593,8 +592,8 @@ BOOST_AUTO_TEST_CASE(v5_unsub_from_broker) {
                 // publish 4
                 yield ep(pub).send(
                     am::v5::publish_packet{
-                        "topic1"_mb,
-                        "payload4"_mb,
+                        "topic1",
+                        "payload4",
                         am::qos::at_most_once
                     },
                     *this
@@ -605,8 +604,8 @@ BOOST_AUTO_TEST_CASE(v5_unsub_from_broker) {
                 yield ep(pub).send(
                     am::v5::publish_packet{
                         *ep(pub).acquire_unique_packet_id(),
-                        "topic1"_mb,
-                        "payload5"_mb,
+                        "topic1",
+                        "payload5",
                         am::qos::at_least_once
                     },
                     *this
@@ -618,8 +617,8 @@ BOOST_AUTO_TEST_CASE(v5_unsub_from_broker) {
                 yield ep(pub).send(
                     am::v5::publish_packet{
                         *ep(pub).acquire_unique_packet_id(),
-                        "topic1"_mb,
-                        "payload6"_mb,
+                        "topic1",
+                        "payload6",
                         am::qos::exactly_once
                     },
                     *this
@@ -632,8 +631,8 @@ BOOST_AUTO_TEST_CASE(v5_unsub_from_broker) {
                     *pv
                     ==
                     (am::v5::publish_packet{
-                        "topic1"_mb,
-                        "payload4"_mb,
+                        "topic1",
+                        "payload4",
                         am::qos::at_most_once,
                         {am::property::subscription_identifier{1}}
                     })
@@ -645,8 +644,8 @@ BOOST_AUTO_TEST_CASE(v5_unsub_from_broker) {
                     ==
                     (am::v5::publish_packet{
                         2,
-                        "topic1"_mb,
-                        "payload5"_mb,
+                        "topic1",
+                        "payload5",
                         am::qos::at_least_once,
                         {am::property::subscription_identifier{10}}
                     })
@@ -657,8 +656,8 @@ BOOST_AUTO_TEST_CASE(v5_unsub_from_broker) {
                     ==
                     (am::v5::publish_packet{
                         1,
-                        "topic1"_mb,
-                        "payload6"_mb,
+                        "topic1",
+                        "payload6",
                         am::qos::at_least_once,
                         {am::property::subscription_identifier{1}}
                     })

--- a/test/system/st_sub.cpp
+++ b/test/system/st_sub.cpp
@@ -15,7 +15,6 @@
 BOOST_AUTO_TEST_SUITE(st_sub)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 namespace as = boost::asio;
 
 BOOST_AUTO_TEST_CASE(v311_sub) {
@@ -46,10 +45,10 @@ BOOST_AUTO_TEST_CASE(v311_sub) {
                     am::v3_1_1::connect_packet{
                         true,   // clean_session
                         0,      // keep_alive none
-                        "cid1"_mb,
+                        "cid1",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -63,9 +62,9 @@ BOOST_AUTO_TEST_CASE(v311_sub) {
                     am::v3_1_1::subscribe_packet{
                         pid,
                         {
-                            {"topic1"_mb, am::qos::at_most_once},
-                            {"topic2"_mb, am::qos::at_least_once},
-                            {"topic3"_mb, am::qos::exactly_once},
+                            {"topic1", am::qos::at_most_once},
+                            {"topic2", am::qos::at_least_once},
+                            {"topic3", am::qos::exactly_once},
                         }
                     },
                     *this
@@ -89,9 +88,9 @@ BOOST_AUTO_TEST_CASE(v311_sub) {
                     am::v3_1_1::subscribe_packet{
                         pid,
                         {
-                            {"topic1"_mb, am::qos::at_least_once},
-                            {"topic2"_mb, am::qos::exactly_once},
-                            {"topic3"_mb, am::qos::at_most_once},
+                            {"topic1", am::qos::at_least_once},
+                            {"topic2", am::qos::exactly_once},
+                            {"topic3", am::qos::at_most_once},
                         }
                     },
                     *this
@@ -115,9 +114,9 @@ BOOST_AUTO_TEST_CASE(v311_sub) {
                     am::v3_1_1::unsubscribe_packet{
                         pid,
                         {
-                            "topic1"_mb,
-                            "topic2"_mb,
-                            "topic3"_mb,
+                            "topic1",
+                            "topic2",
+                            "topic3",
                         }
                     },
                     *this
@@ -170,10 +169,10 @@ BOOST_AUTO_TEST_CASE(v5_sub) {
                     am::v5::connect_packet{
                         true,   // clean_session
                         0,      // keep_alive none
-                        "cid1"_mb,
+                        "cid1",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb,
+                        "u1",
+                        "passforu1",
                         am::properties{}
                     },
                     *this
@@ -189,21 +188,21 @@ BOOST_AUTO_TEST_CASE(v5_sub) {
                         pid,
                         {
                             {
-                                "topic1"_mb,
+                                "topic1",
                                 am::qos::at_most_once |
                                 am::sub::retain_handling::send |
                                 am::sub::rap::dont |
                                 am::sub::nl::no
                             },
                             {
-                                "topic2"_mb,
+                                "topic2",
                                 am::qos::at_least_once |
                                 am::sub::retain_handling::send_only_new_subscription |
                                 am::sub::rap::retain |
                                 am::sub::nl::yes
                             },
                             {
-                                "topic3"_mb,
+                                "topic3",
                                 am::qos::exactly_once |
                                 am::sub::retain_handling::not_send
                             },
@@ -232,9 +231,9 @@ BOOST_AUTO_TEST_CASE(v5_sub) {
                     am::v5::subscribe_packet{
                         pid,
                         {
-                            {"topic1"_mb, am::qos::at_least_once},
-                            {"topic2"_mb, am::qos::exactly_once},
-                            {"topic3"_mb, am::qos::at_most_once},
+                            {"topic1", am::qos::at_least_once},
+                            {"topic2", am::qos::exactly_once},
+                            {"topic3", am::qos::at_most_once},
                         },
                         am::properties{}
                     },
@@ -260,9 +259,9 @@ BOOST_AUTO_TEST_CASE(v5_sub) {
                     am::v5::unsubscribe_packet{
                         pid,
                         {
-                            "topic1"_mb,
-                            "topic2"_mb,
-                            "topic3"_mb,
+                            "topic1",
+                            "topic2",
+                            "topic3",
                         },
                         am::properties{}
                     },

--- a/test/system/st_will.cpp
+++ b/test/system/st_will.cpp
@@ -15,7 +15,6 @@
 BOOST_AUTO_TEST_SUITE(st_will)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 namespace as = boost::asio;
 
 BOOST_AUTO_TEST_CASE(v311_will) {
@@ -55,10 +54,10 @@ BOOST_AUTO_TEST_CASE(v311_will) {
                     am::v3_1_1::connect_packet{
                         true,   // clean_session
                         0, // keep_alive
-                        "sub"_mb,
+                        "sub",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -79,7 +78,7 @@ BOOST_AUTO_TEST_CASE(v311_will) {
                     am::v3_1_1::subscribe_packet{
                         *ep(sub).acquire_unique_packet_id(),
                         {
-                            {"topic1"_mb, am::qos::exactly_once},
+                            {"topic1", am::qos::exactly_once},
                         }
                     },
                     *this
@@ -98,14 +97,14 @@ BOOST_AUTO_TEST_CASE(v311_will) {
                     am::v3_1_1::connect_packet{
                         true,   // clean_session
                         0, // keep_alive
-                        "pub"_mb,
+                        "pub",
                         am::will{
-                            "topic1"_mb,
-                            "payload0"_mb,
+                            "topic1",
+                            "payload0",
                             am::qos::at_most_once
                         },
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -119,8 +118,8 @@ BOOST_AUTO_TEST_CASE(v311_will) {
                     *pv
                     ==
                     (am::v3_1_1::publish_packet{
-                        "topic1"_mb,
-                        "payload0"_mb,
+                        "topic1",
+                        "payload0",
                         am::qos::at_most_once
                     })
                 );
@@ -174,10 +173,10 @@ BOOST_AUTO_TEST_CASE(v5_will_wd_send) {
                     am::v5::connect_packet{
                         true,   // clean_start
                         0, // keep_alive
-                        "sub"_mb,
+                        "sub",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -198,7 +197,7 @@ BOOST_AUTO_TEST_CASE(v5_will_wd_send) {
                     am::v5::subscribe_packet{
                         *ep(sub).acquire_unique_packet_id(),
                         {
-                            {"topic1"_mb, am::qos::exactly_once},
+                            {"topic1", am::qos::exactly_once},
                         }
                     },
                     *this
@@ -217,15 +216,15 @@ BOOST_AUTO_TEST_CASE(v5_will_wd_send) {
                     am::v5::connect_packet{
                         true,   // clean_start
                         0, // keep_alive
-                        "pub"_mb,
+                        "pub",
                         am::will{
-                            "topic1"_mb,
-                            "payload0"_mb,
+                            "topic1",
+                            "payload0",
                             am::qos::at_most_once,
                             {am::property::will_delay_interval{1}},
                         },
-                        "u1"_mb,
-                        "passforu1"_mb,
+                        "u1",
+                        "passforu1",
                         {
                             am::property::session_expiry_interval{2},
                         }
@@ -242,8 +241,8 @@ BOOST_AUTO_TEST_CASE(v5_will_wd_send) {
                     *pv
                     ==
                     (am::v5::publish_packet{
-                        "topic1"_mb,
-                        "payload0"_mb,
+                        "topic1",
+                        "payload0",
                         am::qos::at_most_once
                     })
                 );
@@ -297,10 +296,10 @@ BOOST_AUTO_TEST_CASE(v5_will_wd_send_sei) {
                     am::v5::connect_packet{
                         true,   // clean_start
                         0, // keep_alive
-                        "sub"_mb,
+                        "sub",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -321,7 +320,7 @@ BOOST_AUTO_TEST_CASE(v5_will_wd_send_sei) {
                     am::v5::subscribe_packet{
                         *ep(sub).acquire_unique_packet_id(),
                         {
-                            {"topic1"_mb, am::qos::exactly_once},
+                            {"topic1", am::qos::exactly_once},
                         }
                     },
                     *this
@@ -340,15 +339,15 @@ BOOST_AUTO_TEST_CASE(v5_will_wd_send_sei) {
                     am::v5::connect_packet{
                         true,   // clean_start
                         0, // keep_alive
-                        "pub"_mb,
+                        "pub",
                         am::will{
-                            "topic1"_mb,
-                            "payload0"_mb,
+                            "topic1",
+                            "payload0",
                             am::qos::at_most_once,
                             {am::property::will_delay_interval{2}},
                         },
-                        "u1"_mb,
-                        "passforu1"_mb,
+                        "u1",
+                        "passforu1",
                         {
                             am::property::session_expiry_interval{1},
                         }
@@ -365,8 +364,8 @@ BOOST_AUTO_TEST_CASE(v5_will_wd_send_sei) {
                     *pv
                     ==
                     (am::v5::publish_packet{
-                        "topic1"_mb,
-                        "payload0"_mb,
+                        "topic1",
+                        "payload0",
                         am::qos::at_most_once
                     })
                 );
@@ -420,10 +419,10 @@ BOOST_AUTO_TEST_CASE(v5_will_wd_send_sei_disconnect) {
                     am::v5::connect_packet{
                         true,   // clean_start
                         0, // keep_alive
-                        "sub"_mb,
+                        "sub",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -444,7 +443,7 @@ BOOST_AUTO_TEST_CASE(v5_will_wd_send_sei_disconnect) {
                     am::v5::subscribe_packet{
                         *ep(sub).acquire_unique_packet_id(),
                         {
-                            {"topic1"_mb, am::qos::exactly_once},
+                            {"topic1", am::qos::exactly_once},
                         }
                     },
                     *this
@@ -463,15 +462,15 @@ BOOST_AUTO_TEST_CASE(v5_will_wd_send_sei_disconnect) {
                     am::v5::connect_packet{
                         true,   // clean_start
                         0, // keep_alive
-                        "pub"_mb,
+                        "pub",
                         am::will{
-                            "topic1"_mb,
-                            "payload0"_mb,
+                            "topic1",
+                            "payload0",
                             am::qos::at_most_once,
                             {am::property::will_delay_interval{2}},
                         },
-                        "u1"_mb,
-                        "passforu1"_mb,
+                        "u1",
+                        "passforu1",
                         {
                             am::property::session_expiry_interval{1},
                         }
@@ -495,8 +494,8 @@ BOOST_AUTO_TEST_CASE(v5_will_wd_send_sei_disconnect) {
                     *pv
                     ==
                     (am::v5::publish_packet{
-                        "topic1"_mb,
-                        "payload0"_mb,
+                        "topic1",
+                        "payload0",
                         am::qos::at_most_once
                     })
                 );
@@ -550,10 +549,10 @@ BOOST_AUTO_TEST_CASE(v5_will_wd_not_send_sei_disconnect) {
                     am::v5::connect_packet{
                         true,   // clean_start
                         0, // keep_alive
-                        "sub"_mb,
+                        "sub",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -574,7 +573,7 @@ BOOST_AUTO_TEST_CASE(v5_will_wd_not_send_sei_disconnect) {
                     am::v5::subscribe_packet{
                         *ep(sub).acquire_unique_packet_id(),
                         {
-                            {"topic1"_mb, am::qos::exactly_once},
+                            {"topic1", am::qos::exactly_once},
                         }
                     },
                     *this
@@ -593,15 +592,15 @@ BOOST_AUTO_TEST_CASE(v5_will_wd_not_send_sei_disconnect) {
                     am::v5::connect_packet{
                         true,   // clean_start
                         0, // keep_alive
-                        "pub"_mb,
+                        "pub",
                         am::will{
-                            "topic1"_mb,
-                            "payload0"_mb,
+                            "topic1",
+                            "payload0",
                             am::qos::at_most_once,
                             {am::property::will_delay_interval{1}},
                         },
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -692,10 +691,10 @@ BOOST_AUTO_TEST_CASE(v5_will_wd_not_send_mei) {
                     am::v5::connect_packet{
                         true,   // clean_start
                         0, // keep_alive
-                        "sub"_mb,
+                        "sub",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );
@@ -716,7 +715,7 @@ BOOST_AUTO_TEST_CASE(v5_will_wd_not_send_mei) {
                     am::v5::subscribe_packet{
                         *ep(sub).acquire_unique_packet_id(),
                         {
-                            {"topic1"_mb, am::qos::exactly_once},
+                            {"topic1", am::qos::exactly_once},
                         }
                     },
                     *this
@@ -735,18 +734,18 @@ BOOST_AUTO_TEST_CASE(v5_will_wd_not_send_mei) {
                     am::v5::connect_packet{
                         true,   // clean_start
                         0, // keep_alive
-                        "pub"_mb,
+                        "pub",
                         am::will{
-                            "topic1"_mb,
-                            "payload0"_mb,
+                            "topic1",
+                            "payload0",
                             am::qos::at_most_once,
                             {
                                 am::property::will_delay_interval{2},
                                 am::property::message_expiry_interval{1}
                             },
                         },
-                        "u1"_mb,
-                        "passforu1"_mb,
+                        "u1",
+                        "passforu1",
                         {
                             am::property::session_expiry_interval{2}
                         }

--- a/test/system/st_ws_connect.cpp
+++ b/test/system/st_ws_connect.cpp
@@ -17,7 +17,6 @@
 BOOST_AUTO_TEST_SUITE(st_connect)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 namespace as = boost::asio;
 
 BOOST_AUTO_TEST_CASE(cb) {
@@ -44,10 +43,10 @@ BOOST_AUTO_TEST_CASE(cb) {
                         am::v3_1_1::connect_packet{
                             true,   // clean_session
                             0x1234, // keep_alive
-                            "cid1"_mb,
+                            "cid1",
                             std::nullopt, // will
-                            "u1"_mb,
-                            "passforu1"_mb
+                            "u1",
+                            "passforu1"
                         },
                         [&](am::system_error const& se) {
                             BOOST_TEST(!se);
@@ -131,10 +130,10 @@ BOOST_AUTO_TEST_CASE(fut) {
                 am::v3_1_1::connect_packet{
                     true,   // clean_session
                     0x1234, // keep_alive
-                    "cid1"_mb,
+                    "cid1",
                     std::nullopt, // will
-                    "u1"_mb,
-                    "passforu1"_mb
+                    "u1",
+                    "passforu1"
                 },
                 as::use_future
             );
@@ -196,10 +195,10 @@ BOOST_AUTO_TEST_CASE(coro) {
                     am::v3_1_1::connect_packet{
                         true,   // clean_session
                         0x1234, // keep_alive
-                        "cid1"_mb,
+                        "cid1",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );

--- a/test/system/st_wss_connect.cpp
+++ b/test/system/st_wss_connect.cpp
@@ -17,7 +17,6 @@
 BOOST_AUTO_TEST_SUITE(st_connect)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 namespace as = boost::asio;
 
 BOOST_AUTO_TEST_CASE(cb) {
@@ -54,10 +53,10 @@ BOOST_AUTO_TEST_CASE(cb) {
                                 am::v3_1_1::connect_packet{
                                     true,   // clean_session
                                     0x1234, // keep_alive
-                                    "cid1"_mb,
+                                    "cid1",
                                     std::nullopt, // will
-                                    "u1"_mb,
-                                    "passforu1"_mb
+                                    "u1",
+                                    "passforu1"
                                 },
                                 [&](am::system_error const& se) {
                                     BOOST_TEST(!se);
@@ -161,10 +160,10 @@ BOOST_AUTO_TEST_CASE(fut) {
                 am::v3_1_1::connect_packet{
                     true,   // clean_session
                     0x1234, // keep_alive
-                    "cid1"_mb,
+                    "cid1",
                     std::nullopt, // will
-                    "u1"_mb,
-                    "passforu1"_mb
+                    "u1",
+                    "passforu1"
                 },
                 as::use_future
             );
@@ -236,10 +235,10 @@ BOOST_AUTO_TEST_CASE(coro) {
                     am::v3_1_1::connect_packet{
                         true,   // clean_session
                         0x1234, // keep_alive
-                        "cid1"_mb,
+                        "cid1",
                         std::nullopt, // will
-                        "u1"_mb,
-                        "passforu1"_mb
+                        "u1",
+                        "passforu1"
                     },
                     *this
                 );

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -83,9 +83,14 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     link_directories(${Boost_LIBRARY_DIRS})
 endif()
 
+
 foreach(source_file ${check_PROGRAMS})
     get_filename_component(source_file_we ${source_file} NAME_WE)
     add_executable(${source_file_we} ${source_file})
+    if(${source_file} MATCHES "ut_packet_v.*")
+        message(STATUS ${source_file})
+        target_compile_definitions(${source_file_we} PUBLIC ASYNC_MQTT_UNIT_TEST_FOR_PACKET)
+    endif()
     target_link_libraries(${source_file_we} async_mqtt_iface)
     target_compile_definitions(
         ${source_file_we}

--- a/test/unit/cpp20coro_stub_socket.hpp
+++ b/test/unit/cpp20coro_stub_socket.hpp
@@ -14,6 +14,8 @@
 
 #include <async_mqtt/buffer_to_packet_variant.hpp>
 
+#include "test_allocate_buffer.hpp"
+
 namespace async_mqtt {
 
 namespace as = boost::asio;

--- a/test/unit/stub_socket.hpp
+++ b/test/unit/stub_socket.hpp
@@ -13,6 +13,8 @@
 
 #include <async_mqtt/buffer_to_packet_variant.hpp>
 
+#include "test_allocate_buffer.hpp"
+
 namespace async_mqtt {
 
 namespace as = boost::asio;

--- a/test/unit/test_allocate_buffer.hpp
+++ b/test/unit/test_allocate_buffer.hpp
@@ -1,0 +1,30 @@
+// Copyright Takatoshi Kondo 2022
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(ASYNC_MQTT_TEST_UNI_ALLOCATE_BUFFER_HPP)
+#define ASYNC_MQTT_TEST_UNI_ALLOCATE_BUFFER_HPP
+
+#include <async_mqtt/buffer.hpp>
+
+namespace async_mqtt {
+
+template <typename Iterator>
+inline buffer allocate_buffer(Iterator b, Iterator e) {
+    auto size = static_cast<std::size_t>(std::distance(b, e));
+    if (size == 0) return buffer(&*b, size);
+    auto spa = make_shared_ptr_array(size);
+    std::copy(b, e, spa.get());
+    auto p = spa.get();
+    return buffer(p, size, force_move(spa));
+}
+
+inline buffer allocate_buffer(std::string_view sv) {
+    return allocate_buffer(sv.begin(), sv.end());
+}
+
+} // namespace async_mqtt
+
+#endif // ASYNC_MQTT_TEST_UNI_ALLOCATE_BUFFER_HPP

--- a/test/unit/ut_broker_security.cpp
+++ b/test/unit/ut_broker_security.cpp
@@ -12,7 +12,6 @@
 BOOST_AUTO_TEST_SUITE(ut_broker_security)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 
 void load_config(am::security &security, std::string const& value)
 {

--- a/test/unit/ut_cpp20coro_broker.cpp
+++ b/test/unit/ut_cpp20coro_broker.cpp
@@ -22,7 +22,6 @@
 BOOST_AUTO_TEST_SUITE(ut_broker)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 namespace as = boost::asio;
 
 BOOST_AUTO_TEST_CASE(tc1) {
@@ -66,7 +65,7 @@ BOOST_AUTO_TEST_CASE(tc1) {
                 auto c2b_packet = am::v3_1_1::connect_packet{
                     true,   // clean_session
                     0x1234, // keep_alive
-                    "cid1"_mb
+                    "cid1"
                 };
                 co_await ep1->next_layer().emulate_recv(
                     am::force_move(c2b_packet),
@@ -86,8 +85,8 @@ BOOST_AUTO_TEST_CASE(tc1) {
                 auto c2b_packet = am::v3_1_1::subscribe_packet{
                     0x1234,         // packet_id
                     {
-                        {"topic1"_mb, am::qos::at_most_once},
-                        {"topic2"_mb, am::qos::exactly_once},
+                        {"topic1", am::qos::at_most_once},
+                        {"topic2", am::qos::exactly_once},
                     }
                 };
                 co_await ep1->next_layer().emulate_recv(
@@ -111,7 +110,7 @@ BOOST_AUTO_TEST_CASE(tc1) {
                 auto c2b_packet = am::v5::connect_packet{
                     true,   // clean_start
                     0x1234, // keep_alive
-                    "cid2"_mb
+                    "cid2"
                 };
                 co_await ep2->next_layer().emulate_recv(
                     am::force_move(c2b_packet),
@@ -135,7 +134,7 @@ BOOST_AUTO_TEST_CASE(tc1) {
                 auto c2b_packet = am::v5::subscribe_packet{
                     0x1234,         // packet_id
                     {
-                        {"topic1"_mb, am::qos::at_most_once}
+                        {"topic1", am::qos::at_most_once}
                     }
                 };
                 co_await ep2->next_layer().emulate_recv(
@@ -157,8 +156,8 @@ BOOST_AUTO_TEST_CASE(tc1) {
                 // publish ep2
                 auto c2b_packet = am::v5::publish_packet{
                     0x1234, // packet_id
-                    "topic1"_mb,
-                    "payload1"_mb,
+                    "topic1",
+                    "payload1",
                     am::qos::at_least_once | am::pub::retain::yes | am::pub::dup::no,
                     am::properties{
                         am::property::content_type("json")
@@ -172,8 +171,8 @@ BOOST_AUTO_TEST_CASE(tc1) {
             {
                 // recv ep1
                 auto exp_packet = am::v3_1_1::publish_packet{
-                    "topic1"_mb,
-                    "payload1"_mb,
+                    "topic1",
+                    "payload1",
                     am::qos::at_most_once | am::pub::retain::no | am::pub::dup::no
                 };
                 auto b2c_packet = co_await ep1->next_layer().wait_response(as::deferred);
@@ -182,8 +181,8 @@ BOOST_AUTO_TEST_CASE(tc1) {
             {
                 std::set<am::packet_variant> exp_packets {
                     am::v5::publish_packet{
-                        "topic1"_mb,
-                        "payload1"_mb,
+                        "topic1",
+                        "payload1",
                         am::qos::at_most_once | am::pub::retain::no | am::pub::dup::no,
                         am::properties{
                             am::property::content_type("json")

--- a/test/unit/ut_cpp20coro_ep.cpp
+++ b/test/unit/ut_cpp20coro_ep.cpp
@@ -19,7 +19,6 @@
 BOOST_AUTO_TEST_SUITE(ut_broker)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 namespace as = boost::asio;
 
 BOOST_AUTO_TEST_CASE(pingresp_tout_v311) {
@@ -42,7 +41,7 @@ BOOST_AUTO_TEST_CASE(pingresp_tout_v311) {
                 auto connect = am::v3_1_1::connect_packet{
                     true,   // clean_session
                     0x1234, // keep_alive
-                    "cid1"_mb
+                    "cid1"
                 };
                 auto se = co_await ep->send(connect, as::deferred);
                 BOOST_TEST(!se);
@@ -93,7 +92,7 @@ BOOST_AUTO_TEST_CASE(pingresp_tout_v5) {
                 auto connect = am::v5::connect_packet{
                     true,   // clean_session
                     0x1234, // keep_alive
-                    "cid1"_mb
+                    "cid1"
                 };
                 auto se = co_await ep->send(connect, as::deferred);
                 BOOST_TEST(!se);

--- a/test/unit/ut_cpp20coro_exec.cpp
+++ b/test/unit/ut_cpp20coro_exec.cpp
@@ -19,7 +19,6 @@
 BOOST_AUTO_TEST_SUITE(ut_cpp20coro_exec)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 namespace as = boost::asio;
 
 // coroutine executor and endpoint executor are different.
@@ -59,10 +58,10 @@ BOOST_AUTO_TEST_CASE(different) {
             auto connect = am::v3_1_1::connect_packet{
                 true,   // clean_session
                 0, // keep_alive
-                "cid1"_mb,
+                "cid1",
                 std::nullopt, // will
-                "user1"_mb,
-                "pass1"_mb
+                "user1",
+                "pass1"
             };
             auto connack = am::v3_1_1::connack_packet{
                 true,   // session_present
@@ -97,8 +96,8 @@ BOOST_AUTO_TEST_CASE(different) {
             BOOST_TEST(str_ep.running_in_this_thread());
 
             auto pub = am::v5::publish_packet{
-                "topic1"_mb,
-                "payload1"_mb,
+                "topic1",
+                "payload1",
                 am::qos::at_most_once | am::pub::retain::yes | am::pub::dup::yes
             };
 
@@ -157,10 +156,10 @@ BOOST_AUTO_TEST_CASE(bind) {
             auto connect = am::v3_1_1::connect_packet{
                 true,   // clean_session
                 0, // keep_alive
-                "cid1"_mb,
+                "cid1",
                 std::nullopt, // will
-                "user1"_mb,
-                "pass1"_mb
+                "user1",
+                "pass1"
             };
             auto connack = am::v3_1_1::connack_packet{
                 true,   // session_present
@@ -195,8 +194,8 @@ BOOST_AUTO_TEST_CASE(bind) {
             BOOST_TEST(str_ep.running_in_this_thread());
 
             auto pub = am::v5::publish_packet{
-                "topic1"_mb,
-                "payload1"_mb,
+                "topic1",
+                "payload1",
                 am::qos::at_most_once | am::pub::retain::yes | am::pub::dup::yes
             };
 
@@ -249,10 +248,10 @@ BOOST_AUTO_TEST_CASE(same) {
             auto connect = am::v3_1_1::connect_packet{
                 true,   // clean_session
                 0, // keep_alive
-                "cid1"_mb,
+                "cid1",
                 std::nullopt, // will
-                "user1"_mb,
-                "pass1"_mb
+                "user1",
+                "pass1"
             };
             auto connack = am::v3_1_1::connack_packet{
                 true,   // session_present
@@ -287,8 +286,8 @@ BOOST_AUTO_TEST_CASE(same) {
             BOOST_TEST(str.running_in_this_thread());
 
             auto pub = am::v5::publish_packet{
-                "topic1"_mb,
-                "payload1"_mb,
+                "topic1",
+                "payload1",
                 am::qos::at_most_once | am::pub::retain::yes | am::pub::dup::yes
             };
 

--- a/test/unit/ut_ep_con_discon.cpp
+++ b/test/unit/ut_ep_con_discon.cpp
@@ -19,7 +19,6 @@
 BOOST_AUTO_TEST_SUITE(ut_ep_con_discon)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 namespace as = boost::asio;
 
 // packet_id is hard coded in this test case for just testing.
@@ -48,10 +47,10 @@ BOOST_AUTO_TEST_CASE(valid_client_v3_1_1) {
     auto connect = am::v3_1_1::connect_packet{
         true,   // clean_session
         0x1234, // keep_alive
-        "cid1"_mb,
+        "cid1",
         std::nullopt, // will
-        "user1"_mb,
-        "pass1"_mb
+        "user1",
+        "pass1"
     };
 
     auto connack = am::v3_1_1::connack_packet{
@@ -63,8 +62,8 @@ BOOST_AUTO_TEST_CASE(valid_client_v3_1_1) {
 
     auto publish = am::v3_1_1::publish_packet(
         0x1, // hard coded packet_id for just testing
-        "topic1"_mb,
-        "payload1"_mb,
+        "topic1",
+        "payload1",
         am::qos::exactly_once | am::pub::retain::yes | am::pub::dup::yes
     );
 
@@ -87,16 +86,16 @@ BOOST_AUTO_TEST_CASE(valid_client_v3_1_1) {
     auto subscribe = am::v3_1_1::subscribe_packet{
         0x1, // hard coded packet_id for just testing
         std::vector<am::topic_subopts> {
-            {"topic1"_mb, am::qos::at_most_once},
-            {"topic2"_mb, am::qos::exactly_once},
+            {"topic1", am::qos::at_most_once},
+            {"topic2", am::qos::exactly_once},
         }
     };
 
     auto unsubscribe = am::v3_1_1::unsubscribe_packet{
         0x1, // hard coded packet_id for just testing
         std::vector<am::topic_sharename> {
-            "topic1"_mb,
-            "topic2"_mb,
+            am::topic_sharename{"topic1"},
+            am::topic_sharename{"topic2"},
         }
     };
 
@@ -290,10 +289,10 @@ BOOST_AUTO_TEST_CASE(invalid_client_v3_1_1) {
     auto connect = am::v3_1_1::connect_packet{
         true,   // clean_session
         0x1234, // keep_alive
-        "cid1"_mb,
+        "cid1",
         std::nullopt, // will
-        "user1"_mb,
-        "pass1"_mb
+        "user1",
+        "pass1"
     };
 
     auto connack = am::v3_1_1::connack_packet{
@@ -305,8 +304,8 @@ BOOST_AUTO_TEST_CASE(invalid_client_v3_1_1) {
 
     auto publish = am::v3_1_1::publish_packet(
         0x1, // hard coded packet_id for just testing
-        "topic1"_mb,
-        "payload1"_mb,
+        "topic1",
+        "payload1",
         am::qos::exactly_once | am::pub::retain::yes | am::pub::dup::yes
     );
 
@@ -329,8 +328,8 @@ BOOST_AUTO_TEST_CASE(invalid_client_v3_1_1) {
     auto subscribe = am::v3_1_1::subscribe_packet{
         0x1, // hard coded packet_id for just testing
         std::vector<am::topic_subopts> {
-            {"topic1"_mb, am::qos::at_most_once},
-            {"topic2"_mb, am::qos::exactly_once},
+            {"topic1", am::qos::at_most_once},
+            {"topic2", am::qos::exactly_once},
         }
     };
 
@@ -345,8 +344,8 @@ BOOST_AUTO_TEST_CASE(invalid_client_v3_1_1) {
     auto unsubscribe = am::v3_1_1::unsubscribe_packet{
         0x1, // hard coded packet_id for just testing
         std::vector<am::topic_sharename> {
-            "topic1"_mb,
-            "topic2"_mb,
+            am::topic_sharename{"topic1"},
+            am::topic_sharename{"topic2"},
         }
     };
 
@@ -751,10 +750,10 @@ BOOST_AUTO_TEST_CASE(valid_server_v3_1_1) {
     auto connect = am::v3_1_1::connect_packet{
         true,   // clean_session
         0x1234, // keep_alive
-        "cid1"_mb,
+        "cid1",
         std::nullopt, // will
-        "user1"_mb,
-        "pass1"_mb
+        "user1",
+        "pass1"
     };
 
     auto connack = am::v3_1_1::connack_packet{
@@ -764,8 +763,8 @@ BOOST_AUTO_TEST_CASE(valid_server_v3_1_1) {
 
     auto publish = am::v3_1_1::publish_packet(
         0x1, // hard coded packet_id for just testing
-        "topic1"_mb,
-        "payload1"_mb,
+        "topic1",
+        "payload1",
         am::qos::exactly_once | am::pub::retain::yes | am::pub::dup::yes
     );
 
@@ -986,10 +985,10 @@ BOOST_AUTO_TEST_CASE(invalid_server_v3_1_1) {
     auto connect = am::v3_1_1::connect_packet{
         true,   // clean_session
         0x1234, // keep_alive
-        "cid1"_mb,
+        "cid1",
         std::nullopt, // will
-        "user1"_mb,
-        "pass1"_mb
+        "user1",
+        "pass1"
     };
 
     auto connack = am::v3_1_1::connack_packet{
@@ -1001,8 +1000,8 @@ BOOST_AUTO_TEST_CASE(invalid_server_v3_1_1) {
 
     auto publish = am::v3_1_1::publish_packet(
         0x1, // hard coded packet_id for just testing
-        "topic1"_mb,
-        "payload1"_mb,
+        "topic1",
+        "payload1",
         am::qos::exactly_once | am::pub::retain::yes | am::pub::dup::yes
     );
 
@@ -1025,8 +1024,8 @@ BOOST_AUTO_TEST_CASE(invalid_server_v3_1_1) {
     auto subscribe = am::v3_1_1::subscribe_packet{
         0x1, // hard coded packet_id for just testing
         std::vector<am::topic_subopts> {
-            {"topic1"_mb, am::qos::at_most_once},
-            {"topic2"_mb, am::qos::exactly_once},
+            {"topic1", am::qos::at_most_once},
+            {"topic2", am::qos::exactly_once},
         }
     };
 
@@ -1041,8 +1040,8 @@ BOOST_AUTO_TEST_CASE(invalid_server_v3_1_1) {
     auto unsubscribe = am::v3_1_1::unsubscribe_packet{
         0x1, // hard coded packet_id for just testing
         std::vector<am::topic_sharename> {
-            "topic1"_mb,
-            "topic2"_mb,
+            am::topic_sharename{"topic1"},
+            am::topic_sharename{"topic2"},
         }
     };
 
@@ -1441,10 +1440,10 @@ BOOST_AUTO_TEST_CASE(valid_client_v5) {
     auto connect = am::v5::connect_packet{
         true,   // clean_start
         0x1234, // keep_alive
-        "cid1"_mb,
+        "cid1",
         std::nullopt, // will
-        "user1"_mb,
-        "pass1"_mb,
+        "user1",
+        "pass1",
         am::properties{}
     };
 
@@ -1461,8 +1460,8 @@ BOOST_AUTO_TEST_CASE(valid_client_v5) {
 
     auto publish = am::v5::publish_packet(
         0x1, // hard coded packet_id for just testing
-        "topic1"_mb,
-        "payload1"_mb,
+        "topic1",
+        "payload1",
         am::qos::exactly_once | am::pub::retain::yes | am::pub::dup::yes,
         am::properties{}
     );
@@ -1494,8 +1493,8 @@ BOOST_AUTO_TEST_CASE(valid_client_v5) {
     auto subscribe = am::v5::subscribe_packet{
         0x1, // hard coded packet_id for just testing
         std::vector<am::topic_subopts> {
-            {"topic1"_mb, am::qos::at_most_once},
-            {"topic2"_mb, am::qos::exactly_once},
+            {"topic1", am::qos::at_most_once},
+            {"topic2", am::qos::exactly_once},
         },
         am::properties{}
     };
@@ -1503,8 +1502,8 @@ BOOST_AUTO_TEST_CASE(valid_client_v5) {
     auto unsubscribe = am::v5::unsubscribe_packet{
         0x1, // hard coded packet_id for just testing
         std::vector<am::topic_sharename> {
-            "topic1"_mb,
-            "topic2"_mb,
+            am::topic_sharename{"topic1"},
+            am::topic_sharename{"topic2"},
         },
         am::properties{}
     };
@@ -1725,10 +1724,10 @@ BOOST_AUTO_TEST_CASE(invalid_client_v5) {
     auto connect = am::v5::connect_packet{
         true,   // clean_start
         0x1234, // keep_alive
-        "cid1"_mb,
+        "cid1",
         std::nullopt, // will
-        "user1"_mb,
-        "pass1"_mb,
+        "user1",
+        "pass1",
         am::properties{}
     };
 
@@ -1745,8 +1744,8 @@ BOOST_AUTO_TEST_CASE(invalid_client_v5) {
 
     auto publish = am::v5::publish_packet(
         0x1, // hard coded packet_id for just testing
-        "topic1"_mb,
-        "payload1"_mb,
+        "topic1",
+        "payload1",
         am::qos::exactly_once | am::pub::retain::yes | am::pub::dup::yes,
         am::properties{}
     );
@@ -1778,8 +1777,8 @@ BOOST_AUTO_TEST_CASE(invalid_client_v5) {
     auto subscribe = am::v5::subscribe_packet{
         0x1, // hard coded packet_id for just testing
         std::vector<am::topic_subopts> {
-            {"topic1"_mb, am::qos::at_most_once},
-            {"topic2"_mb, am::qos::exactly_once},
+            {"topic1", am::qos::at_most_once},
+            {"topic2", am::qos::exactly_once},
         },
         am::properties{}
     };
@@ -1796,8 +1795,8 @@ BOOST_AUTO_TEST_CASE(invalid_client_v5) {
     auto unsubscribe = am::v5::unsubscribe_packet{
         0x1, // hard coded packet_id for just testing
         std::vector<am::topic_sharename> {
-            "topic1"_mb,
-            "topic2"_mb,
+            am::topic_sharename{"topic1"},
+            am::topic_sharename{"topic2"},
         },
         am::properties{}
     };
@@ -2225,10 +2224,10 @@ BOOST_AUTO_TEST_CASE(valid_server_v5) {
     auto connect = am::v5::connect_packet{
         true,   // clean_start
         0x1234, // keep_alive
-        "cid1"_mb,
+        "cid1",
         std::nullopt, // will
-        "user1"_mb,
-        "pass1"_mb,
+        "user1",
+        "pass1",
         am::properties{}
     };
 
@@ -2245,8 +2244,8 @@ BOOST_AUTO_TEST_CASE(valid_server_v5) {
 
     auto publish = am::v5::publish_packet(
         0x1, // hard coded packet_id for just testing
-        "topic1"_mb,
-        "payload1"_mb,
+        "topic1",
+        "payload1",
         am::qos::exactly_once | am::pub::retain::yes | am::pub::dup::yes,
         am::properties{}
     );
@@ -2508,10 +2507,10 @@ BOOST_AUTO_TEST_CASE(invalid_server_v5) {
     auto connect = am::v5::connect_packet{
         true,   // clean_start
         0x1234, // keep_alive
-        "cid1"_mb,
+        "cid1",
         std::nullopt, // will
-        "user1"_mb,
-        "pass1"_mb,
+        "user1",
+        "pass1",
         am::properties{}
     };
 
@@ -2528,8 +2527,8 @@ BOOST_AUTO_TEST_CASE(invalid_server_v5) {
 
     auto publish = am::v5::publish_packet(
         0x1, // hard coded packet_id for just testing
-        "topic1"_mb,
-        "payload1"_mb,
+        "topic1",
+        "payload1",
         am::qos::exactly_once | am::pub::retain::yes | am::pub::dup::yes,
         am::properties{}
     );
@@ -2561,8 +2560,8 @@ BOOST_AUTO_TEST_CASE(invalid_server_v5) {
     auto subscribe = am::v5::subscribe_packet{
         0x1, // hard coded packet_id for just testing
         std::vector<am::topic_subopts> {
-            {"topic1"_mb, am::qos::at_most_once},
-            {"topic2"_mb, am::qos::exactly_once},
+            {"topic1", am::qos::at_most_once},
+            {"topic2", am::qos::exactly_once},
         },
         am::properties{}
     };
@@ -2579,8 +2578,8 @@ BOOST_AUTO_TEST_CASE(invalid_server_v5) {
     auto unsubscribe = am::v5::unsubscribe_packet{
         0x1, // hard coded packet_id for just testing
         std::vector<am::topic_sharename> {
-            "topic1"_mb,
-            "topic2"_mb,
+            am::topic_sharename{"topic1"},
+            am::topic_sharename{"topic2"},
         },
         am::properties{}
     };

--- a/test/unit/ut_ep_pid.cpp
+++ b/test/unit/ut_ep_pid.cpp
@@ -19,7 +19,6 @@
 BOOST_AUTO_TEST_SUITE(ut_ep_pid)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 namespace as = boost::asio;
 
 // v3_1_1

--- a/test/unit/ut_ep_recv_filter.cpp
+++ b/test/unit/ut_ep_recv_filter.cpp
@@ -19,7 +19,6 @@
 BOOST_AUTO_TEST_SUITE(ut_ep_recv_filter)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 namespace as = boost::asio;
 
 // To test the bug fix for https://github.com/redboltz/async_mqtt/issues/42
@@ -43,10 +42,10 @@ BOOST_AUTO_TEST_CASE(recv_filter) {
     auto connect = am::v5::connect_packet{
         true,   // clean_start
         0x1234, // keep_alive
-        "cid1"_mb,
+        "cid1",
         std::nullopt, // will
-        "user1"_mb,
-        "pass1"_mb,
+        "user1",
+        "pass1",
         am::properties{}
     };
 

--- a/test/unit/ut_ep_recv_max.cpp
+++ b/test/unit/ut_ep_recv_max.cpp
@@ -19,7 +19,6 @@
 BOOST_AUTO_TEST_SUITE(ut_ep_recv_max)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 namespace as = boost::asio;
 
 BOOST_AUTO_TEST_CASE(client_send) {
@@ -42,10 +41,10 @@ BOOST_AUTO_TEST_CASE(client_send) {
     auto connect = am::v5::connect_packet{
         true,   // clean_start
         0x1234, // keep_alive
-        "cid1"_mb,
+        "cid1",
         std::nullopt, // will
-        "user1"_mb,
-        "pass1"_mb,
+        "user1",
+        "pass1",
         am::properties{}
     };
 
@@ -85,8 +84,8 @@ BOOST_AUTO_TEST_CASE(client_send) {
     BOOST_TEST(pid_opt1.has_value());
     auto publish_1_q1 = am::v5::publish_packet(
         *pid_opt1,
-        "topic1"_mb,
-        "payload1"_mb,
+        "topic1",
+        "payload1",
         am::qos::at_least_once,
         am::properties{}
     );
@@ -95,8 +94,8 @@ BOOST_AUTO_TEST_CASE(client_send) {
     BOOST_TEST(pid_opt2.has_value());
     auto publish_2_q1 = am::v5::publish_packet(
         *pid_opt2,
-        "topic1"_mb,
-        "payload1"_mb,
+        "topic1",
+        "payload1",
         am::qos::at_least_once,
         am::properties{}
     );
@@ -105,16 +104,16 @@ BOOST_AUTO_TEST_CASE(client_send) {
     BOOST_TEST(pid_opt3.has_value());
     auto publish_3_q2 = am::v5::publish_packet(
         *pid_opt3,
-        "topic1"_mb,
-        "payload1"_mb,
+        "topic1",
+        "payload1",
         am::qos::exactly_once,
         am::properties{}
     );
 
     auto publish_4_q0 = am::v5::publish_packet(
         0x0, // packet_id
-        "topic1"_mb,
-        "payload1"_mb,
+        "topic1",
+        "payload1",
         am::qos::at_most_once,
         am::properties{}
     );
@@ -261,10 +260,10 @@ BOOST_AUTO_TEST_CASE(server_send) {
     auto connect = am::v5::connect_packet{
         true,   // clean_start
         0x1234, // keep_alive
-        "cid1"_mb,
+        "cid1",
         std::nullopt, // will
-        "user1"_mb,
-        "pass1"_mb,
+        "user1",
+        "pass1",
         am::properties{
             am::property::receive_maximum{2}
         }
@@ -304,8 +303,8 @@ BOOST_AUTO_TEST_CASE(server_send) {
     BOOST_TEST(pid_opt1.has_value());
     auto publish_1_q1 = am::v5::publish_packet(
         *pid_opt1,
-        "topic1"_mb,
-        "payload1"_mb,
+        "topic1",
+        "payload1",
         am::qos::at_least_once,
         am::properties{}
     );
@@ -314,8 +313,8 @@ BOOST_AUTO_TEST_CASE(server_send) {
     BOOST_TEST(pid_opt2.has_value());
     auto publish_2_q1 = am::v5::publish_packet(
         *pid_opt2,
-        "topic1"_mb,
-        "payload1"_mb,
+        "topic1",
+        "payload1",
         am::qos::at_least_once,
         am::properties{}
     );
@@ -324,16 +323,16 @@ BOOST_AUTO_TEST_CASE(server_send) {
     BOOST_TEST(pid_opt3.has_value());
     auto publish_3_q2 = am::v5::publish_packet(
         *pid_opt3,
-        "topic1"_mb,
-        "payload1"_mb,
+        "topic1",
+        "payload1",
         am::qos::exactly_once,
         am::properties{}
     );
 
     auto publish_4_q0 = am::v5::publish_packet(
         0x0, // packet_id
-        "topic1"_mb,
-        "payload1"_mb,
+        "topic1",
+        "payload1",
         am::qos::at_most_once,
         am::properties{}
     );
@@ -480,10 +479,10 @@ BOOST_AUTO_TEST_CASE(client_recv) {
     auto connect = am::v5::connect_packet{
         true,   // clean_start
         0x1234, // keep_alive
-        "cid1"_mb,
+        "cid1",
         std::nullopt, // will
-        "user1"_mb,
-        "pass1"_mb,
+        "user1",
+        "pass1",
         am::properties{
             am::property::receive_maximum{2}
         }
@@ -528,48 +527,48 @@ BOOST_AUTO_TEST_CASE(client_recv) {
 
     auto publish_1_q1 = am::v5::publish_packet(
         0x1, // packet_id
-        "topic1"_mb,
-        "payload1"_mb,
+        "topic1",
+        "payload1",
         am::qos::at_least_once,
         am::properties{}
     );
 
     auto publish_2_q1 = am::v5::publish_packet(
         0x2, // packet_id
-        "topic1"_mb,
-        "payload1"_mb,
+        "topic1",
+        "payload1",
         am::qos::at_least_once,
         am::properties{}
     );
 
     auto publish_3_q0 = am::v5::publish_packet(
         0x0, // packet_id
-        "topic1"_mb,
-        "payload1"_mb,
+        "topic1",
+        "payload1",
         am::qos::at_most_once,
         am::properties{}
     );
 
     auto publish_4_q2 = am::v5::publish_packet(
         0x3, // packet_id
-        "topic1"_mb,
-        "payload1"_mb,
+        "topic1",
+        "payload1",
         am::qos::exactly_once,
         am::properties{}
     );
 
     auto publish_5_q1 = am::v5::publish_packet(
         0x5, // packet_id
-        "topic1"_mb,
-        "payload1"_mb,
+        "topic1",
+        "payload1",
         am::qos::at_least_once,
         am::properties{}
     );
 
     auto publish_6_q1 = am::v5::publish_packet(
         0x6, // packet_id
-        "topic1"_mb,
-        "payload1"_mb,
+        "topic1",
+        "payload1",
         am::qos::at_least_once,
         am::properties{}
     );
@@ -790,10 +789,10 @@ BOOST_AUTO_TEST_CASE(server_recv) {
     auto connect = am::v5::connect_packet{
         true,   // clean_start
         0x1234, // keep_alive
-        "cid1"_mb,
+        "cid1",
         std::nullopt, // will
-        "user1"_mb,
-        "pass1"_mb,
+        "user1",
+        "pass1",
         am::properties{}
     };
 
@@ -838,48 +837,48 @@ BOOST_AUTO_TEST_CASE(server_recv) {
 
     auto publish_1_q1 = am::v5::publish_packet(
         0x1, // packet_id
-        "topic1"_mb,
-        "payload1"_mb,
+        "topic1",
+        "payload1",
         am::qos::at_least_once,
         am::properties{}
     );
 
     auto publish_2_q1 = am::v5::publish_packet(
         0x2, // packet_id
-        "topic1"_mb,
-        "payload1"_mb,
+        "topic1",
+        "payload1",
         am::qos::at_least_once,
         am::properties{}
     );
 
     auto publish_3_q0 = am::v5::publish_packet(
         0x0, // packet_id
-        "topic1"_mb,
-        "payload1"_mb,
+        "topic1",
+        "payload1",
         am::qos::at_most_once,
         am::properties{}
     );
 
     auto publish_4_q2 = am::v5::publish_packet(
         0x3, // packet_id
-        "topic1"_mb,
-        "payload1"_mb,
+        "topic1",
+        "payload1",
         am::qos::exactly_once,
         am::properties{}
     );
 
     auto publish_5_q1 = am::v5::publish_packet(
         0x5, // packet_id
-        "topic1"_mb,
-        "payload1"_mb,
+        "topic1",
+        "payload1",
         am::qos::at_least_once,
         am::properties{}
     );
 
     auto publish_6_q1 = am::v5::publish_packet(
         0x6, // packet_id
-        "topic1"_mb,
-        "payload1"_mb,
+        "topic1",
+        "payload1",
         am::qos::at_least_once,
         am::properties{}
     );

--- a/test/unit/ut_ep_send_rt_chk.cpp
+++ b/test/unit/ut_ep_send_rt_chk.cpp
@@ -19,7 +19,6 @@
 BOOST_AUTO_TEST_SUITE(ut_ep_send_rt_chk)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 namespace as = boost::asio;
 
 using namespace std::literals::string_view_literals;
@@ -50,10 +49,10 @@ BOOST_AUTO_TEST_CASE(v311_client) {
         auto p = am::v5::connect_packet{
             true,   // clean_start
             0x1234, // keep_alive
-            "cid1"_mb,
+            "cid1",
             std::nullopt,
-            "user1"_mb,
-            "pass1"_mb,
+            "user1",
+            "pass1",
             am::properties{}
         };
         auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
@@ -63,10 +62,10 @@ BOOST_AUTO_TEST_CASE(v311_client) {
         auto p = am::v3_1_1::connect_packet{
             true,   // clean_session
             0x0, // keep_alive
-            "cid1"_mb,
+            "cid1",
             std::nullopt,
-            "user1"_mb,
-            "pass1"_mb
+            "user1",
+            "pass1"
         };
         auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
@@ -81,8 +80,8 @@ BOOST_AUTO_TEST_CASE(v311_client) {
     }
     {
         auto p = am::v3_1_1::publish_packet{
-            "topic1"_mb,
-            "payload1"_mb,
+            "topic1",
+            "payload1",
             am::qos::at_most_once | am::pub::retain::yes | am::pub::dup::yes
         };
         auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
@@ -118,8 +117,8 @@ BOOST_AUTO_TEST_CASE(v311_client) {
     }
     {
         std::vector<am::topic_subopts> args {
-            {"topic1"_mb, am::qos::at_most_once},
-            {"topic2"_mb, am::qos::exactly_once},
+            {"topic1", am::qos::at_most_once},
+            {"topic2", am::qos::exactly_once},
         };
         auto p = am::v3_1_1::subscribe_packet{
             0x1234,         // packet_id
@@ -142,8 +141,8 @@ BOOST_AUTO_TEST_CASE(v311_client) {
     }
     {
         std::vector<am::topic_sharename> args {
-            "topic1"_mb,
-            "topic2"_mb,
+            {"topic1"},
+            {"topic2"},
         };
 
         auto p = am::v3_1_1::unsubscribe_packet{
@@ -200,10 +199,10 @@ BOOST_AUTO_TEST_CASE(v311_server) {
         auto p = am::v3_1_1::connect_packet{
             true,   // clean_session
             0x0, // keep_alive
-            "cid1"_mb,
+            "cid1",
             std::nullopt,
-            "user1"_mb,
-            "pass1"_mb
+            "user1",
+            "pass1"
         };
         auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
@@ -218,8 +217,8 @@ BOOST_AUTO_TEST_CASE(v311_server) {
     }
     {
         auto p = am::v3_1_1::publish_packet{
-            "topic1"_mb,
-            "payload1"_mb,
+            "topic1",
+            "payload1",
             am::qos::at_most_once | am::pub::retain::yes | am::pub::dup::yes
         };
         auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
@@ -255,8 +254,8 @@ BOOST_AUTO_TEST_CASE(v311_server) {
     }
     {
         std::vector<am::topic_subopts> args {
-            {"topic1"_mb, am::qos::at_most_once},
-            {"topic2"_mb, am::qos::exactly_once},
+            {"topic1", am::qos::at_most_once},
+            {"topic2", am::qos::exactly_once},
         };
         auto p = am::v3_1_1::subscribe_packet{
             0x1234,         // packet_id
@@ -279,8 +278,8 @@ BOOST_AUTO_TEST_CASE(v311_server) {
     }
     {
         std::vector<am::topic_sharename> args {
-            "topic1"_mb,
-            "topic2"_mb,
+            {"topic1"},
+            {"topic2"},
         };
 
         auto p = am::v3_1_1::unsubscribe_packet{
@@ -338,10 +337,10 @@ BOOST_AUTO_TEST_CASE(v311_any) {
         auto p = am::v3_1_1::connect_packet{
             true,   // clean_session
             0x0, // keep_alive
-            "cid1"_mb,
+            "cid1",
             std::nullopt,
-            "user1"_mb,
-            "pass1"_mb
+            "user1",
+            "pass1"
         };
         auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(!ec_what_start_with(ec, "packet cannot be send by MQTT protocol"));
@@ -356,8 +355,8 @@ BOOST_AUTO_TEST_CASE(v311_any) {
     }
     {
         auto p = am::v3_1_1::publish_packet{
-            "topic1"_mb,
-            "payload1"_mb,
+            "topic1",
+            "payload1",
             am::qos::at_most_once | am::pub::retain::yes | am::pub::dup::yes
         };
         auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
@@ -393,8 +392,8 @@ BOOST_AUTO_TEST_CASE(v311_any) {
     }
     {
         std::vector<am::topic_subopts> args {
-            {"topic1"_mb, am::qos::at_most_once},
-            {"topic2"_mb, am::qos::exactly_once},
+            {"topic1", am::qos::at_most_once},
+            {"topic2", am::qos::exactly_once},
         };
         auto p = am::v3_1_1::subscribe_packet{
             0x1234,         // packet_id
@@ -417,8 +416,8 @@ BOOST_AUTO_TEST_CASE(v311_any) {
     }
     {
         std::vector<am::topic_sharename> args {
-            "topic1"_mb,
-            "topic2"_mb,
+            {"topic1"},
+            {"topic2"},
         };
 
         auto p = am::v3_1_1::unsubscribe_packet{
@@ -475,10 +474,10 @@ BOOST_AUTO_TEST_CASE(v5_client) {
         auto p = am::v3_1_1::connect_packet{
             true,   // clean_session
             0x0, // keep_alive
-            "cid1"_mb,
+            "cid1",
             std::nullopt,
-            "user1"_mb,
-            "pass1"_mb
+            "user1",
+            "pass1"
         };
         auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
         BOOST_TEST(ec_what_start_with(ec, "protocol version mismatch"));
@@ -487,10 +486,10 @@ BOOST_AUTO_TEST_CASE(v5_client) {
         auto p = am::v5::connect_packet{
             true,   // clean_start
             0x0, // keep_alive
-            "cid1"_mb,
+            "cid1",
             std::nullopt,
-            "user1"_mb,
-            "pass1"_mb,
+            "user1",
+            "pass1",
             am::properties{}
         };
         auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
@@ -508,8 +507,8 @@ BOOST_AUTO_TEST_CASE(v5_client) {
     }
     {
         auto p = am::v5::publish_packet{
-            "topic1"_mb,
-            "payload1"_mb,
+            "topic1",
+            "payload1",
             am::qos::at_most_once | am::pub::retain::yes | am::pub::dup::yes,
             am::properties{}
         };
@@ -554,8 +553,8 @@ BOOST_AUTO_TEST_CASE(v5_client) {
     }
     {
         std::vector<am::topic_subopts> args {
-            {"topic1"_mb, am::qos::at_most_once | am::sub::nl::yes | am::sub::retain_handling::not_send},
-            {"topic2"_mb, am::qos::exactly_once | am::sub::rap::retain},
+            {"topic1", am::qos::at_most_once | am::sub::nl::yes | am::sub::retain_handling::not_send},
+            {"topic2", am::qos::exactly_once | am::sub::rap::retain},
         };
         auto p = am::v5::subscribe_packet{
             0x1234,         // packet_id
@@ -580,8 +579,8 @@ BOOST_AUTO_TEST_CASE(v5_client) {
     }
     {
         std::vector<am::topic_sharename> args {
-            "topic1"_mb,
-            "topic2"_mb,
+            {"topic1"},
+            {"topic2"},
         };
         auto p = am::v5::unsubscribe_packet{
             0x1234,         // packet_id
@@ -655,10 +654,10 @@ BOOST_AUTO_TEST_CASE(v5_server) {
         auto p = am::v5::connect_packet{
             true,   // clean_start
             0x0, // keep_alive
-            "cid1"_mb,
+            "cid1",
             std::nullopt,
-            "user1"_mb,
-            "pass1"_mb,
+            "user1",
+            "pass1",
             am::properties{}
         };
         auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
@@ -676,8 +675,8 @@ BOOST_AUTO_TEST_CASE(v5_server) {
     }
     {
         auto p = am::v5::publish_packet{
-            "topic1"_mb,
-            "payload1"_mb,
+            "topic1",
+            "payload1",
             am::qos::at_most_once | am::pub::retain::yes | am::pub::dup::yes,
             am::properties{}
         };
@@ -722,8 +721,8 @@ BOOST_AUTO_TEST_CASE(v5_server) {
     }
     {
         std::vector<am::topic_subopts> args {
-            {"topic1"_mb, am::qos::at_most_once | am::sub::nl::yes | am::sub::retain_handling::not_send},
-            {"topic2"_mb, am::qos::exactly_once | am::sub::rap::retain},
+            {"topic1", am::qos::at_most_once | am::sub::nl::yes | am::sub::retain_handling::not_send},
+            {"topic2", am::qos::exactly_once | am::sub::rap::retain},
         };
         auto p = am::v5::subscribe_packet{
             0x1234,         // packet_id
@@ -748,8 +747,8 @@ BOOST_AUTO_TEST_CASE(v5_server) {
     }
     {
         std::vector<am::topic_sharename> args {
-            "topic1"_mb,
-            "topic2"_mb,
+            {"topic1"},
+            {"topic2"},
         };
         auto p = am::v5::unsubscribe_packet{
             0x1234,         // packet_id
@@ -823,10 +822,10 @@ BOOST_AUTO_TEST_CASE(v5_any) {
         auto p = am::v5::connect_packet{
             true,   // clean_start
             0x0, // keep_alive
-            "cid1"_mb,
+            "cid1",
             std::nullopt,
-            "user1"_mb,
-            "pass1"_mb,
+            "user1",
+            "pass1",
             am::properties{}
         };
         auto ec = ep->send(am::packet_variant{p}, as::use_future).get();
@@ -844,8 +843,8 @@ BOOST_AUTO_TEST_CASE(v5_any) {
     }
     {
         auto p = am::v5::publish_packet{
-            "topic1"_mb,
-            "payload1"_mb,
+            "topic1",
+            "payload1",
             am::qos::at_most_once | am::pub::retain::yes | am::pub::dup::yes,
             am::properties{}
         };
@@ -890,8 +889,8 @@ BOOST_AUTO_TEST_CASE(v5_any) {
     }
     {
         std::vector<am::topic_subopts> args {
-            {"topic1"_mb, am::qos::at_most_once | am::sub::nl::yes | am::sub::retain_handling::not_send},
-            {"topic2"_mb, am::qos::exactly_once | am::sub::rap::retain},
+            {"topic1", am::qos::at_most_once | am::sub::nl::yes | am::sub::retain_handling::not_send},
+            {"topic2", am::qos::exactly_once | am::sub::rap::retain},
         };
         auto p = am::v5::subscribe_packet{
             0x1234,         // packet_id
@@ -916,8 +915,8 @@ BOOST_AUTO_TEST_CASE(v5_any) {
     }
     {
         std::vector<am::topic_sharename> args {
-            "topic1"_mb,
-            "topic2"_mb,
+            {"topic1"},
+            {"topic2"},
         };
         auto p = am::v5::unsubscribe_packet{
             0x1234,         // packet_id

--- a/test/unit/ut_ep_size_max.cpp
+++ b/test/unit/ut_ep_size_max.cpp
@@ -19,7 +19,6 @@
 BOOST_AUTO_TEST_SUITE(ut_ep_size_max)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 namespace as = boost::asio;
 
 BOOST_AUTO_TEST_CASE(client_send) {
@@ -46,10 +45,10 @@ BOOST_AUTO_TEST_CASE(client_send) {
     auto connect = am::v5::connect_packet{
         true,   // clean_start
         0x1234, // keep_alive
-        "cid1"_mb,
+        "cid1",
         std::nullopt, // will
-        "user1"_mb,
-        "pass1"_mb,
+        "user1",
+        "pass1",
         am::properties{
             am::property::session_expiry_interval{am::session_never_expire}
         }
@@ -92,8 +91,8 @@ BOOST_AUTO_TEST_CASE(client_send) {
     BOOST_TEST(pid_opt1.has_value());
     auto publish_1_q1 = am::v5::publish_packet(
         *pid_opt1,
-        "topic1"_mb,
-        "payload1"_mb,
+        "topic1",
+        "payload1",
         am::qos::at_least_once,
         am::properties{}
     );
@@ -103,8 +102,8 @@ BOOST_AUTO_TEST_CASE(client_send) {
     BOOST_TEST(pid_opt2.has_value());
     auto publish_2_q1 = am::v5::publish_packet(
         *pid_opt2,
-        "topic1"_mb,
-        "payload1+"_mb,
+        "topic1",
+        "payload1+",
         am::qos::at_least_once,
         am::properties{}
     );
@@ -164,10 +163,10 @@ BOOST_AUTO_TEST_CASE(client_send_no_store) {
     auto connect = am::v5::connect_packet{
         true,   // clean_start
         0x1234, // keep_alive
-        "cid1"_mb,
+        "cid1",
         std::nullopt, // will
-        "user1"_mb,
-        "pass1"_mb
+        "user1",
+        "pass1"
     };
 
     auto connack = am::v5::connack_packet{
@@ -207,8 +206,8 @@ BOOST_AUTO_TEST_CASE(client_send_no_store) {
     BOOST_TEST(pid_opt1.has_value());
     auto publish_1_q1 = am::v5::publish_packet(
         *pid_opt1,
-        "topic1"_mb,
-        "payload1"_mb,
+        "topic1",
+        "payload1",
         am::qos::at_least_once,
         am::properties{}
     );
@@ -218,8 +217,8 @@ BOOST_AUTO_TEST_CASE(client_send_no_store) {
     BOOST_TEST(pid_opt2.has_value());
     auto publish_2_q1 = am::v5::publish_packet(
         *pid_opt2,
-        "topic1"_mb,
-        "payload1+"_mb,
+        "topic1",
+        "payload1+",
         am::qos::at_least_once,
         am::properties{}
     );
@@ -279,10 +278,10 @@ BOOST_AUTO_TEST_CASE(client_recv) {
     auto connect = am::v5::connect_packet{
         true,   // clean_start
         0x1234, // keep_alive
-        "cid1"_mb,
+        "cid1",
         std::nullopt, // will
-        "user1"_mb,
-        "pass1"_mb,
+        "user1",
+        "pass1",
         am::properties{
             am::property::session_expiry_interval{am::session_never_expire},
             am::property::maximum_packet_size{21}
@@ -330,8 +329,8 @@ BOOST_AUTO_TEST_CASE(client_recv) {
     BOOST_TEST(pid_opt1.has_value());
     auto publish_1_q1 = am::v5::publish_packet(
         *pid_opt1,
-        "topic1"_mb,
-        "payload1"_mb,
+        "topic1",
+        "payload1",
         am::qos::at_least_once,
         am::properties{}
     );
@@ -341,8 +340,8 @@ BOOST_AUTO_TEST_CASE(client_recv) {
     BOOST_TEST(pid_opt2.has_value());
     auto publish_2_q1 = am::v5::publish_packet(
         *pid_opt2,
-        "topic1"_mb,
-        "payload1+"_mb,
+        "topic1",
+        "payload1+",
         am::qos::at_least_once,
         am::properties{}
     );
@@ -407,10 +406,10 @@ BOOST_AUTO_TEST_CASE(server_recv) {
     auto connect = am::v5::connect_packet{
         true,   // clean_start
         0x1234, // keep_alive
-        "cid1"_mb,
+        "cid1",
         std::nullopt, // will
-        "user1"_mb,
-        "pass1"_mb,
+        "user1",
+        "pass1",
         am::properties{
             am::property::session_expiry_interval{am::session_never_expire}
         }
@@ -458,8 +457,8 @@ BOOST_AUTO_TEST_CASE(server_recv) {
     BOOST_TEST(pid_opt1.has_value());
     auto publish_1_q1 = am::v5::publish_packet(
         *pid_opt1,
-        "topic1"_mb,
-        "payload1"_mb,
+        "topic1",
+        "payload1",
         am::qos::at_least_once,
         am::properties{}
     );
@@ -469,8 +468,8 @@ BOOST_AUTO_TEST_CASE(server_recv) {
     BOOST_TEST(pid_opt2.has_value());
     auto publish_2_q1 = am::v5::publish_packet(
         *pid_opt2,
-        "topic1"_mb,
-        "payload1+"_mb,
+        "topic1",
+        "payload1+",
         am::qos::at_least_once,
         am::properties{}
     );

--- a/test/unit/ut_ep_store.cpp
+++ b/test/unit/ut_ep_store.cpp
@@ -19,7 +19,6 @@
 BOOST_AUTO_TEST_SUITE(ut_ep_store)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 namespace as = boost::asio;
 
 // v3_1_1
@@ -44,10 +43,10 @@ BOOST_AUTO_TEST_CASE(v311_client) {
     auto connect = am::v3_1_1::connect_packet{
         false,   // clean_session
         0x1234, // keep_alive
-        "cid1"_mb,
+        "cid1",
         std::nullopt, // will
-        "user1"_mb,
-        "pass1"_mb
+        "user1",
+        "pass1"
     };
 
     auto connack_sp_false = am::v3_1_1::connack_packet{
@@ -88,8 +87,8 @@ BOOST_AUTO_TEST_CASE(v311_client) {
 
     auto publish0 = am::v3_1_1::publish_packet(
         0x0, // packet_id
-        "topic1"_mb,
-        "payload0"_mb,
+        "topic1",
+        "payload0",
         am::qos::at_most_once
     );
 
@@ -97,8 +96,8 @@ BOOST_AUTO_TEST_CASE(v311_client) {
     BOOST_TEST(pid_opt1.has_value());
     auto publish1 = am::v3_1_1::publish_packet(
         *pid_opt1,
-        "topic1"_mb,
-        "payload1"_mb,
+        "topic1",
+        "payload1",
         am::qos::at_least_once
     );
 
@@ -109,8 +108,8 @@ BOOST_AUTO_TEST_CASE(v311_client) {
     BOOST_TEST(pid_opt2.has_value());
     auto publish2 = am::v3_1_1::publish_packet(
         *pid_opt2,
-        "topic1"_mb,
-        "payload2"_mb,
+        "topic1",
+        "payload2",
         am::qos::exactly_once
     );
 
@@ -367,19 +366,19 @@ BOOST_AUTO_TEST_CASE(v311_server) {
     auto connect_no_clean = am::v3_1_1::connect_packet{
         false,   // clean_session
         0x1234, // keep_alive
-        "cid1"_mb,
+        "cid1",
         std::nullopt, // will
-        "user1"_mb,
-        "pass1"_mb
+        "user1",
+        "pass1"
     };
 
     auto connect_clean = am::v3_1_1::connect_packet{
         true,   // clean_session
         0x1234, // keep_alive
-        "cid1"_mb,
+        "cid1",
         std::nullopt, // will
-        "user1"_mb,
-        "pass1"_mb
+        "user1",
+        "pass1"
     };
 
     auto connack_sp_false = am::v3_1_1::connack_packet{
@@ -420,8 +419,8 @@ BOOST_AUTO_TEST_CASE(v311_server) {
 
     auto publish0 = am::v3_1_1::publish_packet(
         0x0, // packet_id
-        "topic1"_mb,
-        "payload0"_mb,
+        "topic1",
+        "payload0",
         am::qos::at_most_once
     );
 
@@ -429,8 +428,8 @@ BOOST_AUTO_TEST_CASE(v311_server) {
     BOOST_TEST(pid_opt1.has_value());
     auto publish1 = am::v3_1_1::publish_packet(
         *pid_opt1,
-        "topic1"_mb,
-        "payload1"_mb,
+        "topic1",
+        "payload1",
         am::qos::at_least_once
     );
 
@@ -441,8 +440,8 @@ BOOST_AUTO_TEST_CASE(v311_server) {
     BOOST_TEST(pid_opt2.has_value());
     auto publish2 = am::v3_1_1::publish_packet(
         *pid_opt2,
-        "topic1"_mb,
-        "payload2"_mb,
+        "topic1",
+        "payload2",
         am::qos::exactly_once
     );
 
@@ -728,10 +727,10 @@ BOOST_AUTO_TEST_CASE(v5_client) {
     auto connect = am::v5::connect_packet{
         false,   // clean_session
         0x1234, // keep_alive
-        "cid1"_mb,
+        "cid1",
         std::nullopt, // will
-        "user1"_mb,
-        "pass1"_mb,
+        "user1",
+        "pass1",
         am::properties{
             am::property::session_expiry_interval{am::session_never_expire}
         }
@@ -777,8 +776,8 @@ BOOST_AUTO_TEST_CASE(v5_client) {
 
     auto publish0 = am::v5::publish_packet(
         0x0, // packet_id
-        "topic1"_mb,
-        "payload0"_mb,
+        "topic1",
+        "payload0",
         am::qos::at_most_once,
         am::properties{}
     );
@@ -787,8 +786,8 @@ BOOST_AUTO_TEST_CASE(v5_client) {
     BOOST_TEST(pid_opt1.has_value());
     auto publish1 = am::v5::publish_packet(
         *pid_opt1,
-        "topic1"_mb,
-        "payload1"_mb,
+        "topic1",
+        "payload1",
         am::qos::at_least_once,
         am::properties{}
     );
@@ -800,8 +799,8 @@ BOOST_AUTO_TEST_CASE(v5_client) {
     BOOST_TEST(pid_opt2.has_value());
     auto publish2 = am::v5::publish_packet(
         *pid_opt2,
-        "topic1"_mb,
-        "payload2"_mb,
+        "topic1",
+        "payload2",
         am::qos::exactly_once,
         am::properties{}
     );
@@ -1059,10 +1058,10 @@ BOOST_AUTO_TEST_CASE(v5_server) {
     auto connect_no_clean = am::v5::connect_packet{
         false,   // clean_session
         0x1234, // keep_alive
-        "cid1"_mb,
+        "cid1",
         std::nullopt, // will
-        "user1"_mb,
-        "pass1"_mb,
+        "user1",
+        "pass1",
         am::properties{
             am::property::session_expiry_interval{am::session_never_expire}
         }
@@ -1071,10 +1070,10 @@ BOOST_AUTO_TEST_CASE(v5_server) {
     auto connect_clean = am::v5::connect_packet{
         true,   // clean_session
         0x1234, // keep_alive
-        "cid1"_mb,
+        "cid1",
         std::nullopt, // will
-        "user1"_mb,
-        "pass1"_mb,
+        "user1",
+        "pass1",
         am::properties{}
     };
 
@@ -1118,8 +1117,8 @@ BOOST_AUTO_TEST_CASE(v5_server) {
 
     auto publish0 = am::v5::publish_packet(
         0x0, // packet_id
-        "topic1"_mb,
-        "payload0"_mb,
+        "topic1",
+        "payload0",
         am::qos::at_most_once,
         am::properties{}
     );
@@ -1128,8 +1127,8 @@ BOOST_AUTO_TEST_CASE(v5_server) {
     BOOST_TEST(pid_opt1.has_value());
     auto publish1 = am::v5::publish_packet(
         *pid_opt1,
-        "topic1"_mb,
-        "payload1"_mb,
+        "topic1",
+        "payload1",
         am::qos::at_least_once,
         am::properties{}
     );
@@ -1141,8 +1140,8 @@ BOOST_AUTO_TEST_CASE(v5_server) {
     BOOST_TEST(pid_opt2.has_value());
     auto publish2 = am::v5::publish_packet(
         *pid_opt2,
-        "topic1"_mb,
-        "payload2"_mb,
+        "topic1",
+        "payload2",
         am::qos::exactly_once,
         am::properties{}
     );
@@ -1428,10 +1427,10 @@ BOOST_AUTO_TEST_CASE(v5_topic_alias) {
     auto connect = am::v5::connect_packet{
         false,   // clean_session
         0x1234, // keep_alive
-        "cid1"_mb,
+        "cid1",
         std::nullopt, // will
-        "user1"_mb,
-        "pass1"_mb,
+        "user1",
+        "pass1",
         am::properties{
             am::property::session_expiry_interval{am::session_never_expire}
         }
@@ -1481,8 +1480,8 @@ BOOST_AUTO_TEST_CASE(v5_topic_alias) {
 
     auto publish0 = am::v5::publish_packet(
         0x0, // packet_id
-        "topic1"_mb,
-        "payload0"_mb,
+        "topic1",
+        "payload0",
         am::qos::at_most_once,
         am::properties{}
     );
@@ -1491,8 +1490,8 @@ BOOST_AUTO_TEST_CASE(v5_topic_alias) {
     BOOST_TEST(pid_opt1.has_value());
     auto publish1 = am::v5::publish_packet(
         *pid_opt1,
-        "topic1"_mb,
-        "payload1"_mb,
+        "topic1",
+        "payload1",
         am::qos::at_least_once,
         am::properties{
             am::property::topic_alias{1}
@@ -1501,8 +1500,8 @@ BOOST_AUTO_TEST_CASE(v5_topic_alias) {
 
     auto publish1no_ta = am::v5::publish_packet(
         *pid_opt1,
-        "topic1"_mb,
-        "payload1"_mb,
+        "topic1",
+        "payload1",
         am::qos::at_least_once,
         am::properties{}
     );
@@ -1514,8 +1513,8 @@ BOOST_AUTO_TEST_CASE(v5_topic_alias) {
     BOOST_TEST(pid_opt2.has_value());
     auto publish2 = am::v5::publish_packet(
         *pid_opt2,
-        am::buffer{},
-        "payload2"_mb,
+        "",
+        "payload2",
         am::qos::exactly_once,
         am::properties{
             am::property::topic_alias{1}
@@ -1524,8 +1523,8 @@ BOOST_AUTO_TEST_CASE(v5_topic_alias) {
 
     auto publish2no_ta = am::v5::publish_packet(
         *pid_opt2,
-        "topic1"_mb,
-        "payload2"_mb,
+        "topic1",
+        "payload2",
         am::qos::exactly_once,
         am::properties{}
     );
@@ -1766,8 +1765,8 @@ BOOST_AUTO_TEST_CASE(restore_packets_error) {
     BOOST_TEST(pid_opt1.has_value());
     auto publish1 = am::v3_1_1::publish_packet(
         *pid_opt1,
-        "topic1"_mb,
-        "payload1"_mb,
+        "topic1",
+        "payload1",
         am::qos::at_least_once
     );
     as::dispatch(

--- a/test/unit/ut_ep_topic_alias.cpp
+++ b/test/unit/ut_ep_topic_alias.cpp
@@ -20,9 +20,7 @@
 BOOST_AUTO_TEST_SUITE(ut_ep_topic_alias)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 namespace as = boost::asio;
-using namespace am::literals;
 
 inline std::optional<am::topic_alias_t> get_topic_alias(am::properties const& props) {
     std::optional<am::topic_alias_t> ta_opt;
@@ -62,10 +60,10 @@ BOOST_AUTO_TEST_CASE(send_client) {
     auto connect = am::v5::connect_packet{
         true,   // clean_start
         0x1234, // keep_alive
-        "cid1"_mb,
+        "cid1",
         std::nullopt, // will
-        "user1"_mb,
-        "pass1"_mb,
+        "user1",
+        "pass1",
         am::properties{}
     };
 
@@ -105,8 +103,8 @@ BOOST_AUTO_TEST_CASE(send_client) {
     BOOST_TEST(pid_opt1.has_value());
     auto publish_reg_t1 = am::v5::publish_packet(
         *pid_opt1,
-        "topic1"_mb,
-        "payload1"_mb,
+        "topic1",
+        "payload1",
         am::qos::exactly_once | am::pub::retain::yes | am::pub::dup::yes,
         am::properties{
             am::property::topic_alias{1}
@@ -117,8 +115,8 @@ BOOST_AUTO_TEST_CASE(send_client) {
     BOOST_TEST(pid_opt2.has_value());
     auto publish_use_ta1 = am::v5::publish_packet(
         *pid_opt2,
-        am::buffer{},
-        am::buffer("payload1"),
+        "",
+        "payload1",
         am::qos::exactly_once | am::pub::retain::yes | am::pub::dup::yes,
         am::properties{
             am::property::topic_alias{1}
@@ -129,8 +127,8 @@ BOOST_AUTO_TEST_CASE(send_client) {
     BOOST_TEST(pid_opt3.has_value());
     auto publish_reg_t2 = am::v5::publish_packet(
         *pid_opt3,
-        "topic2"_mb,
-        "payload1"_mb,
+        "topic2",
+        "payload1",
         am::qos::exactly_once | am::pub::retain::yes | am::pub::dup::yes,
         am::properties{
             am::property::topic_alias{2}
@@ -141,8 +139,8 @@ BOOST_AUTO_TEST_CASE(send_client) {
     BOOST_TEST(pid_opt4.has_value());
     auto publish_use_ta2 = am::v5::publish_packet(
         *pid_opt4,
-        am::buffer{},
-        am::buffer("payload1"),
+        "",
+        "payload1",
         am::qos::exactly_once | am::pub::retain::yes | am::pub::dup::yes,
         am::properties{
             am::property::topic_alias{2}
@@ -153,8 +151,8 @@ BOOST_AUTO_TEST_CASE(send_client) {
     BOOST_TEST(pid_opt5.has_value());
     auto publish_reg_t3 = am::v5::publish_packet(
         *pid_opt5,
-        "topic3"_mb,
-        "payload1"_mb,
+        "topic3",
+        "payload1",
         am::qos::exactly_once | am::pub::retain::yes | am::pub::dup::yes,
         am::properties{
             am::property::topic_alias{3} // over
@@ -165,8 +163,8 @@ BOOST_AUTO_TEST_CASE(send_client) {
     BOOST_TEST(pid_opt6.has_value());
     auto publish_use_ta3 = am::v5::publish_packet(
         *pid_opt6,
-        am::buffer{},
-        am::buffer("payload1"),
+        "",
+        "payload1",
         am::qos::exactly_once | am::pub::retain::yes | am::pub::dup::yes,
         am::properties{
             am::property::topic_alias{3} // over
@@ -177,8 +175,8 @@ BOOST_AUTO_TEST_CASE(send_client) {
     BOOST_TEST(pid_opt7.has_value());
     auto publish_upd_t3 = am::v5::publish_packet(
         *pid_opt7,
-        "topic3"_mb,
-        "payload1"_mb,
+        "topic3",
+        "payload1",
         am::qos::exactly_once | am::pub::retain::yes | am::pub::dup::yes,
         am::properties{
             am::property::topic_alias{1} // update
@@ -198,13 +196,13 @@ BOOST_AUTO_TEST_CASE(send_client) {
     {   // check regulate
         auto p = publish_reg_t1;
         auto rp = ep->regulate_for_store(p, as::use_future).get();
-        BOOST_TEST(rp.topic() == "topic1"_mb);
+        BOOST_TEST(rp.topic() == "topic1");
         BOOST_TEST(!get_topic_alias(rp.props()));
 
         // idempotence
         auto p2 = p;
         auto rp2 = ep->regulate_for_store(p2, as::use_future).get();
-        BOOST_TEST(rp2.topic() == "topic1"_mb);
+        BOOST_TEST(rp2.topic() == "topic1");
         BOOST_TEST(!get_topic_alias(rp2.props()));
     }
 
@@ -221,7 +219,7 @@ BOOST_AUTO_TEST_CASE(send_client) {
     {   // check regulate
         auto p = publish_use_ta1;
         auto rp = ep->regulate_for_store(p, as::use_future).get();
-        BOOST_TEST(rp.topic() == "topic1"_mb);
+        BOOST_TEST(rp.topic() == "topic1");
         BOOST_TEST(!get_topic_alias(rp.props()));
     }
 
@@ -305,10 +303,10 @@ BOOST_AUTO_TEST_CASE(send_server) {
     auto connect = am::v5::connect_packet{
         true,   // clean_start
         0x1234, // keep_alive
-        "cid1"_mb,
+        "cid1",
         std::nullopt, // will
-        "user1"_mb,
-        "pass1"_mb,
+        "user1",
+        "pass1",
         am::properties{
             am::property::topic_alias_maximum{2}
         }
@@ -348,8 +346,8 @@ BOOST_AUTO_TEST_CASE(send_server) {
     BOOST_TEST(pid_opt1.has_value());
     auto publish_reg_t1 = am::v5::publish_packet(
         *pid_opt1,
-        "topic1"_mb,
-        "payload1"_mb,
+        "topic1",
+        "payload1",
         am::qos::exactly_once | am::pub::retain::yes | am::pub::dup::yes,
         am::properties{
             am::property::topic_alias{1}
@@ -360,8 +358,8 @@ BOOST_AUTO_TEST_CASE(send_server) {
     BOOST_TEST(pid_opt2.has_value());
     auto publish_use_ta1 = am::v5::publish_packet(
         *pid_opt2,
-        am::buffer{},
-        am::buffer("payload1"),
+        "",
+        "payload1",
         am::qos::exactly_once | am::pub::retain::yes | am::pub::dup::yes,
         am::properties{
             am::property::topic_alias{1}
@@ -372,8 +370,8 @@ BOOST_AUTO_TEST_CASE(send_server) {
     BOOST_TEST(pid_opt3.has_value());
     auto publish_reg_t2 = am::v5::publish_packet(
         *pid_opt3,
-        "topic2"_mb,
-        "payload1"_mb,
+        "topic2",
+        "payload1",
         am::qos::exactly_once | am::pub::retain::yes | am::pub::dup::yes,
         am::properties{
             am::property::topic_alias{2}
@@ -384,8 +382,8 @@ BOOST_AUTO_TEST_CASE(send_server) {
     BOOST_TEST(pid_opt4.has_value());
     auto publish_use_ta2 = am::v5::publish_packet(
         *pid_opt4,
-        am::buffer{},
-        am::buffer("payload1"),
+        "",
+        "payload1",
         am::qos::exactly_once | am::pub::retain::yes | am::pub::dup::yes,
         am::properties{
             am::property::topic_alias{2}
@@ -396,8 +394,8 @@ BOOST_AUTO_TEST_CASE(send_server) {
     BOOST_TEST(pid_opt5.has_value());
     auto publish_reg_t3 = am::v5::publish_packet(
         *pid_opt5,
-        "topic3"_mb,
-        "payload1"_mb,
+        "topic3",
+        "payload1",
         am::qos::exactly_once | am::pub::retain::yes | am::pub::dup::yes,
         am::properties{
             am::property::topic_alias{3} // over
@@ -408,8 +406,8 @@ BOOST_AUTO_TEST_CASE(send_server) {
     BOOST_TEST(pid_opt6.has_value());
     auto publish_use_ta3 = am::v5::publish_packet(
         *pid_opt6,
-        am::buffer{},
-        am::buffer("payload1"),
+        "",
+        "payload1",
         am::qos::exactly_once | am::pub::retain::yes | am::pub::dup::yes,
         am::properties{
             am::property::topic_alias{3} // over
@@ -420,8 +418,8 @@ BOOST_AUTO_TEST_CASE(send_server) {
     BOOST_TEST(pid_opt7.has_value());
     auto publish_upd_t3 = am::v5::publish_packet(
         *pid_opt7,
-        "topic3"_mb,
-        "payload1"_mb,
+        "topic3",
+        "payload1",
         am::qos::exactly_once | am::pub::retain::yes | am::pub::dup::yes,
         am::properties{
             am::property::topic_alias{1} // update
@@ -530,10 +528,10 @@ BOOST_AUTO_TEST_CASE(send_auto_map) {
     auto connect = am::v5::connect_packet{
         true,   // clean_start
         0x1234, // keep_alive
-        "cid1"_mb,
+        "cid1",
         std::nullopt, // will
-        "user1"_mb,
-        "pass1"_mb,
+        "user1",
+        "pass1",
         am::properties{}
     };
 
@@ -575,16 +573,16 @@ BOOST_AUTO_TEST_CASE(send_auto_map) {
     BOOST_TEST(pid_opt1.has_value());
     auto publish_t1 = am::v5::publish_packet(
         *pid_opt1,
-        "topic1"_mb,
-        "payload1"_mb,
+        "topic1",
+        "payload1",
         am::qos::exactly_once | am::pub::retain::yes | am::pub::dup::yes,
         am::properties{}
     );
 
     auto publish_mapped_ta1 = am::v5::publish_packet(
         *pid_opt1,
-        "topic1"_mb,
-        am::buffer("payload1"),
+        "topic1",
+        "payload1",
         am::qos::exactly_once | am::pub::retain::yes | am::pub::dup::yes,
         am::properties{
             am::property::topic_alias{1}
@@ -593,8 +591,8 @@ BOOST_AUTO_TEST_CASE(send_auto_map) {
 
     auto publish_use_ta1 = am::v5::publish_packet(
         *pid_opt1,
-        am::buffer{},
-        am::buffer("payload1"),
+        "",
+        "payload1",
         am::qos::exactly_once | am::pub::retain::yes | am::pub::dup::yes,
         am::properties{
             am::property::topic_alias{1}
@@ -605,16 +603,16 @@ BOOST_AUTO_TEST_CASE(send_auto_map) {
     BOOST_TEST(pid_opt2.has_value());
     auto publish_t2 = am::v5::publish_packet(
         *pid_opt2,
-        "topic2"_mb,
-        "payload1"_mb,
+        "topic2",
+        "payload1",
         am::qos::exactly_once | am::pub::retain::yes | am::pub::dup::yes,
         am::properties{}
     );
 
     auto publish_mapped_ta2 = am::v5::publish_packet(
         *pid_opt2,
-        "topic2"_mb,
-        am::buffer("payload1"),
+        "topic2",
+        "payload1",
         am::qos::exactly_once | am::pub::retain::yes | am::pub::dup::yes,
         am::properties{
             am::property::topic_alias{2}
@@ -623,8 +621,8 @@ BOOST_AUTO_TEST_CASE(send_auto_map) {
 
     auto publish_use_ta2 = am::v5::publish_packet(
         *pid_opt2,
-        am::buffer{},
-        am::buffer("payload1"),
+        "",
+        "payload1",
         am::qos::exactly_once | am::pub::retain::yes | am::pub::dup::yes,
         am::properties{
             am::property::topic_alias{2}
@@ -635,16 +633,16 @@ BOOST_AUTO_TEST_CASE(send_auto_map) {
     BOOST_TEST(pid_opt3.has_value());
     auto publish_t3 = am::v5::publish_packet(
         *pid_opt3,
-        "topic3"_mb,
-        "payload1"_mb,
+        "topic3",
+        "payload1",
         am::qos::exactly_once | am::pub::retain::yes | am::pub::dup::yes,
         am::properties{}
     );
 
     auto publish_mapped_ta1_2 = am::v5::publish_packet(
         *pid_opt3,
-        "topic3"_mb,
-        am::buffer("payload1"),
+        "topic3",
+        "payload1",
         am::qos::exactly_once | am::pub::retain::yes | am::pub::dup::yes,
         am::properties{
             am::property::topic_alias{1}
@@ -653,8 +651,8 @@ BOOST_AUTO_TEST_CASE(send_auto_map) {
 
     auto publish_use_ta1_2 = am::v5::publish_packet(
         *pid_opt3,
-        am::buffer{},
-        am::buffer("payload1"),
+        "",
+        "payload1",
         am::qos::exactly_once | am::pub::retain::yes | am::pub::dup::yes,
         am::properties{
             am::property::topic_alias{1}
@@ -752,10 +750,10 @@ BOOST_AUTO_TEST_CASE(send_auto_replace) {
     auto connect = am::v5::connect_packet{
         true,   // clean_start
         0x1234, // keep_alive
-        "cid1"_mb,
+        "cid1",
         std::nullopt, // will
-        "user1"_mb,
-        "pass1"_mb,
+        "user1",
+        "pass1",
         am::properties{}
     };
 
@@ -797,8 +795,8 @@ BOOST_AUTO_TEST_CASE(send_auto_replace) {
     BOOST_TEST(pid_opt1.has_value());
     auto publish_t1 = am::v5::publish_packet(
         *pid_opt1,
-        "topic1"_mb,
-        "payload1"_mb,
+        "topic1",
+        "payload1",
         am::qos::exactly_once | am::pub::retain::yes | am::pub::dup::yes,
         am::properties{}
     );
@@ -807,8 +805,8 @@ BOOST_AUTO_TEST_CASE(send_auto_replace) {
     BOOST_TEST(pid_opt2.has_value());
     auto publish_map_ta1 = am::v5::publish_packet(
         *pid_opt2,
-        "topic1"_mb,
-        am::buffer("payload1"),
+        "topic1",
+        "payload1",
         am::qos::exactly_once | am::pub::retain::yes | am::pub::dup::yes,
         am::properties{
             am::property::topic_alias{1}
@@ -819,8 +817,8 @@ BOOST_AUTO_TEST_CASE(send_auto_replace) {
     BOOST_TEST(pid_opt3.has_value());
     auto publish_use_ta1 = am::v5::publish_packet(
         *pid_opt3,
-        am::buffer{},
-        am::buffer("payload1"),
+        "",
+        "payload1",
         am::qos::exactly_once | am::pub::retain::yes | am::pub::dup::yes,
         am::properties{
             am::property::topic_alias{1}
@@ -831,16 +829,16 @@ BOOST_AUTO_TEST_CASE(send_auto_replace) {
     BOOST_TEST(pid_opt4.has_value());
     auto publish_t1_2 = am::v5::publish_packet(
         *pid_opt4,
-        "topic1"_mb,
-        "payload1"_mb,
+        "topic1",
+        "payload1",
         am::qos::exactly_once | am::pub::retain::yes | am::pub::dup::yes,
         am::properties{}
     );
 
     auto publish_exp_ta1 = am::v5::publish_packet(
         *pid_opt4,
-        am::buffer{},
-        am::buffer("payload1"),
+        "",
+        "payload1",
         am::qos::exactly_once | am::pub::retain::yes | am::pub::dup::yes,
         am::properties{
             am::property::topic_alias{1}
@@ -917,10 +915,10 @@ BOOST_AUTO_TEST_CASE(recv_client) {
     auto connect = am::v5::connect_packet{
         true,   // clean_start
         0x1234, // keep_alive
-        "cid1"_mb,
+        "cid1",
         std::nullopt, // will
-        "user1"_mb,
-        "pass1"_mb,
+        "user1",
+        "pass1",
         am::properties{
             am::property::topic_alias_maximum{2}
         }
@@ -972,8 +970,8 @@ BOOST_AUTO_TEST_CASE(recv_client) {
     BOOST_TEST(pid_opt1.has_value());
     auto publish_reg_t1 = am::v5::publish_packet(
         *pid_opt1,
-        "topic1"_mb,
-        "payload1"_mb,
+        "topic1",
+        "payload1",
         am::qos::exactly_once | am::pub::retain::yes | am::pub::dup::yes,
         am::properties{
             am::property::topic_alias{1}
@@ -984,8 +982,8 @@ BOOST_AUTO_TEST_CASE(recv_client) {
     BOOST_TEST(pid_opt2.has_value());
     auto publish_use_ta1 = am::v5::publish_packet(
         *pid_opt2,
-        am::buffer{},
-        am::buffer("payload1"),
+        "",
+        "payload1",
         am::qos::exactly_once | am::pub::retain::yes | am::pub::dup::yes,
         am::properties{
             am::property::topic_alias{1}
@@ -994,8 +992,8 @@ BOOST_AUTO_TEST_CASE(recv_client) {
 
     auto publish_exp_t1 = am::v5::publish_packet(
         *pid_opt2,
-        "topic1"_mb,
-        "payload1"_mb,
+        "topic1",
+        "payload1",
         am::qos::exactly_once | am::pub::retain::yes | am::pub::dup::yes,
         am::properties{
             am::property::topic_alias{1}
@@ -1006,8 +1004,8 @@ BOOST_AUTO_TEST_CASE(recv_client) {
     BOOST_TEST(pid_opt3.has_value());
     auto publish_reg_t2 = am::v5::publish_packet(
         *pid_opt3,
-        "topic2"_mb,
-        "payload1"_mb,
+        "topic2",
+        "payload1",
         am::qos::exactly_once | am::pub::retain::yes | am::pub::dup::yes,
         am::properties{
             am::property::topic_alias{2}
@@ -1018,8 +1016,8 @@ BOOST_AUTO_TEST_CASE(recv_client) {
     BOOST_TEST(pid_opt4.has_value());
     auto publish_use_ta2 = am::v5::publish_packet(
         *pid_opt4,
-        am::buffer{},
-        am::buffer("payload1"),
+        "",
+        "payload1",
         am::qos::exactly_once | am::pub::retain::yes | am::pub::dup::yes,
         am::properties{
             am::property::topic_alias{2}
@@ -1028,8 +1026,8 @@ BOOST_AUTO_TEST_CASE(recv_client) {
 
     auto publish_exp_t2 = am::v5::publish_packet(
         *pid_opt4,
-        "topic2"_mb,
-        "payload1"_mb,
+        "topic2",
+        "payload1",
         am::qos::exactly_once | am::pub::retain::yes | am::pub::dup::yes,
         am::properties{
             am::property::topic_alias{2}
@@ -1040,8 +1038,8 @@ BOOST_AUTO_TEST_CASE(recv_client) {
     BOOST_TEST(pid_opt5.has_value());
     auto publish_reg_t3 = am::v5::publish_packet(
         *pid_opt5,
-        "topic3"_mb,
-        "payload1"_mb,
+        "topic3",
+        "payload1",
         am::qos::exactly_once | am::pub::retain::yes | am::pub::dup::yes,
         am::properties{
             am::property::topic_alias{3} // over
@@ -1052,8 +1050,8 @@ BOOST_AUTO_TEST_CASE(recv_client) {
     BOOST_TEST(pid_opt6.has_value());
     auto publish_use_ta3 = am::v5::publish_packet(
         *pid_opt6,
-        am::buffer{},
-        am::buffer("payload1"),
+        "",
+        "payload1",
         am::qos::exactly_once | am::pub::retain::yes | am::pub::dup::yes,
         am::properties{
             am::property::topic_alias{3} // over
@@ -1064,8 +1062,8 @@ BOOST_AUTO_TEST_CASE(recv_client) {
     BOOST_TEST(pid_opt7.has_value());
     auto publish_upd_t3 = am::v5::publish_packet(
         *pid_opt7,
-        "topic3"_mb,
-        "payload1"_mb,
+        "topic3",
+        "payload1",
         am::qos::exactly_once | am::pub::retain::yes | am::pub::dup::yes,
         am::properties{
             am::property::topic_alias{1} // update
@@ -1076,8 +1074,8 @@ BOOST_AUTO_TEST_CASE(recv_client) {
     BOOST_TEST(pid_opt8.has_value());
     auto publish_use_ta1_t3 = am::v5::publish_packet(
         *pid_opt8,
-        am::buffer{},
-        am::buffer("payload1"),
+        "",
+        "payload1",
         am::qos::exactly_once | am::pub::retain::yes | am::pub::dup::yes,
         am::properties{
             am::property::topic_alias{1}
@@ -1086,8 +1084,8 @@ BOOST_AUTO_TEST_CASE(recv_client) {
 
     auto publish_exp_t3 = am::v5::publish_packet(
         *pid_opt8,
-        "topic3"_mb,
-        "payload1"_mb,
+        "topic3",
+        "payload1",
         am::qos::exactly_once | am::pub::retain::yes | am::pub::dup::yes,
         am::properties{
             am::property::topic_alias{1} // update
@@ -1227,10 +1225,10 @@ BOOST_AUTO_TEST_CASE(recv_server) {
     auto connect = am::v5::connect_packet{
         true,   // clean_start
         0x1234, // keep_alive
-        "cid1"_mb,
+        "cid1",
         std::nullopt, // will
-        "user1"_mb,
-        "pass1"_mb,
+        "user1",
+        "pass1",
         am::properties{}
     };
 
@@ -1283,8 +1281,8 @@ BOOST_AUTO_TEST_CASE(recv_server) {
     BOOST_TEST(pid_opt1.has_value());
     auto publish_reg_t1 = am::v5::publish_packet(
         *pid_opt1,
-        "topic1"_mb,
-        "payload1"_mb,
+        "topic1",
+        "payload1",
         am::qos::exactly_once | am::pub::retain::yes | am::pub::dup::yes,
         am::properties{
             am::property::topic_alias{1}
@@ -1295,8 +1293,8 @@ BOOST_AUTO_TEST_CASE(recv_server) {
     BOOST_TEST(pid_opt2.has_value());
     auto publish_use_ta1 = am::v5::publish_packet(
         *pid_opt2,
-        am::buffer{},
-        am::buffer("payload1"),
+        "",
+        "payload1",
         am::qos::exactly_once | am::pub::retain::yes | am::pub::dup::yes,
         am::properties{
             am::property::topic_alias{1}
@@ -1305,8 +1303,8 @@ BOOST_AUTO_TEST_CASE(recv_server) {
 
     auto publish_exp_t1 = am::v5::publish_packet(
         *pid_opt2,
-        "topic1"_mb,
-        "payload1"_mb,
+        "topic1",
+        "payload1",
         am::qos::exactly_once | am::pub::retain::yes | am::pub::dup::yes,
         am::properties{
             am::property::topic_alias{1}
@@ -1317,8 +1315,8 @@ BOOST_AUTO_TEST_CASE(recv_server) {
     BOOST_TEST(pid_opt3.has_value());
     auto publish_reg_t2 = am::v5::publish_packet(
         *pid_opt3,
-        "topic2"_mb,
-        "payload1"_mb,
+        "topic2",
+        "payload1",
         am::qos::exactly_once | am::pub::retain::yes | am::pub::dup::yes,
         am::properties{
             am::property::topic_alias{2}
@@ -1329,8 +1327,8 @@ BOOST_AUTO_TEST_CASE(recv_server) {
     BOOST_TEST(pid_opt4.has_value());
     auto publish_use_ta2 = am::v5::publish_packet(
         *pid_opt4,
-        am::buffer{},
-        am::buffer("payload1"),
+        "",
+        "payload1",
         am::qos::exactly_once | am::pub::retain::yes | am::pub::dup::yes,
         am::properties{
             am::property::topic_alias{2}
@@ -1339,8 +1337,8 @@ BOOST_AUTO_TEST_CASE(recv_server) {
 
     auto publish_exp_t2 = am::v5::publish_packet(
         *pid_opt4,
-        "topic2"_mb,
-        "payload1"_mb,
+        "topic2",
+        "payload1",
         am::qos::exactly_once | am::pub::retain::yes | am::pub::dup::yes,
         am::properties{
             am::property::topic_alias{2}
@@ -1351,8 +1349,8 @@ BOOST_AUTO_TEST_CASE(recv_server) {
     BOOST_TEST(pid_opt5.has_value());
     auto publish_reg_t3 = am::v5::publish_packet(
         *pid_opt5,
-        "topic3"_mb,
-        "payload1"_mb,
+        "topic3",
+        "payload1",
         am::qos::exactly_once | am::pub::retain::yes | am::pub::dup::yes,
         am::properties{
             am::property::topic_alias{3} // over
@@ -1363,8 +1361,8 @@ BOOST_AUTO_TEST_CASE(recv_server) {
     BOOST_TEST(pid_opt6.has_value());
     auto publish_use_ta3 = am::v5::publish_packet(
         *pid_opt6,
-        am::buffer{},
-        am::buffer("payload1"),
+        "",
+        "payload1",
         am::qos::exactly_once | am::pub::retain::yes | am::pub::dup::yes,
         am::properties{
             am::property::topic_alias{3} // over
@@ -1375,8 +1373,8 @@ BOOST_AUTO_TEST_CASE(recv_server) {
     BOOST_TEST(pid_opt7.has_value());
     auto publish_upd_t3 = am::v5::publish_packet(
         *pid_opt7,
-        "topic3"_mb,
-        "payload1"_mb,
+        "topic3",
+        "payload1",
         am::qos::exactly_once | am::pub::retain::yes | am::pub::dup::yes,
         am::properties{
             am::property::topic_alias{1} // update
@@ -1387,8 +1385,8 @@ BOOST_AUTO_TEST_CASE(recv_server) {
     BOOST_TEST(pid_opt8.has_value());
     auto publish_use_ta1_t3 = am::v5::publish_packet(
         *pid_opt8,
-        am::buffer{},
-        am::buffer("payload1"),
+        "",
+        "payload1",
         am::qos::exactly_once | am::pub::retain::yes | am::pub::dup::yes,
         am::properties{
             am::property::topic_alias{1}
@@ -1397,8 +1395,8 @@ BOOST_AUTO_TEST_CASE(recv_server) {
 
     auto publish_exp_t3 = am::v5::publish_packet(
         *pid_opt8,
-        "topic3"_mb,
-        "payload1"_mb,
+        "topic3",
+        "payload1",
         am::qos::exactly_once | am::pub::retain::yes | am::pub::dup::yes,
         am::properties{
             am::property::topic_alias{1} // update

--- a/test/unit/ut_null_strand.cpp
+++ b/test/unit/ut_null_strand.cpp
@@ -19,7 +19,6 @@
 BOOST_AUTO_TEST_SUITE(ut_null_strand)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 namespace as = boost::asio;
 
 // v3_1_1

--- a/test/unit/ut_packet_v3_1_1_connack.cpp
+++ b/test/unit/ut_packet_v3_1_1_connack.cpp
@@ -9,6 +9,10 @@
 
 #include <boost/lexical_cast.hpp>
 
+BOOST_AUTO_TEST_SUITE(ut_packet)
+struct v311_connack;
+BOOST_AUTO_TEST_SUITE_END()
+
 #include <async_mqtt/packet/v3_1_1_connack.hpp>
 #include <async_mqtt/packet/packet_iterator.hpp>
 #include <async_mqtt/packet/packet_traits.hpp>
@@ -16,7 +20,6 @@
 BOOST_AUTO_TEST_SUITE(ut_packet)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 
 BOOST_AUTO_TEST_CASE(v311_connack) {
     BOOST_TEST(am::is_connack<am::v3_1_1::connack_packet>());
@@ -44,7 +47,7 @@ BOOST_AUTO_TEST_CASE(v311_connack) {
         auto [b, e] = am::make_packet_range(cbs);
         BOOST_TEST(std::equal(b, e, std::begin(expected)));
 
-        auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+        am::buffer buf{std::begin(expected), std::end(expected)};
         auto p = am::v3_1_1::connack_packet{buf};
         BOOST_TEST(p.session_present());
         BOOST_TEST(p.code() == am::connect_return_code::not_authorized);

--- a/test/unit/ut_packet_v3_1_1_connect.cpp
+++ b/test/unit/ut_packet_v3_1_1_connect.cpp
@@ -9,6 +9,10 @@
 
 #include <boost/lexical_cast.hpp>
 
+BOOST_AUTO_TEST_SUITE(ut_packet)
+struct v311_connect;
+BOOST_AUTO_TEST_SUITE_END()
+
 #include <async_mqtt/packet/v3_1_1_connect.hpp>
 #include <async_mqtt/packet/packet_iterator.hpp>
 #include <async_mqtt/packet/packet_traits.hpp>
@@ -16,7 +20,6 @@
 BOOST_AUTO_TEST_SUITE(ut_packet)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 
 BOOST_AUTO_TEST_CASE(v311_connect) {
     BOOST_TEST(am::is_connect<am::v3_1_1::connect_packet>());
@@ -26,18 +29,18 @@ BOOST_AUTO_TEST_CASE(v311_connect) {
     BOOST_TEST(!am::is_server_sendable<am::v3_1_1::connect_packet>());
 
     auto w = am::will{
-        "topic1"_mb,
-        "payload1"_mb,
+        "topic1",
+        "payload1",
         am::pub::retain::yes | am::qos::at_least_once
     };
 
     auto p = am::v3_1_1::connect_packet{
         true,   // clean_session
         0x1234, // keep_alive
-        "cid1"_mb,
+        "cid1",
         w,
-        "user1"_mb,
-        "pass1"_mb
+        "user1",
+        "pass1"
     };
 
     BOOST_TEST(p.clean_session());
@@ -74,7 +77,7 @@ BOOST_AUTO_TEST_CASE(v311_connect) {
         auto [b, e] = am::make_packet_range(cbs);
         BOOST_TEST(std::equal(b, e, std::begin(expected)));
 
-        auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+        am::buffer buf{std::begin(expected), std::end(expected)};
         auto p = am::v3_1_1::connect_packet{buf};
         BOOST_TEST(p.clean_session());
         BOOST_TEST(p.keep_alive() == 0x1234);

--- a/test/unit/ut_packet_v3_1_1_disconnect.cpp
+++ b/test/unit/ut_packet_v3_1_1_disconnect.cpp
@@ -9,6 +9,10 @@
 
 #include <boost/lexical_cast.hpp>
 
+BOOST_AUTO_TEST_SUITE(ut_packet)
+struct v311_disconnect;
+BOOST_AUTO_TEST_SUITE_END()
+
 #include <async_mqtt/packet/v3_1_1_disconnect.hpp>
 #include <async_mqtt/packet/packet_iterator.hpp>
 #include <async_mqtt/packet/packet_traits.hpp>
@@ -16,9 +20,8 @@
 BOOST_AUTO_TEST_SUITE(ut_packet)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 
-BOOST_AUTO_TEST_CASE(v3_1_1_disconnect) {
+BOOST_AUTO_TEST_CASE(v311_disconnect) {
     BOOST_TEST(am::is_disconnect<am::v3_1_1::disconnect_packet>());
     BOOST_TEST(am::is_v3_1_1<am::v3_1_1::disconnect_packet>());
     BOOST_TEST(!am::is_v5<am::v3_1_1::disconnect_packet>());
@@ -37,7 +40,7 @@ BOOST_AUTO_TEST_CASE(v3_1_1_disconnect) {
         auto [b, e] = am::make_packet_range(cbs);
         BOOST_TEST(std::equal(b, e, std::begin(expected)));
 
-        auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+        am::buffer buf{std::begin(expected), std::end(expected)};
         auto p = am::v3_1_1::disconnect_packet{buf};
 
         auto cbs2 = p.const_buffer_sequence();

--- a/test/unit/ut_packet_v3_1_1_pingreq.cpp
+++ b/test/unit/ut_packet_v3_1_1_pingreq.cpp
@@ -9,6 +9,10 @@
 
 #include <boost/lexical_cast.hpp>
 
+BOOST_AUTO_TEST_SUITE(ut_packet)
+struct v311_pingreq;
+BOOST_AUTO_TEST_SUITE_END()
+
 #include <async_mqtt/packet/v3_1_1_pingreq.hpp>
 #include <async_mqtt/packet/packet_iterator.hpp>
 #include <async_mqtt/packet/packet_traits.hpp>
@@ -16,7 +20,6 @@
 BOOST_AUTO_TEST_SUITE(ut_packet)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 
 BOOST_AUTO_TEST_CASE(v311_pingreq) {
     BOOST_TEST(am::is_pingreq<am::v3_1_1::pingreq_packet>());
@@ -37,7 +40,7 @@ BOOST_AUTO_TEST_CASE(v311_pingreq) {
         auto [b, e] = am::make_packet_range(cbs);
         BOOST_TEST(std::equal(b, e, std::begin(expected)));
 
-        auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+        am::buffer buf{std::begin(expected), std::end(expected)};
         auto p = am::v3_1_1::pingreq_packet{buf};
 
         auto cbs2 = p.const_buffer_sequence();

--- a/test/unit/ut_packet_v3_1_1_pingresp.cpp
+++ b/test/unit/ut_packet_v3_1_1_pingresp.cpp
@@ -9,6 +9,10 @@
 
 #include <boost/lexical_cast.hpp>
 
+BOOST_AUTO_TEST_SUITE(ut_packet)
+struct v311_pingresp;
+BOOST_AUTO_TEST_SUITE_END()
+
 #include <async_mqtt/packet/v3_1_1_pingresp.hpp>
 #include <async_mqtt/packet/packet_iterator.hpp>
 #include <async_mqtt/packet/packet_traits.hpp>
@@ -16,7 +20,6 @@
 BOOST_AUTO_TEST_SUITE(ut_packet)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 
 BOOST_AUTO_TEST_CASE(v311_pingresp) {
     BOOST_TEST(am::is_pingresp<am::v3_1_1::pingresp_packet>());
@@ -37,7 +40,7 @@ BOOST_AUTO_TEST_CASE(v311_pingresp) {
         auto [b, e] = am::make_packet_range(cbs);
         BOOST_TEST(std::equal(b, e, std::begin(expected)));
 
-        auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+        am::buffer buf{std::begin(expected), std::end(expected)};
         auto p = am::v3_1_1::pingresp_packet{buf};
 
         auto cbs2 = p.const_buffer_sequence();

--- a/test/unit/ut_packet_v3_1_1_puback.cpp
+++ b/test/unit/ut_packet_v3_1_1_puback.cpp
@@ -9,6 +9,12 @@
 
 #include <boost/lexical_cast.hpp>
 
+BOOST_AUTO_TEST_SUITE(ut_packet)
+struct v311_puback;
+struct v311_puback_pid4;
+BOOST_AUTO_TEST_SUITE_END()
+
+
 #include <async_mqtt/packet/v3_1_1_puback.hpp>
 #include <async_mqtt/packet/packet_iterator.hpp>
 #include <async_mqtt/packet/packet_traits.hpp>
@@ -16,7 +22,6 @@
 BOOST_AUTO_TEST_SUITE(ut_packet)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 
 BOOST_AUTO_TEST_CASE(v311_puback) {
     BOOST_TEST(am::is_puback<am::v3_1_1::puback_packet>());
@@ -42,7 +47,7 @@ BOOST_AUTO_TEST_CASE(v311_puback) {
         auto [b, e] = am::make_packet_range(cbs);
         BOOST_TEST(std::equal(b, e, std::begin(expected)));
 
-        auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+        am::buffer buf{std::begin(expected), std::end(expected)};
         auto p = am::v3_1_1::puback_packet{buf};
         BOOST_TEST(p.packet_id() == 0x1234);
 
@@ -75,7 +80,7 @@ BOOST_AUTO_TEST_CASE(v311_puback_pid4) {
         auto [b, e] = am::make_packet_range(cbs);
         BOOST_TEST(std::equal(b, e, std::begin(expected)));
 
-        auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+        am::buffer buf{std::begin(expected), std::end(expected)};
         auto p = am::v3_1_1::basic_puback_packet<4>{buf};
         BOOST_TEST(p.packet_id() == 0x12345678);
 

--- a/test/unit/ut_packet_v3_1_1_pubcomp.cpp
+++ b/test/unit/ut_packet_v3_1_1_pubcomp.cpp
@@ -9,6 +9,11 @@
 
 #include <boost/lexical_cast.hpp>
 
+BOOST_AUTO_TEST_SUITE(ut_packet)
+struct v311_pubcomp;
+struct v311_pubcomp_pid4;
+BOOST_AUTO_TEST_SUITE_END()
+
 #include <async_mqtt/packet/v3_1_1_pubcomp.hpp>
 #include <async_mqtt/packet/packet_iterator.hpp>
 #include <async_mqtt/packet/packet_traits.hpp>
@@ -16,7 +21,6 @@
 BOOST_AUTO_TEST_SUITE(ut_packet)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 
 BOOST_AUTO_TEST_CASE(v311_pubcomp) {
     BOOST_TEST(am::is_pubcomp<am::v3_1_1::pubcomp_packet>());
@@ -42,7 +46,7 @@ BOOST_AUTO_TEST_CASE(v311_pubcomp) {
         auto [b, e] = am::make_packet_range(cbs);
         BOOST_TEST(std::equal(b, e, std::begin(expected)));
 
-        auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+        am::buffer buf{std::begin(expected), std::end(expected)};
         auto p = am::v3_1_1::pubcomp_packet{buf};
         BOOST_TEST(p.packet_id() == 0x1234);
 
@@ -75,7 +79,7 @@ BOOST_AUTO_TEST_CASE(v311_pubcomp_pid4) {
         auto [b, e] = am::make_packet_range(cbs);
         BOOST_TEST(std::equal(b, e, std::begin(expected)));
 
-        auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+        am::buffer buf{std::begin(expected), std::end(expected)};
         auto p = am::v3_1_1::basic_pubcomp_packet<4>{buf};
         BOOST_TEST(p.packet_id() == 0x12345678);
 

--- a/test/unit/ut_packet_v3_1_1_pubrec.cpp
+++ b/test/unit/ut_packet_v3_1_1_pubrec.cpp
@@ -9,6 +9,11 @@
 
 #include <boost/lexical_cast.hpp>
 
+BOOST_AUTO_TEST_SUITE(ut_packet)
+struct v311_pubrec;
+struct v311_pubrec_pid4;
+BOOST_AUTO_TEST_SUITE_END()
+
 #include <async_mqtt/packet/v3_1_1_pubrec.hpp>
 #include <async_mqtt/packet/packet_iterator.hpp>
 #include <async_mqtt/packet/packet_traits.hpp>
@@ -16,7 +21,6 @@
 BOOST_AUTO_TEST_SUITE(ut_packet)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 
 BOOST_AUTO_TEST_CASE(v311_pubrec) {
     BOOST_TEST(am::is_pubrec<am::v3_1_1::pubrec_packet>());
@@ -42,7 +46,7 @@ BOOST_AUTO_TEST_CASE(v311_pubrec) {
         auto [b, e] = am::make_packet_range(cbs);
         BOOST_TEST(std::equal(b, e, std::begin(expected)));
 
-        auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+        am::buffer buf{std::begin(expected), std::end(expected)};
         auto p = am::v3_1_1::pubrec_packet{buf};
         BOOST_TEST(p.packet_id() == 0x1234);
 
@@ -75,7 +79,7 @@ BOOST_AUTO_TEST_CASE(v311_pubrec_pid4) {
         auto [b, e] = am::make_packet_range(cbs);
         BOOST_TEST(std::equal(b, e, std::begin(expected)));
 
-        auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+        am::buffer buf{std::begin(expected), std::end(expected)};
         auto p = am::v3_1_1::basic_pubrec_packet<4>{buf};
         BOOST_TEST(p.packet_id() == 0x12345678);
 

--- a/test/unit/ut_packet_v3_1_1_pubrel.cpp
+++ b/test/unit/ut_packet_v3_1_1_pubrel.cpp
@@ -9,6 +9,11 @@
 
 #include <boost/lexical_cast.hpp>
 
+BOOST_AUTO_TEST_SUITE(ut_packet)
+struct v311_pubrel;
+struct v311_pubrel_pid4;
+BOOST_AUTO_TEST_SUITE_END()
+
 #include <async_mqtt/packet/v3_1_1_pubrel.hpp>
 #include <async_mqtt/packet/packet_iterator.hpp>
 #include <async_mqtt/packet/packet_traits.hpp>
@@ -16,7 +21,6 @@
 BOOST_AUTO_TEST_SUITE(ut_packet)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 
 BOOST_AUTO_TEST_CASE(v311_pubrel) {
     BOOST_TEST(am::is_pubrel<am::v3_1_1::pubrel_packet>());
@@ -42,7 +46,7 @@ BOOST_AUTO_TEST_CASE(v311_pubrel) {
         auto [b, e] = am::make_packet_range(cbs);
         BOOST_TEST(std::equal(b, e, std::begin(expected)));
 
-        auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+        am::buffer buf{std::begin(expected), std::end(expected)};
         auto p = am::v3_1_1::pubrel_packet{buf};
         BOOST_TEST(p.packet_id() == 0x1234);
 
@@ -75,7 +79,7 @@ BOOST_AUTO_TEST_CASE(v311_pubrel_pid4) {
         auto [b, e] = am::make_packet_range(cbs);
         BOOST_TEST(std::equal(b, e, std::begin(expected)));
 
-        auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+        am::buffer buf{std::begin(expected), std::end(expected)};
         auto p = am::v3_1_1::basic_pubrel_packet<4>{buf};
         BOOST_TEST(p.packet_id() == 0x12345678);
 

--- a/test/unit/ut_packet_v3_1_1_suback.cpp
+++ b/test/unit/ut_packet_v3_1_1_suback.cpp
@@ -9,6 +9,11 @@
 
 #include <boost/lexical_cast.hpp>
 
+BOOST_AUTO_TEST_SUITE(ut_packet)
+struct v311_suback;
+struct v311_suback_pid4;
+BOOST_AUTO_TEST_SUITE_END()
+
 #include <async_mqtt/packet/v3_1_1_suback.hpp>
 #include <async_mqtt/packet/packet_iterator.hpp>
 #include <async_mqtt/packet/packet_traits.hpp>
@@ -16,7 +21,6 @@
 BOOST_AUTO_TEST_SUITE(ut_packet)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 
 BOOST_AUTO_TEST_CASE(v311_suback) {
     BOOST_TEST(am::is_suback<am::v3_1_1::suback_packet>());
@@ -49,7 +53,7 @@ BOOST_AUTO_TEST_CASE(v311_suback) {
         auto [b, e] = am::make_packet_range(cbs);
         BOOST_TEST(std::equal(b, e, std::begin(expected)));
 
-        auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+        am::buffer buf{std::begin(expected), std::end(expected)};
         auto p = am::v3_1_1::suback_packet{buf};
         BOOST_TEST(p.packet_id() == 0x1234);
         BOOST_TEST((p.entries() == args));
@@ -90,7 +94,7 @@ BOOST_AUTO_TEST_CASE(v311_suback_pid4) {
         auto [b, e] = am::make_packet_range(cbs);
         BOOST_TEST(std::equal(b, e, std::begin(expected)));
 
-        auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+        am::buffer buf{std::begin(expected), std::end(expected)};
         auto p = am::v3_1_1::basic_suback_packet<4>{buf};
         BOOST_TEST(p.packet_id() == 0x12345678);
         BOOST_TEST((p.entries() == args));

--- a/test/unit/ut_packet_v3_1_1_subscribe.cpp
+++ b/test/unit/ut_packet_v3_1_1_subscribe.cpp
@@ -9,6 +9,11 @@
 
 #include <boost/lexical_cast.hpp>
 
+BOOST_AUTO_TEST_SUITE(ut_packet)
+struct v311_subscribe;
+struct v311_subscribe_pid4;
+BOOST_AUTO_TEST_SUITE_END()
+
 #include <async_mqtt/packet/v3_1_1_subscribe.hpp>
 #include <async_mqtt/packet/packet_iterator.hpp>
 #include <async_mqtt/packet/packet_traits.hpp>
@@ -16,7 +21,6 @@
 BOOST_AUTO_TEST_SUITE(ut_packet)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 
 BOOST_AUTO_TEST_CASE(v311_subscribe) {
     BOOST_TEST(am::is_subscribe<am::v3_1_1::subscribe_packet>());
@@ -26,8 +30,8 @@ BOOST_AUTO_TEST_CASE(v311_subscribe) {
     BOOST_TEST(!am::is_server_sendable<am::v3_1_1::subscribe_packet>());
 
     std::vector<am::topic_subopts> args {
-        {"topic1"_mb, am::qos::at_most_once},
-        {"topic2"_mb, am::qos::exactly_once},
+        {"topic1", am::qos::at_most_once},
+        {"topic2", am::qos::exactly_once},
     };
 
     auto p = am::v3_1_1::subscribe_packet{
@@ -52,7 +56,7 @@ BOOST_AUTO_TEST_CASE(v311_subscribe) {
         auto [b, e] = am::make_packet_range(cbs);
         BOOST_TEST(std::equal(b, e, std::begin(expected)));
 
-        auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+        am::buffer buf{std::begin(expected), std::end(expected)};
         auto p = am::v3_1_1::subscribe_packet{buf};
         BOOST_TEST(p.packet_id() == 0x1234);
         BOOST_TEST((p.entries() == args));
@@ -70,8 +74,8 @@ BOOST_AUTO_TEST_CASE(v311_subscribe) {
 
 BOOST_AUTO_TEST_CASE(v311_subscribe_pid4) {
     std::vector<am::topic_subopts> args {
-        {"topic1"_mb, am::qos::at_most_once},
-        {"topic2"_mb, am::qos::exactly_once},
+        {"topic1", am::qos::at_most_once},
+        {"topic2", am::qos::exactly_once},
     };
 
     auto p = am::v3_1_1::basic_subscribe_packet<4>{
@@ -96,7 +100,7 @@ BOOST_AUTO_TEST_CASE(v311_subscribe_pid4) {
         auto [b, e] = am::make_packet_range(cbs);
         BOOST_TEST(std::equal(b, e, std::begin(expected)));
 
-        auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+        am::buffer buf{std::begin(expected), std::end(expected)};
         auto p = am::v3_1_1::basic_subscribe_packet<4>{buf};
         BOOST_TEST(p.packet_id() == 0x12345678);
         BOOST_TEST((p.entries() == args));

--- a/test/unit/ut_packet_v3_1_1_unsuback.cpp
+++ b/test/unit/ut_packet_v3_1_1_unsuback.cpp
@@ -9,6 +9,11 @@
 
 #include <boost/lexical_cast.hpp>
 
+BOOST_AUTO_TEST_SUITE(ut_packet)
+struct v311_unsuback;
+struct v311_unsuback_pid4;
+BOOST_AUTO_TEST_SUITE_END()
+
 #include <async_mqtt/packet/v3_1_1_unsuback.hpp>
 #include <async_mqtt/packet/packet_iterator.hpp>
 #include <async_mqtt/packet/packet_traits.hpp>
@@ -16,7 +21,6 @@
 BOOST_AUTO_TEST_SUITE(ut_packet)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 
 BOOST_AUTO_TEST_CASE(v311_unsuback) {
     BOOST_TEST(am::is_unsuback<am::v3_1_1::unsuback_packet>());
@@ -42,7 +46,7 @@ BOOST_AUTO_TEST_CASE(v311_unsuback) {
         auto [b, e] = am::make_packet_range(cbs);
         BOOST_TEST(std::equal(b, e, std::begin(expected)));
 
-        auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+        am::buffer buf{std::begin(expected), std::end(expected)};
         auto p = am::v3_1_1::unsuback_packet{buf};
         BOOST_TEST(p.packet_id() == 0x1234);
 
@@ -75,7 +79,7 @@ BOOST_AUTO_TEST_CASE(v311_unsuback_pid4) {
         auto [b, e] = am::make_packet_range(cbs);
         BOOST_TEST(std::equal(b, e, std::begin(expected)));
 
-        auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+        am::buffer buf{std::begin(expected), std::end(expected)};
         auto p = am::v3_1_1::basic_unsuback_packet<4>{buf};
         BOOST_TEST(p.packet_id() == 0x12345678);
 

--- a/test/unit/ut_packet_v3_1_1_unsubscribe.cpp
+++ b/test/unit/ut_packet_v3_1_1_unsubscribe.cpp
@@ -9,6 +9,11 @@
 
 #include <boost/lexical_cast.hpp>
 
+BOOST_AUTO_TEST_SUITE(ut_packet)
+struct v311_unsubscribe;
+struct v311_unsubscribe_pid4;
+BOOST_AUTO_TEST_SUITE_END()
+
 #include <async_mqtt/packet/v3_1_1_unsubscribe.hpp>
 #include <async_mqtt/packet/packet_iterator.hpp>
 #include <async_mqtt/packet/packet_traits.hpp>
@@ -16,7 +21,6 @@
 BOOST_AUTO_TEST_SUITE(ut_packet)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 
 BOOST_AUTO_TEST_CASE(v311_unsubscribe) {
     BOOST_TEST(am::is_unsubscribe<am::v3_1_1::unsubscribe_packet>());
@@ -26,8 +30,8 @@ BOOST_AUTO_TEST_CASE(v311_unsubscribe) {
     BOOST_TEST(!am::is_server_sendable<am::v3_1_1::unsubscribe_packet>());
 
     std::vector<am::topic_sharename> args {
-        "topic1"_mb,
-        "topic2"_mb,
+        "topic1",
+        "topic2",
     };
 
     auto p = am::v3_1_1::unsubscribe_packet{
@@ -50,7 +54,7 @@ BOOST_AUTO_TEST_CASE(v311_unsubscribe) {
         auto [b, e] = am::make_packet_range(cbs);
         BOOST_TEST(std::equal(b, e, std::begin(expected)));
 
-        auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+        am::buffer buf{std::begin(expected), std::end(expected)};
         auto p = am::v3_1_1::unsubscribe_packet{buf};
         BOOST_TEST(p.packet_id() == 0x1234);
         BOOST_TEST((p.entries() == args));
@@ -68,8 +72,8 @@ BOOST_AUTO_TEST_CASE(v311_unsubscribe) {
 
 BOOST_AUTO_TEST_CASE(v311_unsubscribe_pid4) {
     std::vector<am::topic_sharename> args {
-        "topic1"_mb,
-        "topic2"_mb,
+        "topic1",
+        "topic2",
     };
 
     auto p = am::v3_1_1::basic_unsubscribe_packet<4>{
@@ -92,7 +96,7 @@ BOOST_AUTO_TEST_CASE(v311_unsubscribe_pid4) {
         auto [b, e] = am::make_packet_range(cbs);
         BOOST_TEST(std::equal(b, e, std::begin(expected)));
 
-        auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+        am::buffer buf{std::begin(expected), std::end(expected)};
         auto p = am::v3_1_1::basic_unsubscribe_packet<4>{buf};
         BOOST_TEST(p.packet_id() == 0x12345678);
         BOOST_TEST((p.entries() == args));

--- a/test/unit/ut_packet_v5_auth.cpp
+++ b/test/unit/ut_packet_v5_auth.cpp
@@ -9,6 +9,13 @@
 
 #include <boost/lexical_cast.hpp>
 
+BOOST_AUTO_TEST_SUITE(ut_packet)
+struct v5_auth;
+struct v5_auth_no_arg;
+struct v5_auth_pid_rc;
+struct v5_auth_prop_len_last;
+BOOST_AUTO_TEST_SUITE_END()
+
 #include <async_mqtt/packet/v5_auth.hpp>
 #include <async_mqtt/packet/packet_iterator.hpp>
 #include <async_mqtt/packet/packet_traits.hpp>
@@ -16,7 +23,6 @@
 BOOST_AUTO_TEST_SUITE(ut_packet)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 
 BOOST_AUTO_TEST_CASE(v5_auth) {
     BOOST_TEST(am::is_auth<am::v5::auth_packet>());
@@ -48,7 +54,7 @@ BOOST_AUTO_TEST_CASE(v5_auth) {
         auto [b, e] = am::make_packet_range(cbs);
         BOOST_TEST(std::equal(b, e, std::begin(expected)));
 
-        auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+        am::buffer buf{std::begin(expected), std::end(expected)};
         auto p = am::v5::auth_packet{buf};
         BOOST_TEST(p.code() == am::auth_reason_code::continue_authentication);
         BOOST_TEST(p.props() == props);
@@ -79,7 +85,7 @@ BOOST_AUTO_TEST_CASE(v5_auth_no_arg) {
         auto [b, e] = am::make_packet_range(cbs);
         BOOST_TEST(std::equal(b, e, std::begin(expected)));
 
-        auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+        am::buffer buf{std::begin(expected), std::end(expected)};
         auto p = am::v5::auth_packet{buf};
         BOOST_TEST(p.code() == am::auth_reason_code::success);
         BOOST_TEST(p.props().empty());
@@ -113,7 +119,7 @@ BOOST_AUTO_TEST_CASE(v5_auth_pid_rc) {
         auto [b, e] = am::make_packet_range(cbs);
         BOOST_TEST(std::equal(b, e, std::begin(expected)));
 
-        auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+        am::buffer buf{std::begin(expected), std::end(expected)};
         auto p = am::v5::auth_packet{buf};
         BOOST_TEST(p.code() == am::auth_reason_code::success);
         BOOST_TEST(p.props().empty());
@@ -136,7 +142,7 @@ BOOST_AUTO_TEST_CASE(v5_auth_prop_len_last) {
         0x00,                               // reason_code
         0x00,                               // property_length
     };
-    auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+    am::buffer buf{std::begin(expected), std::end(expected)};
     auto p = am::v5::auth_packet{buf};
     BOOST_TEST(p.code() == am::auth_reason_code::success);
     BOOST_TEST(p.props().empty());

--- a/test/unit/ut_packet_v5_connack.cpp
+++ b/test/unit/ut_packet_v5_connack.cpp
@@ -9,6 +9,10 @@
 
 #include <boost/lexical_cast.hpp>
 
+BOOST_AUTO_TEST_SUITE(ut_packet)
+struct v5_connack;
+BOOST_AUTO_TEST_SUITE_END()
+
 #include <async_mqtt/packet/v5_connack.hpp>
 #include <async_mqtt/packet/packet_iterator.hpp>
 #include <async_mqtt/packet/packet_traits.hpp>
@@ -16,7 +20,6 @@
 BOOST_AUTO_TEST_SUITE(ut_packet)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 
 BOOST_AUTO_TEST_CASE(v5_connack) {
     BOOST_TEST(am::is_connack<am::v5::connack_packet>());
@@ -51,7 +54,7 @@ BOOST_AUTO_TEST_CASE(v5_connack) {
         auto [b, e] = am::make_packet_range(cbs);
         BOOST_TEST(std::equal(b, e, std::begin(expected)));
 
-        auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+        am::buffer buf{std::begin(expected), std::end(expected)};
         auto p = am::v5::connack_packet{buf};
         BOOST_TEST(p.session_present());
         BOOST_TEST(p.code() == am::connect_reason_code::not_authorized);

--- a/test/unit/ut_packet_v5_connect.cpp
+++ b/test/unit/ut_packet_v5_connect.cpp
@@ -9,6 +9,10 @@
 
 #include <boost/lexical_cast.hpp>
 
+BOOST_AUTO_TEST_SUITE(ut_packet)
+struct v5_connect;
+BOOST_AUTO_TEST_SUITE_END()
+
 #include <async_mqtt/packet/v5_connect.hpp>
 #include <async_mqtt/packet/packet_iterator.hpp>
 #include <async_mqtt/packet/packet_traits.hpp>
@@ -16,7 +20,6 @@
 BOOST_AUTO_TEST_SUITE(ut_packet)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 
 BOOST_AUTO_TEST_CASE(v5_connect) {
     BOOST_TEST(am::is_connect<am::v5::connect_packet>());
@@ -26,8 +29,8 @@ BOOST_AUTO_TEST_CASE(v5_connect) {
     BOOST_TEST(!am::is_server_sendable<am::v5::connect_packet>());
 
     auto w = am::will{
-        "topic1"_mb,
-        "payload1"_mb,
+        "topic1",
+        "payload1",
         am::pub::retain::yes | am::qos::at_least_once,
         am::properties{
             am::property::will_delay_interval(0x0fffffff),
@@ -43,10 +46,10 @@ BOOST_AUTO_TEST_CASE(v5_connect) {
     auto p = am::v5::connect_packet{
         true,   // clean_start
         0x1234, // keep_alive
-        "cid1"_mb,
+        "cid1",
         w,
-        "user1"_mb,
-        "pass1"_mb,
+        "user1",
+        "pass1",
         props
     };
 
@@ -93,7 +96,7 @@ BOOST_AUTO_TEST_CASE(v5_connect) {
         auto [b, e] = am::make_packet_range(cbs);
         BOOST_TEST(std::equal(b, e, std::begin(expected)));
 
-        auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+        am::buffer buf{std::begin(expected), std::end(expected)};
         auto p = am::v5::connect_packet{buf};
         BOOST_TEST(p.clean_start());
         BOOST_TEST(p.keep_alive() == 0x1234);

--- a/test/unit/ut_packet_v5_disconnect.cpp
+++ b/test/unit/ut_packet_v5_disconnect.cpp
@@ -9,6 +9,13 @@
 
 #include <boost/lexical_cast.hpp>
 
+BOOST_AUTO_TEST_SUITE(ut_packet)
+struct v5_disconnect;
+struct v5_disconnect_no_arg;
+struct v5_disconnect_pid_rc;
+struct v5_disconnect_prop_len_last;
+BOOST_AUTO_TEST_SUITE_END()
+
 #include <async_mqtt/packet/v5_disconnect.hpp>
 #include <async_mqtt/packet/packet_iterator.hpp>
 #include <async_mqtt/packet/packet_traits.hpp>
@@ -16,7 +23,6 @@
 BOOST_AUTO_TEST_SUITE(ut_packet)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 
 BOOST_AUTO_TEST_CASE(v5_disconnect) {
     BOOST_TEST(am::is_disconnect<am::v5::disconnect_packet>());
@@ -48,7 +54,7 @@ BOOST_AUTO_TEST_CASE(v5_disconnect) {
         auto [b, e] = am::make_packet_range(cbs);
         BOOST_TEST(std::equal(b, e, std::begin(expected)));
 
-        auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+        am::buffer buf{std::begin(expected), std::end(expected)};
         auto p = am::v5::disconnect_packet{buf};
         BOOST_TEST(p.code() == am::disconnect_reason_code::protocol_error);
         BOOST_TEST(p.props() == props);
@@ -79,7 +85,7 @@ BOOST_AUTO_TEST_CASE(v5_disconnect_no_arg) {
         auto [b, e] = am::make_packet_range(cbs);
         BOOST_TEST(std::equal(b, e, std::begin(expected)));
 
-        auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+        am::buffer buf{std::begin(expected), std::end(expected)};
         auto p = am::v5::disconnect_packet{buf};
         BOOST_TEST(p.code() == am::disconnect_reason_code::normal_disconnection);
         BOOST_TEST(p.props().empty());
@@ -113,7 +119,7 @@ BOOST_AUTO_TEST_CASE(v5_disconnect_pid_rc) {
         auto [b, e] = am::make_packet_range(cbs);
         BOOST_TEST(std::equal(b, e, std::begin(expected)));
 
-        auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+        am::buffer buf{std::begin(expected), std::end(expected)};
         auto p = am::v5::disconnect_packet{buf};
         BOOST_TEST(p.code() == am::disconnect_reason_code::normal_disconnection);
         BOOST_TEST(p.props().empty());
@@ -136,7 +142,7 @@ BOOST_AUTO_TEST_CASE(v5_disconnect_prop_len_last) {
         0x00,                               // reason_code
         0x00,                               // property_length
     };
-    auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+    am::buffer buf{std::begin(expected), std::end(expected)};
     auto p = am::v5::disconnect_packet{buf};
     BOOST_TEST(p.code() == am::disconnect_reason_code::normal_disconnection);
     BOOST_TEST(p.props().empty());

--- a/test/unit/ut_packet_v5_pingreq.cpp
+++ b/test/unit/ut_packet_v5_pingreq.cpp
@@ -9,6 +9,10 @@
 
 #include <boost/lexical_cast.hpp>
 
+BOOST_AUTO_TEST_SUITE(ut_packet)
+struct v5_pingreq;
+BOOST_AUTO_TEST_SUITE_END()
+
 #include <async_mqtt/packet/v5_pingreq.hpp>
 #include <async_mqtt/packet/packet_iterator.hpp>
 #include <async_mqtt/packet/packet_traits.hpp>
@@ -16,7 +20,6 @@
 BOOST_AUTO_TEST_SUITE(ut_packet)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 
 BOOST_AUTO_TEST_CASE(v5_pingreq) {
     BOOST_TEST(am::is_pingreq<am::v5::pingreq_packet>());
@@ -37,7 +40,7 @@ BOOST_AUTO_TEST_CASE(v5_pingreq) {
         auto [b, e] = am::make_packet_range(cbs);
         BOOST_TEST(std::equal(b, e, std::begin(expected)));
 
-        auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+        am::buffer buf{std::begin(expected), std::end(expected)};
         auto p = am::v5::pingreq_packet{buf};
 
         auto cbs2 = p.const_buffer_sequence();

--- a/test/unit/ut_packet_v5_pingresp.cpp
+++ b/test/unit/ut_packet_v5_pingresp.cpp
@@ -9,6 +9,10 @@
 
 #include <boost/lexical_cast.hpp>
 
+BOOST_AUTO_TEST_SUITE(ut_packet)
+struct v5_pingresp;
+BOOST_AUTO_TEST_SUITE_END()
+
 #include <async_mqtt/packet/v5_pingresp.hpp>
 #include <async_mqtt/packet/packet_iterator.hpp>
 #include <async_mqtt/packet/packet_traits.hpp>
@@ -16,7 +20,6 @@
 BOOST_AUTO_TEST_SUITE(ut_packet)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 
 BOOST_AUTO_TEST_CASE(v5_pingresp) {
     BOOST_TEST(am::is_pingresp<am::v5::pingresp_packet>());
@@ -37,7 +40,7 @@ BOOST_AUTO_TEST_CASE(v5_pingresp) {
         auto [b, e] = am::make_packet_range(cbs);
         BOOST_TEST(std::equal(b, e, std::begin(expected)));
 
-        auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+        am::buffer buf{std::begin(expected), std::end(expected)};
         auto p = am::v5::pingresp_packet{buf};
 
         auto cbs2 = p.const_buffer_sequence();

--- a/test/unit/ut_packet_v5_puback.cpp
+++ b/test/unit/ut_packet_v5_puback.cpp
@@ -9,6 +9,14 @@
 
 #include <boost/lexical_cast.hpp>
 
+BOOST_AUTO_TEST_SUITE(ut_packet)
+struct v5_puback;
+struct v5_puback_pid4;
+struct v5_puback_pid_only;
+struct v5_puback_pid_rc;
+struct v5_puback_prop_len_last;
+BOOST_AUTO_TEST_SUITE_END()
+
 #include <async_mqtt/packet/v5_puback.hpp>
 #include <async_mqtt/packet/packet_iterator.hpp>
 #include <async_mqtt/packet/packet_traits.hpp>
@@ -16,7 +24,6 @@
 BOOST_AUTO_TEST_SUITE(ut_packet)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 
 BOOST_AUTO_TEST_CASE(v5_puback) {
     BOOST_TEST(am::is_puback<am::v5::puback_packet>());
@@ -51,7 +58,7 @@ BOOST_AUTO_TEST_CASE(v5_puback) {
         auto [b, e] = am::make_packet_range(cbs);
         BOOST_TEST(std::equal(b, e, std::begin(expected)));
 
-        auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+        am::buffer buf{std::begin(expected), std::end(expected)};
         auto p = am::v5::puback_packet{buf};
         BOOST_TEST(p.packet_id() == 0x1234);
         BOOST_TEST(p.code() == am::puback_reason_code::packet_identifier_in_use);
@@ -97,7 +104,7 @@ BOOST_AUTO_TEST_CASE(v5_puback_pid4) {
         auto [b, e] = am::make_packet_range(cbs);
         BOOST_TEST(std::equal(b, e, std::begin(expected)));
 
-        auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+        am::buffer buf{std::begin(expected), std::end(expected)};
         auto p = am::v5::basic_puback_packet<4>{buf};
         BOOST_TEST(p.packet_id() == 0x12345678);
         BOOST_TEST(p.code() == am::puback_reason_code::packet_identifier_in_use);
@@ -133,7 +140,7 @@ BOOST_AUTO_TEST_CASE(v5_puback_pid_only) {
         auto [b, e] = am::make_packet_range(cbs);
         BOOST_TEST(std::equal(b, e, std::begin(expected)));
 
-        auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+        am::buffer buf{std::begin(expected), std::end(expected)};
         auto p = am::v5::puback_packet{buf};
         BOOST_TEST(p.packet_id() == 0x1234);
         BOOST_TEST(p.code() == am::puback_reason_code::success);
@@ -171,7 +178,7 @@ BOOST_AUTO_TEST_CASE(v5_puback_pid_rc) {
         auto [b, e] = am::make_packet_range(cbs);
         BOOST_TEST(std::equal(b, e, std::begin(expected)));
 
-        auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+        am::buffer buf{std::begin(expected), std::end(expected)};
         auto p = am::v5::puback_packet{buf};
         BOOST_TEST(p.packet_id() == 0x1234);
         BOOST_TEST(p.code() == am::puback_reason_code::success);
@@ -196,7 +203,7 @@ BOOST_AUTO_TEST_CASE(v5_puback_prop_len_last) {
         0x00,                               // reason_code
         0x00,                               // property_length
     };
-    auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+    am::buffer buf{std::begin(expected), std::end(expected)};
     auto p = am::v5::puback_packet{buf};
     BOOST_TEST(p.packet_id() == 0x1234);
     BOOST_TEST(p.code() == am::puback_reason_code::success);

--- a/test/unit/ut_packet_v5_pubcomp.cpp
+++ b/test/unit/ut_packet_v5_pubcomp.cpp
@@ -9,6 +9,14 @@
 
 #include <boost/lexical_cast.hpp>
 
+BOOST_AUTO_TEST_SUITE(ut_packet)
+struct v5_pubcomp;
+struct v5_pubcomp_pid4;
+struct v5_pubcomp_pid_only;
+struct v5_pubcomp_pid_rc;
+struct v5_pubcomp_prop_len_last;
+BOOST_AUTO_TEST_SUITE_END()
+
 #include <async_mqtt/packet/v5_pubcomp.hpp>
 #include <async_mqtt/packet/packet_iterator.hpp>
 #include <async_mqtt/packet/packet_traits.hpp>
@@ -16,7 +24,6 @@
 BOOST_AUTO_TEST_SUITE(ut_packet)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 
 BOOST_AUTO_TEST_CASE(v5_pubcomp) {
     BOOST_TEST(am::is_pubcomp<am::v5::pubcomp_packet>());
@@ -52,7 +59,7 @@ BOOST_AUTO_TEST_CASE(v5_pubcomp) {
         auto [b, e] = am::make_packet_range(cbs);
         BOOST_TEST(std::equal(b, e, std::begin(expected)));
 
-        auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+        am::buffer buf{std::begin(expected), std::end(expected)};
         auto p = am::v5::pubcomp_packet{buf};
         BOOST_TEST(p.packet_id() == 0x1234);
         BOOST_TEST(p.code() == am::pubcomp_reason_code::packet_identifier_not_found);
@@ -98,7 +105,7 @@ BOOST_AUTO_TEST_CASE(v5_pubcomp_pid4) {
         auto [b, e] = am::make_packet_range(cbs);
         BOOST_TEST(std::equal(b, e, std::begin(expected)));
 
-        auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+        am::buffer buf{std::begin(expected), std::end(expected)};
         auto p = am::v5::basic_pubcomp_packet<4>{buf};
         BOOST_TEST(p.packet_id() == 0x12345678);
         BOOST_TEST(p.code() == am::pubcomp_reason_code::packet_identifier_not_found);
@@ -134,7 +141,7 @@ BOOST_AUTO_TEST_CASE(v5_pubcomp_pid_only) {
         auto [b, e] = am::make_packet_range(cbs);
         BOOST_TEST(std::equal(b, e, std::begin(expected)));
 
-        auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+        am::buffer buf{std::begin(expected), std::end(expected)};
         auto p = am::v5::pubcomp_packet{buf};
         BOOST_TEST(p.packet_id() == 0x1234);
         BOOST_TEST(p.code() == am::pubcomp_reason_code::success);
@@ -172,7 +179,7 @@ BOOST_AUTO_TEST_CASE(v5_pubcomp_pid_rc) {
         auto [b, e] = am::make_packet_range(cbs);
         BOOST_TEST(std::equal(b, e, std::begin(expected)));
 
-        auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+        am::buffer buf{std::begin(expected), std::end(expected)};
         auto p = am::v5::pubcomp_packet{buf};
         BOOST_TEST(p.packet_id() == 0x1234);
         BOOST_TEST(p.code() == am::pubcomp_reason_code::success);
@@ -197,7 +204,7 @@ BOOST_AUTO_TEST_CASE(v5_pubcomp_prop_len_last) {
         0x00,                               // reason_code
         0x00,                               // property_length
     };
-    auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+    am::buffer buf{std::begin(expected), std::end(expected)};
     auto p = am::v5::pubcomp_packet{buf};
     BOOST_TEST(p.packet_id() == 0x1234);
     BOOST_TEST(p.code() == am::pubcomp_reason_code::success);

--- a/test/unit/ut_packet_v5_pubrec.cpp
+++ b/test/unit/ut_packet_v5_pubrec.cpp
@@ -9,6 +9,14 @@
 
 #include <boost/lexical_cast.hpp>
 
+BOOST_AUTO_TEST_SUITE(ut_packet)
+struct v5_pubrec;
+struct v5_pubrec_pid4;
+struct v5_pubrec_pid_only;
+struct v5_pubrec_pid_rc;
+struct v5_pubrec_prop_len_last;
+BOOST_AUTO_TEST_SUITE_END()
+
 #include <async_mqtt/packet/v5_pubrec.hpp>
 #include <async_mqtt/packet/packet_iterator.hpp>
 #include <async_mqtt/packet/packet_traits.hpp>
@@ -16,7 +24,6 @@
 BOOST_AUTO_TEST_SUITE(ut_packet)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 
 BOOST_AUTO_TEST_CASE(v5_pubrec) {
     BOOST_TEST(am::is_pubrec<am::v5::pubrec_packet>());
@@ -52,7 +59,7 @@ BOOST_AUTO_TEST_CASE(v5_pubrec) {
         auto [b, e] = am::make_packet_range(cbs);
         BOOST_TEST(std::equal(b, e, std::begin(expected)));
 
-        auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+        am::buffer buf{std::begin(expected), std::end(expected)};
         auto p = am::v5::pubrec_packet{buf};
         BOOST_TEST(p.packet_id() == 0x1234);
         BOOST_TEST(p.code() == am::pubrec_reason_code::packet_identifier_in_use);
@@ -98,7 +105,7 @@ BOOST_AUTO_TEST_CASE(v5_pubrec_pid4) {
         auto [b, e] = am::make_packet_range(cbs);
         BOOST_TEST(std::equal(b, e, std::begin(expected)));
 
-        auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+        am::buffer buf{std::begin(expected), std::end(expected)};
         auto p = am::v5::basic_pubrec_packet<4>{buf};
         BOOST_TEST(p.packet_id() == 0x12345678);
         BOOST_TEST(p.code() == am::pubrec_reason_code::packet_identifier_in_use);
@@ -134,7 +141,7 @@ BOOST_AUTO_TEST_CASE(v5_pubrec_pid_only) {
         auto [b, e] = am::make_packet_range(cbs);
         BOOST_TEST(std::equal(b, e, std::begin(expected)));
 
-        auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+        am::buffer buf{std::begin(expected), std::end(expected)};
         auto p = am::v5::pubrec_packet{buf};
         BOOST_TEST(p.packet_id() == 0x1234);
         BOOST_TEST(p.code() == am::pubrec_reason_code::success);
@@ -172,7 +179,7 @@ BOOST_AUTO_TEST_CASE(v5_pubrec_pid_rc) {
         auto [b, e] = am::make_packet_range(cbs);
         BOOST_TEST(std::equal(b, e, std::begin(expected)));
 
-        auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+        am::buffer buf{std::begin(expected), std::end(expected)};
         auto p = am::v5::pubrec_packet{buf};
         BOOST_TEST(p.packet_id() == 0x1234);
         BOOST_TEST(p.code() == am::pubrec_reason_code::success);
@@ -197,7 +204,7 @@ BOOST_AUTO_TEST_CASE(v5_pubrec_prop_len_last) {
         0x00,                               // reason_code
         0x00,                               // property_length
     };
-    auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+    am::buffer buf{std::begin(expected), std::end(expected)};
     auto p = am::v5::pubrec_packet{buf};
     BOOST_TEST(p.packet_id() == 0x1234);
     BOOST_TEST(p.code() == am::pubrec_reason_code::success);

--- a/test/unit/ut_packet_v5_pubrel.cpp
+++ b/test/unit/ut_packet_v5_pubrel.cpp
@@ -9,6 +9,14 @@
 
 #include <boost/lexical_cast.hpp>
 
+BOOST_AUTO_TEST_SUITE(ut_packet)
+struct v5_pubrel;
+struct v5_pubrel_pid4;
+struct v5_pubrel_pid_only;
+struct v5_pubrel_pid_rc;
+struct v5_pubrel_prop_len_last;
+BOOST_AUTO_TEST_SUITE_END()
+
 #include <async_mqtt/packet/v5_pubrel.hpp>
 #include <async_mqtt/packet/packet_iterator.hpp>
 #include <async_mqtt/packet/packet_traits.hpp>
@@ -16,7 +24,6 @@
 BOOST_AUTO_TEST_SUITE(ut_packet)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 
 BOOST_AUTO_TEST_CASE(v5_pubrel) {
     BOOST_TEST(am::is_pubrel<am::v5::pubrel_packet>());
@@ -52,7 +59,7 @@ BOOST_AUTO_TEST_CASE(v5_pubrel) {
         auto [b, e] = am::make_packet_range(cbs);
         BOOST_TEST(std::equal(b, e, std::begin(expected)));
 
-        auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+        am::buffer buf{std::begin(expected), std::end(expected)};
         auto p = am::v5::pubrel_packet{buf};
         BOOST_TEST(p.packet_id() == 0x1234);
         BOOST_TEST(p.code() == am::pubrel_reason_code::packet_identifier_not_found);
@@ -98,7 +105,7 @@ BOOST_AUTO_TEST_CASE(v5_pubrel_pid4) {
         auto [b, e] = am::make_packet_range(cbs);
         BOOST_TEST(std::equal(b, e, std::begin(expected)));
 
-        auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+        am::buffer buf{std::begin(expected), std::end(expected)};
         auto p = am::v5::basic_pubrel_packet<4>{buf};
         BOOST_TEST(p.packet_id() == 0x12345678);
         BOOST_TEST(p.code() == am::pubrel_reason_code::packet_identifier_not_found);
@@ -134,7 +141,7 @@ BOOST_AUTO_TEST_CASE(v5_pubrel_pid_only) {
         auto [b, e] = am::make_packet_range(cbs);
         BOOST_TEST(std::equal(b, e, std::begin(expected)));
 
-        auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+        am::buffer buf{std::begin(expected), std::end(expected)};
         auto p = am::v5::pubrel_packet{buf};
         BOOST_TEST(p.packet_id() == 0x1234);
         BOOST_TEST(p.code() == am::pubrel_reason_code::success);
@@ -172,7 +179,7 @@ BOOST_AUTO_TEST_CASE(v5_pubrel_pid_rc) {
         auto [b, e] = am::make_packet_range(cbs);
         BOOST_TEST(std::equal(b, e, std::begin(expected)));
 
-        auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+        am::buffer buf{std::begin(expected), std::end(expected)};
         auto p = am::v5::pubrel_packet{buf};
         BOOST_TEST(p.packet_id() == 0x1234);
         BOOST_TEST(p.code() == am::pubrel_reason_code::success);
@@ -197,7 +204,7 @@ BOOST_AUTO_TEST_CASE(v5_pubrel_prop_len_last) {
         0x00,                               // reason_code
         0x00,                               // property_length
     };
-    auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+    am::buffer buf{std::begin(expected), std::end(expected)};
     auto p = am::v5::pubrel_packet{buf};
     BOOST_TEST(p.packet_id() == 0x1234);
     BOOST_TEST(p.code() == am::pubrel_reason_code::success);

--- a/test/unit/ut_packet_v5_suback.cpp
+++ b/test/unit/ut_packet_v5_suback.cpp
@@ -9,6 +9,11 @@
 
 #include <boost/lexical_cast.hpp>
 
+BOOST_AUTO_TEST_SUITE(ut_packet)
+struct v5_suback;
+struct v5_suback_pid4;
+BOOST_AUTO_TEST_SUITE_END()
+
 #include <async_mqtt/packet/v5_suback.hpp>
 #include <async_mqtt/packet/packet_iterator.hpp>
 #include <async_mqtt/packet/packet_traits.hpp>
@@ -16,7 +21,6 @@
 BOOST_AUTO_TEST_SUITE(ut_packet)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 
 BOOST_AUTO_TEST_CASE(v5_suback) {
     BOOST_TEST(am::is_suback<am::v5::suback_packet>());
@@ -56,7 +60,7 @@ BOOST_AUTO_TEST_CASE(v5_suback) {
         auto [b, e] = am::make_packet_range(cbs);
         BOOST_TEST(std::equal(b, e, std::begin(expected)));
 
-        auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+        am::buffer buf{std::begin(expected), std::end(expected)};
         auto p = am::v5::suback_packet{buf};
         BOOST_TEST(p.packet_id() == 0x1234);
         BOOST_TEST((p.entries() == args));
@@ -104,7 +108,7 @@ BOOST_AUTO_TEST_CASE(v5_suback_pid4) {
         auto [b, e] = am::make_packet_range(cbs);
         BOOST_TEST(std::equal(b, e, std::begin(expected)));
 
-        auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+        am::buffer buf{std::begin(expected), std::end(expected)};
         auto p = am::v5::basic_suback_packet<4>{buf};
         BOOST_TEST(p.packet_id() == 0x12345678);
         BOOST_TEST((p.entries() == args));

--- a/test/unit/ut_packet_v5_subscribe.cpp
+++ b/test/unit/ut_packet_v5_subscribe.cpp
@@ -9,6 +9,11 @@
 
 #include <boost/lexical_cast.hpp>
 
+BOOST_AUTO_TEST_SUITE(ut_packet)
+struct v5_subscribe;
+struct v5_subscribe_pid4;
+BOOST_AUTO_TEST_SUITE_END()
+
 #include <async_mqtt/packet/v5_subscribe.hpp>
 #include <async_mqtt/packet/packet_iterator.hpp>
 #include <async_mqtt/packet/packet_traits.hpp>
@@ -16,7 +21,6 @@
 BOOST_AUTO_TEST_SUITE(ut_packet)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 
 BOOST_AUTO_TEST_CASE(v5_subscribe) {
     BOOST_TEST(am::is_subscribe<am::v5::subscribe_packet>());
@@ -26,8 +30,8 @@ BOOST_AUTO_TEST_CASE(v5_subscribe) {
     BOOST_TEST(!am::is_server_sendable<am::v5::subscribe_packet>());
 
     std::vector<am::topic_subopts> args {
-        {"topic1"_mb, am::qos::at_most_once | am::sub::nl::yes | am::sub::retain_handling::not_send},
-        {"topic2"_mb, am::qos::exactly_once | am::sub::rap::retain},
+        {"topic1", am::qos::at_most_once | am::sub::nl::yes | am::sub::retain_handling::not_send},
+        {"topic2", am::qos::exactly_once | am::sub::rap::retain},
     };
 
     auto props = am::properties{
@@ -59,7 +63,7 @@ BOOST_AUTO_TEST_CASE(v5_subscribe) {
         auto [b, e] = am::make_packet_range(cbs);
         BOOST_TEST(std::equal(b, e, std::begin(expected)));
 
-        auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+        am::buffer buf{std::begin(expected), std::end(expected)};
         auto p = am::v5::subscribe_packet{buf};
         BOOST_TEST(p.packet_id() == 0x1234);
         BOOST_TEST((p.entries() == args));
@@ -78,8 +82,8 @@ BOOST_AUTO_TEST_CASE(v5_subscribe) {
 
 BOOST_AUTO_TEST_CASE(v5_subscribe_pid4) {
     std::vector<am::topic_subopts> args {
-        {"topic1"_mb, am::qos::at_most_once | am::sub::nl::yes | am::sub::retain_handling::not_send},
-        {"topic2"_mb, am::qos::exactly_once | am::sub::rap::retain},
+        {"topic1", am::qos::at_most_once | am::sub::nl::yes | am::sub::retain_handling::not_send},
+        {"topic2", am::qos::exactly_once | am::sub::rap::retain},
     };
 
     auto props = am::properties{
@@ -110,7 +114,7 @@ BOOST_AUTO_TEST_CASE(v5_subscribe_pid4) {
         auto [b, e] = am::make_packet_range(cbs);
         BOOST_TEST(std::equal(b, e, std::begin(expected)));
 
-        auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+        am::buffer buf{std::begin(expected), std::end(expected)};
         auto p = am::v5::basic_subscribe_packet<4>{buf};
         BOOST_TEST(p.packet_id() == 0x12345678);
         BOOST_TEST((p.entries() == args));

--- a/test/unit/ut_packet_v5_unsuback.cpp
+++ b/test/unit/ut_packet_v5_unsuback.cpp
@@ -9,6 +9,11 @@
 
 #include <boost/lexical_cast.hpp>
 
+BOOST_AUTO_TEST_SUITE(ut_packet)
+struct v5_unsuback;
+struct v5_unsuback_pid4;
+BOOST_AUTO_TEST_SUITE_END()
+
 #include <async_mqtt/packet/v5_unsuback.hpp>
 #include <async_mqtt/packet/packet_iterator.hpp>
 #include <async_mqtt/packet/packet_traits.hpp>
@@ -16,7 +21,6 @@
 BOOST_AUTO_TEST_SUITE(ut_packet)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 
 BOOST_AUTO_TEST_CASE(v5_unsuback) {
     BOOST_TEST(am::is_unsuback<am::v5::unsuback_packet>());
@@ -56,7 +60,7 @@ BOOST_AUTO_TEST_CASE(v5_unsuback) {
         auto [b, e] = am::make_packet_range(cbs);
         BOOST_TEST(std::equal(b, e, std::begin(expected)));
 
-        auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+        am::buffer buf{std::begin(expected), std::end(expected)};
         auto p = am::v5::unsuback_packet{buf};
         BOOST_TEST(p.packet_id() == 0x1234);
         BOOST_TEST((p.entries() == args));
@@ -104,7 +108,7 @@ BOOST_AUTO_TEST_CASE(v5_unsuback_pid4) {
         auto [b, e] = am::make_packet_range(cbs);
         BOOST_TEST(std::equal(b, e, std::begin(expected)));
 
-        auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+        am::buffer buf{std::begin(expected), std::end(expected)};
         auto p = am::v5::basic_unsuback_packet<4>{buf};
         BOOST_TEST(p.packet_id() == 0x12345678);
         BOOST_TEST((p.entries() == args));

--- a/test/unit/ut_packet_v5_unsubscribe.cpp
+++ b/test/unit/ut_packet_v5_unsubscribe.cpp
@@ -9,6 +9,11 @@
 
 #include <boost/lexical_cast.hpp>
 
+BOOST_AUTO_TEST_SUITE(ut_packet)
+struct v5_unsubscribe;
+struct v5_unsubscribe_pid4;
+BOOST_AUTO_TEST_SUITE_END()
+
 #include <async_mqtt/packet/v5_unsubscribe.hpp>
 #include <async_mqtt/packet/packet_iterator.hpp>
 #include <async_mqtt/packet/packet_traits.hpp>
@@ -16,7 +21,6 @@
 BOOST_AUTO_TEST_SUITE(ut_packet)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 
 BOOST_AUTO_TEST_CASE(v5_unsubscribe) {
     BOOST_TEST(am::is_unsubscribe<am::v5::unsubscribe_packet>());
@@ -26,8 +30,8 @@ BOOST_AUTO_TEST_CASE(v5_unsubscribe) {
     BOOST_TEST(!am::is_server_sendable<am::v5::unsubscribe_packet>());
 
     std::vector<am::topic_sharename> args {
-        "topic1"_mb,
-        "topic2"_mb,
+        "topic1",
+        "topic2",
     };
 
     auto props = am::properties{
@@ -59,7 +63,7 @@ BOOST_AUTO_TEST_CASE(v5_unsubscribe) {
         auto [b, e] = am::make_packet_range(cbs);
         BOOST_TEST(std::equal(b, e, std::begin(expected)));
 
-        auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+        am::buffer buf{std::begin(expected), std::end(expected)};
         auto p = am::v5::unsubscribe_packet{buf};
         BOOST_TEST(p.packet_id() == 0x1234);
         BOOST_TEST((p.entries() == args));
@@ -78,8 +82,8 @@ BOOST_AUTO_TEST_CASE(v5_unsubscribe) {
 
 BOOST_AUTO_TEST_CASE(v5_unsubscribe_pid4) {
     std::vector<am::topic_sharename> args {
-        "topic1"_mb,
-        "topic2"_mb,
+        "topic1",
+        "topic2",
     };
 
     auto props = am::properties{
@@ -110,7 +114,7 @@ BOOST_AUTO_TEST_CASE(v5_unsubscribe_pid4) {
         auto [b, e] = am::make_packet_range(cbs);
         BOOST_TEST(std::equal(b, e, std::begin(expected)));
 
-        auto buf = am::allocate_buffer(std::begin(expected), std::end(expected));
+        am::buffer buf{std::begin(expected), std::end(expected)};
         auto p = am::v5::basic_unsubscribe_packet<4>{buf};
         BOOST_TEST(p.packet_id() == 0x12345678);
         BOOST_TEST((p.entries() == args));

--- a/test/unit/ut_prop_variant.cpp
+++ b/test/unit/ut_prop_variant.cpp
@@ -16,7 +16,6 @@
 BOOST_AUTO_TEST_SUITE(ut_prop_variant)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 
 BOOST_AUTO_TEST_CASE(payload_format_indicator) {
     am::property_variant pv1{
@@ -28,7 +27,7 @@ BOOST_AUTO_TEST_CASE(payload_format_indicator) {
         boost::lexical_cast<std::string>(pv1) ==
         "{id:payload_format_indicator,val:binary}"
     );
-    auto buf{am::allocate_buffer(am::to_string(pv1.const_buffer_sequence()))};
+    am::buffer buf{am::to_string(pv1.const_buffer_sequence())};
     auto wbuf{buf};
     auto pv2 = am::make_property_variant(wbuf, am::property_location::publish);
     BOOST_TEST(pv1 == pv2);
@@ -130,7 +129,7 @@ BOOST_AUTO_TEST_CASE(message_expiry_interval) {
         boost::lexical_cast<std::string>(pv1) ==
         "{id:message_expiry_interval,val:4294967295}"
     );
-    auto buf{am::allocate_buffer(am::to_string(pv1.const_buffer_sequence()))};
+    am::buffer buf{am::to_string(pv1.const_buffer_sequence())};
     auto wbuf{buf};
     auto pv2 = am::make_property_variant(wbuf, am::property_location::publish);
     BOOST_TEST(pv1 == pv2);
@@ -226,13 +225,13 @@ BOOST_AUTO_TEST_CASE(message_expiry_interval) {
 
 BOOST_AUTO_TEST_CASE(content_type) {
     am::property_variant pv1{
-        am::property::content_type{"html"_mb}
+        am::property::content_type{"html"}
     };
     BOOST_TEST(
         boost::lexical_cast<std::string>(pv1) ==
         "{id:content_type,val:html}"
     );
-    auto buf{am::allocate_buffer(am::to_string(pv1.const_buffer_sequence()))};
+    am::buffer buf{am::to_string(pv1.const_buffer_sequence())};
     auto wbuf{buf};
     auto pv2 = am::make_property_variant(wbuf, am::property_location::publish);
     BOOST_TEST(pv1 == pv2);
@@ -328,13 +327,13 @@ BOOST_AUTO_TEST_CASE(content_type) {
 
 BOOST_AUTO_TEST_CASE(response_topic) {
     am::property_variant pv1{
-        am::property::response_topic{"restopic1"_mb}
+        am::property::response_topic{"restopic1"}
     };
     BOOST_TEST(
         boost::lexical_cast<std::string>(pv1) ==
         "{id:response_topic,val:restopic1}"
     );
-    auto buf{am::allocate_buffer(am::to_string(pv1.const_buffer_sequence()))};
+    am::buffer buf{am::to_string(pv1.const_buffer_sequence())};
     auto wbuf{buf};
     auto pv2 = am::make_property_variant(wbuf, am::property_location::publish);
     BOOST_TEST(pv1 == pv2);
@@ -430,13 +429,13 @@ BOOST_AUTO_TEST_CASE(response_topic) {
 
 BOOST_AUTO_TEST_CASE(correlation_data) {
     am::property_variant pv1{
-        am::property::correlation_data{"reqid1"_mb}
+        am::property::correlation_data{"reqid1"}
     };
     BOOST_TEST(
         boost::lexical_cast<std::string>(pv1) ==
         "{id:correlation_data,val:reqid1}"
     );
-    auto buf{am::allocate_buffer(am::to_string(pv1.const_buffer_sequence()))};
+    am::buffer buf{am::to_string(pv1.const_buffer_sequence())};
     auto wbuf{buf};
     auto pv2 = am::make_property_variant(wbuf, am::property_location::publish);
     BOOST_TEST(pv1 == pv2);
@@ -538,7 +537,7 @@ BOOST_AUTO_TEST_CASE(subscription_identifier) {
         boost::lexical_cast<std::string>(pv1) ==
         "{id:subscription_identifier,val:268435455}"
     );
-    auto buf{am::allocate_buffer(am::to_string(pv1.const_buffer_sequence()))};
+    am::buffer buf{am::to_string(pv1.const_buffer_sequence())};
     auto wbuf{buf};
     auto pv2 = am::make_property_variant(wbuf, am::property_location::publish);
     BOOST_TEST(pv1 == pv2);
@@ -640,7 +639,7 @@ BOOST_AUTO_TEST_CASE(session_expiry_interval) {
         boost::lexical_cast<std::string>(pv1) ==
         "{id:session_expiry_interval,val:4294967295}"
     );
-    auto buf{am::allocate_buffer(am::to_string(pv1.const_buffer_sequence()))};
+    am::buffer buf{am::to_string(pv1.const_buffer_sequence())};
     auto wbuf{buf};
     auto pv2 = am::make_property_variant(wbuf, am::property_location::connect);
     BOOST_TEST(pv1 == pv2);
@@ -736,13 +735,13 @@ BOOST_AUTO_TEST_CASE(session_expiry_interval) {
 
 BOOST_AUTO_TEST_CASE(assigned_client_identifier) {
     am::property_variant pv1{
-        am::property::assigned_client_identifier{"cid1"_mb}
+        am::property::assigned_client_identifier{"cid1"}
     };
     BOOST_TEST(
         boost::lexical_cast<std::string>(pv1) ==
         "{id:assigned_client_identifier,val:cid1}"
     );
-    auto buf{am::allocate_buffer(am::to_string(pv1.const_buffer_sequence()))};
+    am::buffer buf{am::to_string(pv1.const_buffer_sequence())};
     auto wbuf{buf};
     auto pv2 = am::make_property_variant(wbuf, am::property_location::connack);
     BOOST_TEST(pv1 == pv2);
@@ -844,7 +843,7 @@ BOOST_AUTO_TEST_CASE(server_keep_alive) {
         boost::lexical_cast<std::string>(pv1) ==
         "{id:server_keep_alive,val:65535}"
     );
-    auto buf{am::allocate_buffer(am::to_string(pv1.const_buffer_sequence()))};
+    am::buffer buf{am::to_string(pv1.const_buffer_sequence())};
     auto wbuf{buf};
     auto pv2 = am::make_property_variant(wbuf, am::property_location::connack);
     BOOST_TEST(pv1 == pv2);
@@ -940,13 +939,13 @@ BOOST_AUTO_TEST_CASE(server_keep_alive) {
 
 BOOST_AUTO_TEST_CASE(authentication_method) {
     am::property_variant pv1{
-        am::property::authentication_method{"basic"_mb}
+        am::property::authentication_method{"basic"}
     };
     BOOST_TEST(
         boost::lexical_cast<std::string>(pv1) ==
         "{id:authentication_method,val:basic}"
     );
-    auto buf{am::allocate_buffer(am::to_string(pv1.const_buffer_sequence()))};
+    am::buffer buf{am::to_string(pv1.const_buffer_sequence())};
     auto wbuf{buf};
     auto pv2 = am::make_property_variant(wbuf, am::property_location::connect);
     BOOST_TEST(pv1 == pv2);
@@ -1042,13 +1041,13 @@ BOOST_AUTO_TEST_CASE(authentication_method) {
 
 BOOST_AUTO_TEST_CASE(authentication_data) {
     am::property_variant pv1{
-        am::property::authentication_data{"data1"_mb}
+        am::property::authentication_data{"data1"}
     };
     BOOST_TEST(
         boost::lexical_cast<std::string>(pv1) ==
         "{id:authentication_data,val:data1}"
     );
-    auto buf{am::allocate_buffer(am::to_string(pv1.const_buffer_sequence()))};
+    am::buffer buf{am::to_string(pv1.const_buffer_sequence())};
     auto wbuf{buf};
     auto pv2 = am::make_property_variant(wbuf, am::property_location::connect);
     BOOST_TEST(pv1 == pv2);
@@ -1150,7 +1149,7 @@ BOOST_AUTO_TEST_CASE(request_problem_information) {
         boost::lexical_cast<std::string>(pv1) ==
         "{id:request_problem_information,val:1}"
     );
-    auto buf{am::allocate_buffer(am::to_string(pv1.const_buffer_sequence()))};
+    am::buffer buf{am::to_string(pv1.const_buffer_sequence())};
     auto wbuf{buf};
     auto pv2 = am::make_property_variant(wbuf, am::property_location::connect);
     BOOST_TEST(pv1 == pv2);
@@ -1252,7 +1251,7 @@ BOOST_AUTO_TEST_CASE(will_delay_interval) {
         boost::lexical_cast<std::string>(pv1) ==
         "{id:will_delay_interval,val:4294967295}"
     );
-    auto buf{am::allocate_buffer(am::to_string(pv1.const_buffer_sequence()))};
+    am::buffer buf{am::to_string(pv1.const_buffer_sequence())};
     auto wbuf{buf};
     auto pv2 = am::make_property_variant(wbuf, am::property_location::will);
     BOOST_TEST(pv1 == pv2);
@@ -1354,7 +1353,7 @@ BOOST_AUTO_TEST_CASE(request_response_information) {
         boost::lexical_cast<std::string>(pv1) ==
         "{id:request_response_information,val:1}"
     );
-    auto buf{am::allocate_buffer(am::to_string(pv1.const_buffer_sequence()))};
+    am::buffer buf{am::to_string(pv1.const_buffer_sequence())};
     auto wbuf{buf};
     auto pv2 = am::make_property_variant(wbuf, am::property_location::connect);
     BOOST_TEST(pv1 == pv2);
@@ -1450,13 +1449,13 @@ BOOST_AUTO_TEST_CASE(request_response_information) {
 
 BOOST_AUTO_TEST_CASE(response_information) {
     am::property_variant pv1{
-        am::property::response_information{"restopic1"_mb}
+        am::property::response_information{"restopic1"}
     };
     BOOST_TEST(
         boost::lexical_cast<std::string>(pv1) ==
         "{id:response_information,val:restopic1}"
     );
-    auto buf{am::allocate_buffer(am::to_string(pv1.const_buffer_sequence()))};
+    am::buffer buf{am::to_string(pv1.const_buffer_sequence())};
     auto wbuf{buf};
     auto pv2 = am::make_property_variant(wbuf, am::property_location::connack);
     BOOST_TEST(pv1 == pv2);
@@ -1552,13 +1551,13 @@ BOOST_AUTO_TEST_CASE(response_information) {
 
 BOOST_AUTO_TEST_CASE(server_reference) {
     am::property_variant pv1{
-        am::property::server_reference{"server1"_mb}
+        am::property::server_reference{"server1"}
     };
     BOOST_TEST(
         boost::lexical_cast<std::string>(pv1) ==
         "{id:server_reference,val:server1}"
     );
-    auto buf{am::allocate_buffer(am::to_string(pv1.const_buffer_sequence()))};
+    am::buffer buf{am::to_string(pv1.const_buffer_sequence())};
     auto wbuf{buf};
     auto pv2 = am::make_property_variant(wbuf, am::property_location::connack);
     BOOST_TEST(pv1 == pv2);
@@ -1654,13 +1653,13 @@ BOOST_AUTO_TEST_CASE(server_reference) {
 
 BOOST_AUTO_TEST_CASE(reason_string) {
     am::property_variant pv1{
-        am::property::reason_string{"reason1"_mb}
+        am::property::reason_string{"reason1"}
     };
     BOOST_TEST(
         boost::lexical_cast<std::string>(pv1) ==
         "{id:reason_string,val:reason1}"
     );
-    auto buf{am::allocate_buffer(am::to_string(pv1.const_buffer_sequence()))};
+    am::buffer buf{am::to_string(pv1.const_buffer_sequence())};
     auto wbuf{buf};
     auto pv2 = am::make_property_variant(wbuf, am::property_location::connack);
     BOOST_TEST(pv1 == pv2);
@@ -1762,7 +1761,7 @@ BOOST_AUTO_TEST_CASE(receive_maximum) {
         boost::lexical_cast<std::string>(pv1) ==
         "{id:receive_maximum,val:65535}"
     );
-    auto buf{am::allocate_buffer(am::to_string(pv1.const_buffer_sequence()))};
+    am::buffer buf{am::to_string(pv1.const_buffer_sequence())};
     auto wbuf{buf};
     auto pv2 = am::make_property_variant(wbuf, am::property_location::connect);
     BOOST_TEST(pv1 == pv2);
@@ -1864,7 +1863,7 @@ BOOST_AUTO_TEST_CASE(topic_alias_maximum) {
         boost::lexical_cast<std::string>(pv1) ==
         "{id:topic_alias_maximum,val:65535}"
     );
-    auto buf{am::allocate_buffer(am::to_string(pv1.const_buffer_sequence()))};
+    am::buffer buf{am::to_string(pv1.const_buffer_sequence())};
     auto wbuf{buf};
     auto pv2 = am::make_property_variant(wbuf, am::property_location::connect);
     BOOST_TEST(pv1 == pv2);
@@ -1966,7 +1965,7 @@ BOOST_AUTO_TEST_CASE(topic_alias) {
         boost::lexical_cast<std::string>(pv1) ==
         "{id:topic_alias,val:65535}"
     );
-    auto buf{am::allocate_buffer(am::to_string(pv1.const_buffer_sequence()))};
+    am::buffer buf{am::to_string(pv1.const_buffer_sequence())};
     auto wbuf{buf};
     auto pv2 = am::make_property_variant(wbuf, am::property_location::publish);
     BOOST_TEST(pv1 == pv2);
@@ -2068,7 +2067,7 @@ BOOST_AUTO_TEST_CASE(maximum_qos) {
         boost::lexical_cast<std::string>(pv1) ==
         "{id:maximum_qos,val:1}"
     );
-    auto buf{am::allocate_buffer(am::to_string(pv1.const_buffer_sequence()))};
+    am::buffer buf{am::to_string(pv1.const_buffer_sequence())};
     auto wbuf{buf};
     auto pv2 = am::make_property_variant(wbuf, am::property_location::connack);
     BOOST_TEST(pv1 == pv2);
@@ -2170,7 +2169,7 @@ BOOST_AUTO_TEST_CASE(retain_available) {
         boost::lexical_cast<std::string>(pv1) ==
         "{id:retain_available,val:1}"
     );
-    auto buf{am::allocate_buffer(am::to_string(pv1.const_buffer_sequence()))};
+    am::buffer buf{am::to_string(pv1.const_buffer_sequence())};
     auto wbuf{buf};
     auto pv2 = am::make_property_variant(wbuf, am::property_location::connack);
     BOOST_TEST(pv1 == pv2);
@@ -2266,13 +2265,13 @@ BOOST_AUTO_TEST_CASE(retain_available) {
 
 BOOST_AUTO_TEST_CASE(user_property) {
     am::property_variant pv1{
-        am::property::user_property{"key1"_mb, "val1"_mb}
+        am::property::user_property{"key1", "val1"}
     };
     BOOST_TEST(
         boost::lexical_cast<std::string>(pv1) ==
         "{id:user_property,key:key1,val:val1}"
     );
-    auto buf{am::allocate_buffer(am::to_string(pv1.const_buffer_sequence()))};
+    am::buffer buf{am::to_string(pv1.const_buffer_sequence())};
     auto wbuf{buf};
     auto pv2 = am::make_property_variant(wbuf, am::property_location::connack);
     BOOST_TEST(pv1 == pv2);
@@ -2374,7 +2373,7 @@ BOOST_AUTO_TEST_CASE(maximum_packet_size) {
         boost::lexical_cast<std::string>(pv1) ==
         "{id:maximum_packet_size,val:4294967295}"
     );
-    auto buf{am::allocate_buffer(am::to_string(pv1.const_buffer_sequence()))};
+    am::buffer buf{am::to_string(pv1.const_buffer_sequence())};
     auto wbuf{buf};
     auto pv2 = am::make_property_variant(wbuf, am::property_location::connect);
     BOOST_TEST(pv1 == pv2);
@@ -2476,7 +2475,7 @@ BOOST_AUTO_TEST_CASE(wildcard_subscription_available) {
         boost::lexical_cast<std::string>(pv1) ==
         "{id:wildcard_subscription_available,val:1}"
     );
-    auto buf{am::allocate_buffer(am::to_string(pv1.const_buffer_sequence()))};
+    am::buffer buf{am::to_string(pv1.const_buffer_sequence())};
     auto wbuf{buf};
     auto pv2 = am::make_property_variant(wbuf, am::property_location::connack);
     BOOST_TEST(pv1 == pv2);
@@ -2578,7 +2577,7 @@ BOOST_AUTO_TEST_CASE(subscription_identifier_available) {
         boost::lexical_cast<std::string>(pv1) ==
         "{id:subscription_identifier_available,val:1}"
     );
-    auto buf{am::allocate_buffer(am::to_string(pv1.const_buffer_sequence()))};
+    am::buffer buf{am::to_string(pv1.const_buffer_sequence())};
     auto wbuf{buf};
     auto pv2 = am::make_property_variant(wbuf, am::property_location::connack);
     BOOST_TEST(pv1 == pv2);
@@ -2680,7 +2679,7 @@ BOOST_AUTO_TEST_CASE(shared_subscription_available) {
         boost::lexical_cast<std::string>(pv1) ==
         "{id:shared_subscription_available,val:1}"
     );
-    auto buf{am::allocate_buffer(am::to_string(pv1.const_buffer_sequence()))};
+    am::buffer buf{am::to_string(pv1.const_buffer_sequence())};
     auto wbuf{buf};
     auto pv2 = am::make_property_variant(wbuf, am::property_location::connack);
     BOOST_TEST(pv1 == pv2);
@@ -2785,7 +2784,7 @@ BOOST_AUTO_TEST_CASE(props) {
         boost::lexical_cast<std::string>(ps1) ==
         "[{id:payload_format_indicator,val:binary},{id:message_expiry_interval,val:4294967295}]"
     );
-    auto buf{am::allocate_buffer(am::to_string(am::const_buffer_sequence(ps1)))};
+    am::buffer buf{am::to_string(am::const_buffer_sequence(ps1))};
     auto ps2 = am::make_properties(buf, am::property_location::publish);
     BOOST_TEST(ps1 == ps2);
 }

--- a/test/unit/ut_property.cpp
+++ b/test/unit/ut_property.cpp
@@ -17,8 +17,7 @@
 BOOST_AUTO_TEST_SUITE(ut_property)
 
 namespace am = async_mqtt;
-using namespace am::literals;
-using namespace am::literals;
+using namespace std::literals::string_view_literals;
 
 BOOST_AUTO_TEST_CASE( payload_format_indicator ) {
     am::property::payload_format_indicator v1 { am::payload_format::binary };
@@ -127,55 +126,54 @@ BOOST_AUTO_TEST_CASE( shared_subscription_available ) {
 // property has _ref
 
 BOOST_AUTO_TEST_CASE( content_type ) {
-    am::property::content_type v1 { "abc"_mb };
+    am::property::content_type v1 { "abc" };
     BOOST_TEST(boost::lexical_cast<std::string>(v1) == "{id:content_type,val:abc}");
 }
 
 BOOST_AUTO_TEST_CASE( response_topic ) {
-    am::property::response_topic v1 { "abc"_mb };
+    am::property::response_topic v1 { "abc" };
 
     BOOST_TEST(boost::lexical_cast<std::string>(v1) == "{id:response_topic,val:abc}");
 }
 
 BOOST_AUTO_TEST_CASE( correlation_data ) {
-    using namespace std::literals::string_view_literals;
-    am::property::correlation_data v1 { "a\0bc"_mb };
+    am::property::correlation_data v1 { std::string{"a\0bc"sv} };
     BOOST_TEST(boost::lexical_cast<std::string>(v1) == "{id:correlation_data,val:a\\u0000bc}"sv);
     BOOST_TEST(v1.val() == "a\0bc"sv);
 }
 
 BOOST_AUTO_TEST_CASE( assigned_client_identifier ) {
-    am::property::assigned_client_identifier v1 { "abc"_mb };
+    am::property::assigned_client_identifier v1 { "abc" };
     BOOST_TEST(boost::lexical_cast<std::string>(v1) == "{id:assigned_client_identifier,val:abc}");
 }
 
 BOOST_AUTO_TEST_CASE( authentication_method ) {
-    am::property::authentication_method v1 { "abc"_mb };
+    am::property::authentication_method v1 { "abc" };
     BOOST_TEST(boost::lexical_cast<std::string>(v1) == "{id:authentication_method,val:abc}");
 }
 
 BOOST_AUTO_TEST_CASE( authentication_data ) {
-    am::property::authentication_data v1 { "abc"_mb };
+    am::property::authentication_data v1 { "abc" };
     BOOST_TEST(boost::lexical_cast<std::string>(v1) == "{id:authentication_data,val:abc}");
 }
 
 BOOST_AUTO_TEST_CASE( response_information ) {
-    am::property::response_information v1 { "abc"_mb };
+    am::property::response_information v1 { "abc" };
     BOOST_TEST(boost::lexical_cast<std::string>(v1) == "{id:response_information,val:abc}");
 }
 
 BOOST_AUTO_TEST_CASE( server_reference ) {
-    am::property::server_reference v1 { "abc"_mb };
+    am::property::server_reference v1 { "abc" };
     BOOST_TEST(boost::lexical_cast<std::string>(v1) == "{id:server_reference,val:abc}");
 }
 
 BOOST_AUTO_TEST_CASE( reason_string ) {
-    am::property::reason_string v1 { "abc"_mb };
+    am::property::reason_string v1 { "abc" };
     BOOST_TEST(boost::lexical_cast<std::string>(v1) == "{id:reason_string,val:abc}");
 }
 
 BOOST_AUTO_TEST_CASE( user_property ) {
-    am::property::user_property v1 { "abc"_mb, "def"_mb };
+    am::property::user_property v1 { "abc", "def" };
     BOOST_TEST(boost::lexical_cast<std::string>(v1) == "{id:user_property,key:abc,val:def}");
 }
 
@@ -300,79 +298,79 @@ BOOST_AUTO_TEST_CASE(comparison) {
         BOOST_TEST(v1 < v2);
     }
     {
-        am::property::content_type v1 { "abc"_mb };
-        am::property::content_type v2 { "def"_mb };
+        am::property::content_type v1 { "abc" };
+        am::property::content_type v2 { "def" };
         BOOST_TEST(v1 == v1);
         BOOST_TEST(v1 != v2);
         BOOST_TEST(v1 < v2);
     }
     {
-        am::property::response_topic v1 { "abc"_mb };
-        am::property::response_topic v2 { "def"_mb };
+        am::property::response_topic v1 { "abc" };
+        am::property::response_topic v2 { "def" };
         BOOST_TEST(v1 == v1);
         BOOST_TEST(v1 != v2);
         BOOST_TEST(v1 < v2);
     }
     {
-        am::property::correlation_data v1 { "ab\0c"_mb };
-        am::property::correlation_data v2 { "ab\0f"_mb };
+        am::property::correlation_data v1 { std::string{"ab\0c"sv} };
+        am::property::correlation_data v2 { std::string{"ab\0f"sv} };
         BOOST_TEST(v1 == v1);
         BOOST_TEST(v1 != v2);
         BOOST_TEST(v1 < v2);
     }
     {
-        am::property::assigned_client_identifier v1 { "abc"_mb };
-        am::property::assigned_client_identifier v2 { "def"_mb };
+        am::property::assigned_client_identifier v1 { "abc" };
+        am::property::assigned_client_identifier v2 { "def" };
         BOOST_TEST(v1 == v1);
         BOOST_TEST(v1 != v2);
         BOOST_TEST(v1 < v2);
     }
     {
-        am::property::authentication_method v1 { "abc"_mb };
-        am::property::authentication_method v2 { "def"_mb };
+        am::property::authentication_method v1 { "abc" };
+        am::property::authentication_method v2 { "def" };
         BOOST_TEST(v1 == v1);
         BOOST_TEST(v1 != v2);
         BOOST_TEST(v1 < v2);
     }
     {
-        am::property::authentication_data v1 { "abc"_mb };
-        am::property::authentication_data v2 { "def"_mb };
+        am::property::authentication_data v1 { "abc" };
+        am::property::authentication_data v2 { "def" };
         BOOST_TEST(v1 == v1);
         BOOST_TEST(v1 != v2);
         BOOST_TEST(v1 < v2);
     }
     {
-        am::property::response_information v1 { "abc"_mb };
-        am::property::response_information v2 { "def"_mb };
+        am::property::response_information v1 { "abc" };
+        am::property::response_information v2 { "def" };
         BOOST_TEST(v1 == v1);
         BOOST_TEST(v1 != v2);
         BOOST_TEST(v1 < v2);
     }
     {
-        am::property::server_reference v1 { "abc"_mb };
-        am::property::server_reference v2 { "def"_mb };
+        am::property::server_reference v1 { "abc" };
+        am::property::server_reference v2 { "def" };
         BOOST_TEST(v1 == v1);
         BOOST_TEST(v1 != v2);
         BOOST_TEST(v1 < v2);
     }
     {
-        am::property::reason_string v1 { "abc"_mb };
-        am::property::reason_string v2 { "def"_mb };
+        am::property::reason_string v1 { "abc" };
+        am::property::reason_string v2 { "def" };
         BOOST_TEST(v1 == v1);
         BOOST_TEST(v1 != v2);
         BOOST_TEST(v1 < v2);
     }
     {
-        am::property::user_property v1 { "abc"_mb, "def"_mb };
-        am::property::user_property v2 { "abc"_mb, "ghi"_mb };
+        am::property::user_property v1 { "abc", "def" };
+        am::property::user_property v2 { "abc", "ghi" };
         BOOST_TEST(v1 == v1);
         BOOST_TEST(v1 != v2);
         BOOST_TEST(v1 < v2);
     }
 
     {
-        am::property::user_property v1 { "abc"_mb, "def"_mb };
-        am::property::user_property v2 { "abc"_mb, "ghi"_mb };
+        am::property::user_property v1 { "abc", "def" };
+        am::property::user_property v2 { "abc", "ghi" };
 
         am::properties ps1 { v1, v2 };
         am::properties ps2 { v2, v1 };

--- a/test/unit/ut_retained_topic_map.cpp
+++ b/test/unit/ut_retained_topic_map.cpp
@@ -18,7 +18,6 @@
 BOOST_AUTO_TEST_SUITE(ut_retained_map)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 
 BOOST_AUTO_TEST_CASE(general) {
     am::retained_topic_map<std::string> map;

--- a/test/unit/ut_retained_topic_map_broker.cpp
+++ b/test/unit/ut_retained_topic_map_broker.cpp
@@ -14,8 +14,6 @@
 BOOST_AUTO_TEST_SUITE(ut_retained_topic_map_broker)
 
 namespace am = async_mqtt;
-using namespace am::literals;
-using namespace am::literals;
 
 struct retain {
     retain(
@@ -42,8 +40,8 @@ BOOST_AUTO_TEST_CASE( multi_non_wc_crud ) {
     // publish
     {
         retain r {
-            "a/b/c"_mb,
-            "contents1"_mb,
+            "a/b/c",
+            "contents1",
             am::properties {},
             am::qos::at_most_once
         };
@@ -51,8 +49,8 @@ BOOST_AUTO_TEST_CASE( multi_non_wc_crud ) {
     }
     {
         retain r {
-            "a/b"_mb,
-            "contents2"_mb,
+            "a/b",
+            "contents2",
             am::properties {},
             am::qos::at_most_once
         };
@@ -87,7 +85,7 @@ BOOST_AUTO_TEST_CASE( multi_non_wc_crud ) {
 
     // remove (publish with empty contents
     {
-        m.erase("a/b"_mb);
+        m.erase("a/b");
         m.find(
             "a/b",
             [&](retain const&) {
@@ -106,7 +104,7 @@ BOOST_AUTO_TEST_CASE( multi_non_wc_crud ) {
         BOOST_TEST(msgs.empty());
     }
     {
-        m.erase("a/b/c"_mb);
+        m.erase("a/b/c");
         m.find(
             "a/b",
             [&](retain const&) {
@@ -128,8 +126,8 @@ BOOST_AUTO_TEST_CASE( multi_wc_crud ) {
     // publish
     {
         retain r {
-            "a/b/c"_mb,
-            "contents1"_mb,
+            "a/b/c",
+            "contents1",
             am::properties {},
             am::qos::at_most_once
         };
@@ -137,8 +135,8 @@ BOOST_AUTO_TEST_CASE( multi_wc_crud ) {
     }
     {
         retain r {
-            "a/b"_mb,
-            "contents2"_mb,
+            "a/b",
+            "contents2",
             am::properties {},
             am::qos::at_most_once
         };
@@ -187,7 +185,7 @@ BOOST_AUTO_TEST_CASE( multi_wc_crud ) {
 
     // remove (publish with empty contents)
     {
-        m.erase("a/b"_mb);
+        m.erase("a/b");
         {
             std::set<std::string_view> msgs {
                 "contents1",
@@ -214,7 +212,7 @@ BOOST_AUTO_TEST_CASE( multi_wc_crud ) {
         }
     }
     {
-        m.erase("a/b/c"_mb);
+        m.erase("a/b/c");
         m.find(
             "a/+/c",
             [&](retain const&) {

--- a/test/unit/ut_static_assert_fail_client.cpp
+++ b/test/unit/ut_static_assert_fail_client.cpp
@@ -13,7 +13,6 @@
 #include "stub_socket.hpp"
 
 namespace am = async_mqtt;
-using namespace am::literals;
 namespace as = boost::asio;
 
 BOOST_AUTO_TEST_CASE(tc) {

--- a/test/unit/ut_static_assert_fail_server.cpp
+++ b/test/unit/ut_static_assert_fail_server.cpp
@@ -13,7 +13,6 @@
 #include "stub_socket.hpp"
 
 namespace am = async_mqtt;
-using namespace am::literals;
 namespace as = boost::asio;
 
 BOOST_AUTO_TEST_CASE(tc) {
@@ -28,10 +27,10 @@ BOOST_AUTO_TEST_CASE(tc) {
     auto p = am::v3_1_1::connect_packet{
         true,   // clean_session
         0x0, // keep_alive
-        "cid1"_mb,
+        "cid1",
         std::nullopt,
-        "user1"_mb,
-        "pass1"_mb
+        "user1",
+        "pass1"
     };
     // static_assert fail as expected
     auto ec = ep->send(p, as::use_future).get();

--- a/test/unit/ut_strm.cpp
+++ b/test/unit/ut_strm.cpp
@@ -20,7 +20,6 @@
 BOOST_AUTO_TEST_SUITE(ut_strm)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 namespace as = boost::asio;
 
 // packet_id is hard coded in this test case for just testing.

--- a/test/unit/ut_subscription_map.cpp
+++ b/test/unit/ut_subscription_map.cpp
@@ -11,7 +11,6 @@
 BOOST_AUTO_TEST_SUITE(ut_subscription_map)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 
 BOOST_AUTO_TEST_CASE( failed_erase ) {
     using elem_t = int;

--- a/test/unit/ut_subscription_map_broker.cpp
+++ b/test/unit/ut_subscription_map_broker.cpp
@@ -21,8 +21,6 @@
 BOOST_AUTO_TEST_SUITE(ut_subscription_map_broker)
 
 namespace am = async_mqtt;
-using namespace am::literals;
-using namespace am::literals;
 
 namespace mi = boost::multi_index;
 
@@ -233,7 +231,7 @@ BOOST_AUTO_TEST_CASE( multi_non_wc_crud ) {
 
     // new subscribe
     {
-        auto it_success = insert_or_update(con1, "a/b/c"_mb, am::qos::at_most_once, 1);
+        auto it_success = insert_or_update(con1, "a/b/c", am::qos::at_most_once, 1);
         BOOST_TEST(it_success.second);
         auto it = it_success.first; // it is const_iterator due to multi_index
         auto& elem = *it;
@@ -251,7 +249,7 @@ BOOST_AUTO_TEST_CASE( multi_non_wc_crud ) {
         BOOST_CHECK(elem.h);
     }
     {
-        auto it_success = insert_or_update(con2, "a/b/c"_mb, am::qos::at_most_once, 5);
+        auto it_success = insert_or_update(con2, "a/b/c", am::qos::at_most_once, 5);
         BOOST_TEST(it_success.second);
         auto it = it_success.first; // it is const_iterator due to multi_index
         auto& elem = *it;
@@ -300,7 +298,7 @@ BOOST_AUTO_TEST_CASE( multi_non_wc_crud ) {
     // unsubscribe (con1 "a/b/c")
     {
         auto& idx = scos.get<tag_con_topic_filter>();
-        auto it = idx.find(std::make_tuple(con1, "a/b/c"_mb));
+        auto it = idx.find(std::make_tuple(con1, "a/b/c"));
         BOOST_TEST((it != idx.end()));
         m.erase(*it->h, *it);
         idx.erase(it);
@@ -322,7 +320,7 @@ BOOST_AUTO_TEST_CASE( multi_non_wc_crud ) {
 
     // update subscribe (con2 "a/b/c")
     {
-        auto it_success = insert_or_update(con2, "a/b/c"_mb, am::qos::at_least_once, 10);
+        auto it_success = insert_or_update(con2, "a/b/c", am::qos::at_least_once, 10);
         BOOST_TEST(!it_success.second);
 
         std::set<int> entries {
@@ -404,7 +402,7 @@ BOOST_AUTO_TEST_CASE( multi_non_wc_crud_ow ) {
 
     // new subscribe
     {
-        auto it_success = insert_or_update(con1, "a/b/c"_mb, am::qos::at_most_once, 1);
+        auto it_success = insert_or_update(con1, "a/b/c", am::qos::at_most_once, 1);
         BOOST_TEST(it_success.second);
         auto it = it_success.first; // it is const_iterator due to multi_index
         auto& elem = *it;
@@ -422,7 +420,7 @@ BOOST_AUTO_TEST_CASE( multi_non_wc_crud_ow ) {
         BOOST_CHECK(elem.h);
     }
     {
-        auto it_success = insert_or_update(con2, "a/b"_mb, am::qos::at_most_once, 5);
+        auto it_success = insert_or_update(con2, "a/b", am::qos::at_most_once, 5);
         BOOST_TEST(it_success.second);
         auto it = it_success.first; // it is const_iterator due to multi_index
         auto& elem = *it;
@@ -490,7 +488,7 @@ BOOST_AUTO_TEST_CASE( multi_non_wc_crud_ow ) {
     // unsubscribe (con2 "a/b")
     {
         auto& idx = scos.get<tag_con_topic_filter>();
-        auto it = idx.find(std::make_tuple(con2, "a/b"_mb));
+        auto it = idx.find(std::make_tuple(con2, "a/b"));
         BOOST_TEST((it != idx.end()));
         m.erase(*it->h, *it);
         idx.erase(it);
@@ -519,7 +517,7 @@ BOOST_AUTO_TEST_CASE( multi_non_wc_crud_ow ) {
     // unsubscribe (con1 "a/b/c")
     {
         auto& idx = scos.get<tag_con_topic_filter>();
-        auto it = idx.find(std::make_tuple(con1, "a/b/c"_mb));
+        auto it = idx.find(std::make_tuple(con1, "a/b/c"));
         BOOST_TEST((it != idx.end()));
         m.erase(*it->h, *it);
         idx.erase(it);
@@ -576,7 +574,7 @@ BOOST_AUTO_TEST_CASE( multi_wc_crud ) {
 
     // new subscribe
     {
-        auto it_success = insert_or_update(con1, "a/+/c"_mb, am::qos::at_most_once, 1);
+        auto it_success = insert_or_update(con1, "a/+/c", am::qos::at_most_once, 1);
         BOOST_TEST(it_success.second);
         auto it = it_success.first; // it is const_iterator due to multi_index
         auto& elem = *it;
@@ -594,7 +592,7 @@ BOOST_AUTO_TEST_CASE( multi_wc_crud ) {
         BOOST_CHECK(elem.h);
     }
     {
-        auto it_success = insert_or_update(con2, "a/#"_mb, am::qos::at_most_once, 5);
+        auto it_success = insert_or_update(con2, "a/#", am::qos::at_most_once, 5);
         BOOST_TEST(it_success.second);
         auto it = it_success.first; // it is const_iterator due to multi_index
         auto& elem = *it;
@@ -663,7 +661,7 @@ BOOST_AUTO_TEST_CASE( multi_wc_crud ) {
     // unsubscribe (con1 "a/+/c")
     {
         auto& idx = scos.get<tag_con_topic_filter>();
-        auto it = idx.find(std::make_tuple(con1, "a/+/c"_mb));
+        auto it = idx.find(std::make_tuple(con1, "a/+/c"));
         BOOST_TEST((it != idx.end()));
         m.erase(*it->h, *it);
         idx.erase(it);
@@ -684,7 +682,7 @@ BOOST_AUTO_TEST_CASE( multi_wc_crud ) {
 
     // update subscribe (con2 "a/#")
     {
-        auto it_success = insert_or_update(con2, "a/#"_mb, am::qos::at_least_once, 10);
+        auto it_success = insert_or_update(con2, "a/#", am::qos::at_least_once, 10);
         BOOST_TEST(!it_success.second);
 
         std::set<int> entries {

--- a/test/unit/ut_topic_sharename.cpp
+++ b/test/unit/ut_topic_sharename.cpp
@@ -12,18 +12,17 @@
 BOOST_AUTO_TEST_SUITE(ut_topic_sharename)
 
 namespace am = async_mqtt;
-using namespace am::literals;
 
 // success
 BOOST_AUTO_TEST_CASE( parse_success1 ) {
-    am::topic_sharename ts{"$share/share_name/topic_filter"_mb};
+    am::topic_sharename ts{"$share/share_name/topic_filter"};
     BOOST_CHECK(ts);
     BOOST_TEST(ts.sharename() == "share_name");
     BOOST_TEST(ts.topic() == "topic_filter");
 }
 
 BOOST_AUTO_TEST_CASE( parse_success2 ) {
-    am::topic_sharename ts{"topic_filter"_mb};
+    am::topic_sharename ts{"topic_filter"};
     BOOST_CHECK(ts);
     BOOST_TEST(ts.sharename() == "");
     BOOST_TEST(ts.topic() == "topic_filter");
@@ -31,7 +30,7 @@ BOOST_AUTO_TEST_CASE( parse_success2 ) {
 
 
 BOOST_AUTO_TEST_CASE( parse_success3 ) {
-    am::topic_sharename ts{"$share/share_name//"_mb};
+    am::topic_sharename ts{"$share/share_name//"};
     BOOST_CHECK(ts);
     BOOST_TEST(ts.sharename() == "share_name");
     BOOST_TEST(ts.topic() == "/");
@@ -40,18 +39,18 @@ BOOST_AUTO_TEST_CASE( parse_success3 ) {
 // error
 
 BOOST_AUTO_TEST_CASE( parse_error1 ) {
-    am::topic_sharename ts{"$share//topic_filter"_mb};
+    am::topic_sharename ts{"$share//topic_filter"};
     BOOST_CHECK(!ts);
 }
 
 
 BOOST_AUTO_TEST_CASE( parse_error2 ) {
-    am::topic_sharename ts{"$share/share_name"_mb};
+    am::topic_sharename ts{"$share/share_name"};
     BOOST_CHECK(!ts);
 }
 
 BOOST_AUTO_TEST_CASE( parse_error3 ) {
-    am::topic_sharename ts{"$share/share_name/"_mb};
+    am::topic_sharename ts{"$share/share_name/"};
     BOOST_CHECK(!ts);
 }
 

--- a/tool/client_cli.cpp
+++ b/tool/client_cli.cpp
@@ -77,8 +77,8 @@ public:
                     return;
                 }
                 publish(
-                    am::allocate_buffer(topic),
-                    am::allocate_buffer(payload),
+                    topic,
+                    payload,
                     static_cast<am::qos>(qos)
                 );
             },
@@ -94,7 +94,7 @@ public:
                     return;
                 }
                 subscribe(
-                    am::allocate_buffer(topic),
+                    topic,
                     static_cast<am::qos>(qos)
                 );
             },
@@ -106,7 +106,7 @@ public:
             {"topic_filter"},
             [this](std::ostream& /*out*/, std::string topic) {
                 unsubscribe(
-                    am::allocate_buffer(topic)
+                    topic
                 );
             },
             "unsubscribe"
@@ -120,7 +120,7 @@ public:
             "topic",
             {"TopicName"},
             [this](std::ostream& o, std::string topic) {
-                pub_topic_ = am::allocate_buffer(topic);
+                pub_topic_ = topic;
                 print_pub(o);
             }
         );
@@ -128,7 +128,7 @@ public:
             "payload",
             {"Payload"},
             [this](std::ostream& o, std::string payload) {
-                pub_payload_ = am::allocate_buffer(payload);
+                pub_payload_ = payload;
                 print_pub(o);
             }
         );
@@ -244,7 +244,7 @@ public:
             "add_up",
             {"key", "val"},
             [this](std::ostream& o, std::string key, std::string val) {
-                pub_ups_.emplace_back(am::allocate_buffer(key), am::allocate_buffer(val));
+                pub_ups_.emplace_back(key, val);
                 print_pub(o);
             },
             "Subscription Identifier Property"
@@ -259,8 +259,8 @@ public:
         pub_menu->Insert(
             "clear",
             [this](std::ostream& o) {
-                pub_payload_ = am::buffer{};
-                pub_topic_ = am::buffer{};
+                pub_payload_ = std::string{};
+                pub_topic_ = std::string{};
                 pub_qos_ = am::qos::at_most_once;
                 pub_retain_ = am::pub::retain::no;
                 pub_pfi_ = std::nullopt;
@@ -278,8 +278,8 @@ public:
             "send",
             [this](std::ostream& /*out*/) {
                 publish(
-                    am::allocate_buffer(pub_topic_),
-                    am::allocate_buffer(pub_payload_),
+                    pub_topic_,
+                    pub_payload_,
                     pub_qos_ | pub_retain_
                 );
             },
@@ -295,7 +295,7 @@ public:
             "topic",
             {"TopicFilter"},
             [this](std::ostream& o, std::string topic) {
-                sub_topic_ = am::allocate_buffer(topic),
+                sub_topic_ = topic,
                 print_sub(o);
             }
         );
@@ -393,7 +393,7 @@ public:
             "add_up",
             {"key", "val"},
             [this](std::ostream& o, std::string key, std::string val) {
-                sub_ups_.emplace_back(am::allocate_buffer(key), am::allocate_buffer(val));
+                sub_ups_.emplace_back(key, val);
                 print_sub(o);
             },
             "Subscription Identifier Property"
@@ -408,7 +408,7 @@ public:
         sub_menu->Insert(
             "clear",
             [this](std::ostream& o) {
-                sub_topic_ = am::buffer{};
+                sub_topic_ = std::string{};
                 sub_qos_ = am::qos::at_most_once;
                 sub_nl_ = am::sub::nl::no;
                 sub_rap_ = am::sub::rap::dont;
@@ -423,7 +423,7 @@ public:
             "send",
             [this](std::ostream& /*out*/) {
                 subscribe(
-                    am::allocate_buffer(sub_topic_),
+                    sub_topic_,
                     sub_qos_ | sub_nl_ | sub_rap_ | sub_rh_
                 );
             },
@@ -507,8 +507,8 @@ private:
 
     void publish(
         packet_id_t pid,
-        am::buffer topic,
-        am::buffer payload,
+        std::string topic,
+        std::string payload,
         am::pub::opts opts
     ) {
         if (version_ == am::protocol_version::v3_1_1) {
@@ -540,17 +540,17 @@ private:
             }
             if (pub_ct_) {
                 props.push_back(
-                    am::property::content_type{am::allocate_buffer(*pub_ct_)}
+                    am::property::content_type{*pub_ct_}
                 );
             }
             if (pub_rt_) {
                 props.push_back(
-                    am::property::response_topic{am::allocate_buffer(*pub_rt_)}
+                    am::property::response_topic{*pub_rt_}
                 );
             }
             if (pub_cd_) {
                 props.push_back(
-                    am::property::correlation_data{am::allocate_buffer(*pub_cd_)}
+                    am::property::correlation_data{*pub_cd_}
                 );
             }
             if (pub_ta_) {
@@ -579,8 +579,8 @@ private:
     }
 
     void publish(
-        am::buffer topic,
-        am::buffer payload,
+        std::string topic,
+        std::string payload,
         am::pub::opts opts
     ) {
         if (opts.get_qos() == am::qos::at_least_once ||
@@ -620,7 +620,7 @@ private:
     }
 
     void subscribe(
-        am::buffer topic,
+        std::string topic,
         am::sub::opts opts
     ) {
         ep_.acquire_unique_packet_id(
@@ -678,7 +678,7 @@ private:
     }
 
     void unsubscribe(
-        am::buffer topic
+        std::string topic
     ) {
         ep_.acquire_unique_packet_id(
             [
@@ -731,8 +731,8 @@ private:
     std::unique_ptr<cli::Cli> cli_;
     std::unique_ptr<cli::CliLocalTerminalSession> session_;
 
-    am::buffer pub_topic_;
-    am::buffer pub_payload_;
+    std::string pub_topic_;
+    std::string pub_payload_;
     am::qos pub_qos_ = am::qos::at_most_once;
     am::pub::retain pub_retain_ = am::pub::retain::no;
     std::optional<am::payload_format> pub_pfi_;
@@ -743,7 +743,7 @@ private:
     std::optional<std::uint16_t> pub_ta_;
     std::vector<am::property::user_property> pub_ups_;
 
-    am::buffer sub_topic_;
+    std::string sub_topic_;
     am::qos sub_qos_ = am::qos::at_most_once;
     am::sub::nl sub_nl_ = am::sub::nl::no;
     am::sub::rap sub_rap_ = am::sub::rap::dont;
@@ -804,25 +804,25 @@ private:
         reenter (coro_) {
             yield {
                 username_ =
-                    [&] () -> std::optional<am::buffer> {
+                    [&] () -> std::optional<std::string> {
                         if (vm_.count("username")) {
-                            return am::allocate_buffer(vm_["username"].template as<std::string>());
+                            return vm_["username"].template as<std::string>();
                         }
                         return std::nullopt;
                     } ();
                 password_ =
-                    [&] () -> std::optional<am::buffer> {
+                    [&] () -> std::optional<std::string> {
                         if (vm_.count("password")) {
-                            return am::allocate_buffer(vm_["password"].template as<std::string>());
+                            return vm_["password"].template as<std::string>();
                         }
                         return std::nullopt;
                     } ();
                 client_id_ =
-                    [&] () -> am::buffer {
+                    [&] () -> std::string {
                         if (vm_.count("client_id")) {
-                            return am::allocate_buffer(vm_["client_id"].template as<std::string>());
+                            return vm_["client_id"].template as<std::string>();
                         }
-                        return am::buffer();
+                        return std::string();
                     } ();
                 keep_alive_ = vm_["keep_alive"].template as<std::uint16_t>();
                 ws_path_ = vm_["ws_path"].template as<std::string>();
@@ -981,9 +981,7 @@ private:
                                 std::cout << color_recv;
                                 std::cout << p << std::endl;
                                 std::cout << "  payload:";
-                                for (auto const& e : p.payload()) {
-                                    std::cout << am::json_like_out(e);
-                                }
+                                std::cout << am::json_like_out(p.payload());
                                 std::cout << std::endl;
                                 std::cout << color_none;
                             },
@@ -991,9 +989,7 @@ private:
                                 std::cout << color_recv;
                                 std::cout << p << std::endl;
                                 std::cout << "  payload:";
-                                for (auto const& e : p.payload()) {
-                                    std::cout << am::json_like_out(e);
-                                }
+                                std::cout << am::json_like_out(p.payload());
                                 std::cout << std::endl;
                                 std::cout << color_none;
                             },
@@ -1023,9 +1019,9 @@ private:
     as::ip::tcp::resolver& res_;
     po::variables_map& vm_;
     am::protocol_version version_;
-    am::buffer client_id_;
-    std::optional<am::buffer> username_;
-    std::optional<am::buffer> password_;
+    std::string client_id_;
+    std::optional<std::string> username_;
+    std::optional<std::string> password_;
     std::uint16_t keep_alive_ = 0;
     bool clean_start_ = true;
     std::uint32_t sei_ = 0;


### PR DESCRIPTION
client doesn't need to think about the buffer.
All packets' and properties such as topic() payload() can get as std::string.
When you construct packet and properties, you can pass std::string.