### PR TITLE
Fixed invalid Message Expiry Interval.

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -3,6 +3,7 @@
 = History
 
 == 9.1.0
+* Fixed invalid Message Expiry Interval applying. #369
 * Fixed invalid template parameter comparison. #368
 * Added custom logger example. #367
 * Refined documents. #364, #365


### PR DESCRIPTION
Message Expiry Interval is applied the following case. A PUBLISH packet send from the broker and the packet is not for re-sending.

So the Message Expiry target cases are:

1. RETAIN
2. WILL
3. A new PUBLISH message delivering to the client but the corresponding session offline.

But the following case is NOT the Message Expiry target:

4. PUBLISH message delivering to the client has been triggered but the corresponding session  offline during the sequence.

This fix removes 4 from the targets.