### PR TITLE
Implemented #265.

### DIFF
--- a/include/async_mqtt/impl/endpoint_impl.hpp
+++ b/include/async_mqtt/impl/endpoint_impl.hpp
@@ -87,6 +87,12 @@ inline
 void
 basic_endpoint<Role, PacketIdBytes, NextLayer>::set_pingreq_send_interval_ms(std::size_t ms) {
     pingreq_send_interval_ms_ = ms;
+    if (pingreq_send_interval_ms_ == 0) {
+        tim_pingreq_send_->cancel();
+    }
+    else {
+        reset_pingreq_send_timer();
+    }
 }
 
 // private

--- a/include/async_mqtt/impl/endpoint_recv.hpp
+++ b/include/async_mqtt/impl/endpoint_recv.hpp
@@ -204,6 +204,11 @@ recv_op {
                                                 BOOST_ASSERT(p.val() != 0);
                                                 ep.maximum_packet_size_send_ = p.val();
                                             },
+                                            [&](property::server_keep_alive const& p) {
+                                                if constexpr (can_send_as_client(Role)) {
+                                                    ep.set_pingreq_send_interval_ms(p.val() * 1000);
+                                                }
+                                            },
                                             [](auto const&) {
                                             }
                                         }

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -21,6 +21,7 @@ list(APPEND check_PROGRAMS
     ut_code.cpp
     ut_ep_alloc.cpp
     ut_ep_con_discon.cpp
+    ut_ep_keep_alive.cpp
     ut_ep_pid.cpp
     ut_ep_topic_alias.cpp
     ut_ep_recv_filter.cpp

--- a/test/unit/ut_ep_keep_alive.cpp
+++ b/test/unit/ut_ep_keep_alive.cpp
@@ -1,0 +1,122 @@
+// Copyright Takatoshi Kondo 2022
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include "../common/test_main.hpp"
+#include "../common/global_fixture.hpp"
+
+#include <thread>
+
+#include <boost/asio.hpp>
+
+#include <async_mqtt/endpoint.hpp>
+
+#include "stub_socket.hpp"
+#include <async_mqtt/util/packet_variant_operator.hpp>
+
+BOOST_AUTO_TEST_SUITE(ut_ep_keep_alive)
+
+namespace am = async_mqtt;
+namespace as = boost::asio;
+
+BOOST_AUTO_TEST_CASE(server_keep_alive) {
+    auto version = am::protocol_version::v5;
+    as::io_context ioc;
+    auto guard = as::make_work_guard(ioc.get_executor());
+    std::thread th {
+        [&] {
+            ioc.run();
+        }
+    };
+
+    auto ep = am::endpoint<async_mqtt::role::client, async_mqtt::stub_socket>::create(
+        version,
+        // for stub_socket args
+        version,
+        ioc.get_executor()
+    );
+
+    auto connect = am::v5::connect_packet{
+        true,   // clean_start
+        0,      // keep_alive no pingreq sending
+        "cid1",
+        std::nullopt, // will
+        "user1",
+        "pass1",
+        am::properties{}
+    };
+
+    auto connack = am::v5::connack_packet{
+        true,   // session_present
+        am::connect_reason_code::success,
+        am::properties{
+            am::property::server_keep_alive{1}, // override keepalive to 1
+        }
+    };
+
+    auto disconnect = am::v5::disconnect_packet{};
+
+    auto pingreq = am::v5::pingreq_packet();
+
+    ep->next_layer().set_recv_packets(
+        {
+            // receive packets
+            {connack},
+            {am::errc::make_error_code(am::errc::connection_reset)},
+        }
+    );
+
+    // send connect
+    ep->next_layer().set_write_packet_checker(
+        [&](am::packet_variant wp) {
+            BOOST_TEST(connect == wp);
+        }
+    );
+    {
+        auto [ec] = ep->async_send(connect, as::as_tuple(as::use_future)).get();
+        BOOST_TEST(!ec);
+    }
+
+    // recv connack
+    {
+        auto [ec, pv] = ep->async_recv(as::as_tuple(as::use_future)).get();
+        BOOST_TEST(!ec);
+        BOOST_TEST(connack == pv);
+    }
+
+    std::promise<void> pro;
+    auto fut = pro.get_future();
+    // send pingreq packet due to overridden keepalive
+    ep->next_layer().set_write_packet_checker(
+        [&](am::packet_variant wp) {
+            BOOST_TEST(pingreq == wp);
+            pro.set_value();
+        }
+    );
+    fut.get();
+
+    // send disconnect
+    ep->next_layer().set_write_packet_checker(
+        [&](am::packet_variant wp) {
+            BOOST_TEST(disconnect == wp);
+        }
+    );
+    {
+        auto [ec] = ep->async_send(disconnect, as::as_tuple(as::use_future)).get();
+        BOOST_TEST(!ec);
+    }
+
+    // recv close
+    {
+        auto [ec, pv] = ep->async_recv(as::as_tuple(as::use_future)).get();
+        BOOST_TEST(ec == am::errc::connection_reset);
+        BOOST_TEST(!pv);
+    }
+
+    guard.reset();
+    th.join();
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
When the endpoint receives CONNACK packet with server_keep_alive property from the broker, pingreq sending interval is updated.