### PR TITLE
Shifted mqtt_error value mapping.

### DIFF
--- a/include/async_mqtt/error.hpp
+++ b/include/async_mqtt/error.hpp
@@ -87,14 +87,13 @@ using system_error = sys::system_error;
  * @brief general error code
  */
 enum class mqtt_error {
-    partial_error_detected        = 0x01, ///< Some entries have error on suback/unsuback (not an error)
-    all_error_detected            = 0x80, ///< All entries have error on suback/unsuback
-    packet_identifier_fully_used  = 0x81, ///< Packet Identifier fully used
-    packet_identifier_conflict    = 0x82, ///< Packet Identifier conflict
-    packet_not_allowed_to_send    = 0x83, ///< Packet is not allowd to be sent
-    packet_too_large              = 0x84, ///< Packet is too large
-    packet_not_allowed_to_store   = 0x85, ///< Packet is not allowd to be stored
-    packet_not_regulated          = 0x86, ///< Packet is not regulated
+    partial_error_detected                 = 0x0101, ///< Some entries have error on suback/unsuback (not an error)
+    all_error_detected                     = 0x0180, ///< All entries have error on suback/unsuback
+    packet_identifier_fully_used           = 0x0181, ///< Packet Identifier fully used
+    packet_identifier_conflict             = 0x0182, ///< Packet Identifier conflict
+    packet_not_allowed_to_send             = 0x0183, ///< Packet is not allowd to be sent
+    packet_not_allowed_to_store            = 0x0185, ///< Packet is not allowd to be stored
+    packet_not_regulated                   = 0x0186, ///< Packet is not regulated
 };
 
 /**

--- a/include/async_mqtt/impl/error.hpp
+++ b/include/async_mqtt/impl/error.hpp
@@ -25,15 +25,14 @@ namespace async_mqtt {
 constexpr
 char const* mqtt_error_to_string(mqtt_error v) {
     switch (v) {
-    case mqtt_error::partial_error_detected:        return "partial_error_detected";
-    case mqtt_error::all_error_detected:            return "all_error_detected";
-    case mqtt_error::packet_identifier_fully_used:  return "packet_identifier_fully_used";
-    case mqtt_error::packet_identifier_conflict:    return "packet_identifier_conflict";
-    case mqtt_error::packet_not_allowed_to_send:    return "packet_not_allowed_to_send";
-    case mqtt_error::packet_too_large:              return "packet_too_large";
-    case mqtt_error::packet_not_allowed_to_store:   return "packet_not_allowed_to_store";
-    case mqtt_error::packet_not_regulated:          return "packet_not_regulated";
-    default:                                           return "unknown_mqtt_error";
+    case mqtt_error::partial_error_detected:                 return "partial_error_detected";
+    case mqtt_error::all_error_detected:                     return "all_error_detected";
+    case mqtt_error::packet_identifier_fully_used:           return "packet_identifier_fully_used";
+    case mqtt_error::packet_identifier_conflict:             return "packet_identifier_conflict";
+    case mqtt_error::packet_not_allowed_to_send:             return "packet_not_allowed_to_send";
+    case mqtt_error::packet_not_allowed_to_store:            return "packet_not_allowed_to_store";
+    case mqtt_error::packet_not_regulated:                   return "packet_not_regulated";
+    default:                                                 return "unknown_mqtt_error";
     }
 }
 
@@ -324,7 +323,7 @@ public:
     }
 
     bool failed(int v) const noexcept override {
-        return v >= 0x80;
+        return (v & 0x80) != 0;
     }
 };
 


### PR DESCRIPTION
Preserved 0x00-0xff for MQTT v5 reason code, if the codes integrated in the future.