### PR TITLE
Fixed Boost requirement version.

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -2,6 +2,9 @@
 
 = History
 == 8.0.1
+* Fixed required boost version. #322
+** Boost 1.84.0 or later is required.
+*** If you don't build tests, Boost 1.82.0 or later is required.
 * Fixed bench tool infinity acqire packet_id problem on QoS1, 2. #320
 * Added `ASYNC_MQTT_BUILD_LIB` cmake option. #319
 * Restored missing Dockerfile.ubuntu. #318

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,7 @@ else()
     message(STATUS "Print payload disabled")
 endif()
 
-find_package(Boost 1.81.0 REQUIRED COMPONENTS ${ASYNC_MQTT_BOOST_COMPONENTS})
+find_package(Boost 1.82.0 REQUIRED COMPONENTS ${ASYNC_MQTT_BOOST_COMPONENTS})
 
 if(ASYNC_MQTT_USE_TLS)
     find_package(OpenSSL REQUIRED)

--- a/README.md
+++ b/README.md
@@ -60,4 +60,5 @@ See [document](https://redboltz.github.io/async_mqtt/doc/latest/tutorial/client.
 ## Requirement
 
 - Compiler: C++17 or later
-- Boost Libraries:  1.81.0 or later
+- Boost Libraries:  1.84.0 or later
+  - If you don't build tests, 1.82.0 or later

--- a/doc/CHANGELOG.html
+++ b/doc/CHANGELOG.html
@@ -64,8 +64,7 @@ div#navigation table {
 <h1>History</h1>
 <div class="details">
 <span id="author" class="author">== 8.0.1</span><br>
-<span id="revnumber">version 1,</span>
-<span id="revdate">2. #320</span>
+<span id="revdate">* Fixed required boost version. #322</span>
 </div>
 </div>
 <div id="content">
@@ -74,10 +73,27 @@ div#navigation table {
 <div class="ulist">
 <ul>
 <li>
+<p>Boost 1.84.0 or later is required.</p>
+<div class="ulist">
+<ul>
+<li>
+<p>If you don&#8217;t build tests, Boost 1.82.0 or later is required.</p>
+<div class="ulist">
+<ul>
+<li>
+<p>Fixed bench tool infinity acqire packet_id problem on QoS1, 2. #320</p>
+</li>
+<li>
 <p>Added <code>ASYNC_MQTT_BUILD_LIB</code> cmake option. #319</p>
 </li>
 <li>
 <p>Restored missing Dockerfile.ubuntu. #318</p>
+</li>
+</ul>
+</div>
+</li>
+</ul>
+</div>
 </li>
 </ul>
 </div>
@@ -894,7 +910,6 @@ Hence I categolize the fix to breaking changes.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version 1<br>
 </div>
 </div>
 </body>

--- a/doc/requirements.html
+++ b/doc/requirements.html
@@ -73,6 +73,20 @@ div#navigation table {
 </li>
 <li>
 <p><strong>Boost:</strong> async_mqtt only works with Boost, not stand-alone Asio</p>
+<div class="ulist">
+<ul>
+<li>
+<p>Boost 1.84.0 or later</p>
+<div class="ulist">
+<ul>
+<li>
+<p>If you don&#8217;t build test, Boost 1.82.0 or later</p>
+</li>
+</ul>
+</div>
+</li>
+</ul>
+</div>
 </li>
 <li>
 <p><strong>OpenSSL:</strong> If you need TLS connection.</p>

--- a/test/system/CMakeLists.txt
+++ b/test/system/CMakeLists.txt
@@ -53,7 +53,7 @@ if(ASYNC_MQTT_USE_TLS AND ASYNC_MQTT_USE_WS)
     )
 endif()
 
-find_package(Boost 1.81.0 REQUIRED COMPONENTS unit_test_framework)
+find_package(Boost 1.84.0 REQUIRED COMPONENTS unit_test_framework)
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     link_directories(${Boost_LIBRARY_DIRS})
 endif()

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -84,7 +84,7 @@ list(APPEND check_ce_PROGRAMS
     ut_static_assert_fail_server.cpp
 )
 
-find_package(Boost 1.81.0 REQUIRED COMPONENTS unit_test_framework)
+find_package(Boost 1.84.0 REQUIRED COMPONENTS unit_test_framework)
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     link_directories(${Boost_LIBRARY_DIRS})
 endif()

--- a/tool/CMakeLists.txt
+++ b/tool/CMakeLists.txt
@@ -4,7 +4,7 @@ list(APPEND exec_PROGRAMS
     client_cli.cpp
 )
 
-find_package(Boost 1.81.0 REQUIRED COMPONENTS program_options)
+find_package(Boost 1.82.0 REQUIRED COMPONENTS program_options)
 
 # Without this setting added, azure pipelines completely fails to find the boost libraries. No idea why.
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")


### PR DESCRIPTION
For all Boost 1.84.0 or later is required.
If you don't build tests, Boost 1.82.0 or later is required.