### PR TITLE
Fix typo in send_recv.adoc

### DIFF
--- a/doc/modules/ROOT/pages/tutorial/send_recv.adoc
+++ b/doc/modules/ROOT/pages/tutorial/send_recv.adoc
@@ -12,7 +12,7 @@ async_recv()'s CompletionToken parameters are error_code and cpp:async_mqtt::pac
 
 If there is no error, you can access the `pv` using the `visit` function and overloaded lambda expressions. Each lambda expression corresponds to the actual packet type.
 
-`packet_variant` is a variant type of all MQTT packets and `std::monostate`. `std::monostate` is only used if error_conde is not `success`.
+`packet_variant` is a variant type of all MQTT packets and `std::monostate`. `std::monostate` is only used if error_code is not `success`.
 
 NOTE: `async_mqtt` has `basic_foobar` type and `foobar` type if the type contains MQTT's Packet Identifier. `basic_foobar` takes a `PacketIdBytes` parameter. `basic_foobar<2>` is the same as `foobar`. The MQTT spec defines the size of the Packet Identifier as 2. However, some clustering brokers use an expanded Packet Identifier for inter-broker communication. General users don't need to worry about `basic_foobar` types; simply use `foobar`.
 


### PR DESCRIPTION
I'm just was read docs and notice a little typo