### PR TITLE
Refined error management.

### DIFF
--- a/include/async_mqtt/endpoint.hpp
+++ b/include/async_mqtt/endpoint.hpp
@@ -263,7 +263,7 @@ public:
      * @brief acuire unique packet_id.
      * @param token
      * - CompletionToken
-     *    - Signature: void(error_code, basic_packet_id_type<PacketIdBytes>)
+     *    - Signature: void(error_code, typename basic_packet_id_type<PacketIdBytes>::type)
      * @return deduced by token
      */
     template <
@@ -272,7 +272,7 @@ public:
 #if !defined(GENERATING_DOCUMENTATION)
     BOOST_ASIO_INITFN_AUTO_RESULT_TYPE(
         CompletionToken,
-        void(error_code, basic_packet_id_type<PacketIdBytes>)
+        void(error_code, typename basic_packet_id_type<PacketIdBytes>::type)
     )
 #endif // !defined(GENERATING_DOCUMENTATION)
     async_acquire_unique_packet_id(
@@ -284,7 +284,7 @@ public:
      * If packet_id is fully acquired, then wait until released.
      * @param token
      * - CompletionToken
-     *    - Signature: void(error_code, basic_packet_id_type<PacketIdBytes>)
+     *    - Signature: void(error_code, typename basic_packet_id_type<PacketIdBytes>::type)
      * @return deduced by token
      */
     template <
@@ -293,7 +293,7 @@ public:
 #if !defined(GENERATING_DOCUMENTATION)
     BOOST_ASIO_INITFN_AUTO_RESULT_TYPE(
         CompletionToken,
-        void(error_code, basic_packet_id_type<PacketIdBytes>)
+        void(error_code, typename basic_packet_id_type<PacketIdBytes>::type)
     )
 #endif // !defined(GENERATING_DOCUMENTATION)
     async_acquire_unique_packet_id_wait_until(

--- a/test/system/st_cancel.cpp
+++ b/test/system/st_cancel.cpp
@@ -67,6 +67,7 @@ BOOST_AUTO_TEST_CASE(cb) {
                                         BOOST_TEST(ec == am::errc::operation_canceled);
                                         BOOST_TEST(!pv);
                                         canceled = true;
+                                        amep->async_close(as::detached);
                                     }
                                 )
                             );


### PR DESCRIPTION
All async function could return error.
async_recv complete with error always started closing process. But it could intentional cancel (operation_aborted). In this case, no longer start closing process. Just report error.

async_send needs to care about packet_id.
Basically, packet_id ownership is moved to the library if async_send() is called. So if error happens, it should be released by async_send() if releasing is needed.

- PUBLISH
  - If packet is stored, packet_id shouldn't be released
  - If packet is not stored but send error happened, the packet_id should be released because the counter part never return acknowlege packet.
- PUBREL
  - packet_id should be owned by async_mqtt until PUBCOMP is received. So it shouldn't be released.
- SUBSCRIBE, UNSUBSCRIBE
  - If send error happened, the packet_id should be released because the counter part never return acknowlege packet.