### PR TITLE
Fixed #391.

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -3,6 +3,8 @@
 = History
 
 == 10.0.1 (undetermined)
+* Fixed broker websocket connection. #393
+** It doesn't affect the library part.
 * Refined documents. #389, #390
 
 == 10.0.0


### PR DESCRIPTION
For the connection between Boost.Beast websocket server and client, the original code works fine.

However, other client e.g. EMQX connect using Websocket, the broker receives EOF at the first packet receiving.

Boost.Beast has websocket::async_accept(), I used to use it. But it doesn't send the expected (by EMQX like client) HTTP response for HTTP upgrade request.
So this fix receive HTTP packet first, and then check the contents of the request, finally websocket async_accpet **with the request**.