### PR TITLE
Refined websocket handling.

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -10,7 +10,7 @@
 ** The `#` line comment syntax is no longer supported.
 ** For migrating, simply replace `#` with `//`.
 ** *This is a breaking change for the tool (not the library), so the major version remains unchanged.*
-* Fixed broker websocket connection. #393
+* Fixed broker websocket connection. #393, #397
 ** It doesn't affect the library part.
 * Refined documents. #389, #390
 

--- a/include/async_mqtt/asio_bind/predefined_layer/customized_websocket_stream.hpp
+++ b/include/async_mqtt/asio_bind/predefined_layer/customized_websocket_stream.hpp
@@ -9,7 +9,7 @@
 
 #include <boost/asio.hpp>
 #include <boost/beast/websocket/stream.hpp>
-
+#include <boost/beast/http/field.hpp>
 #include <async_mqtt/asio_bind/stream_customize.hpp>
 #include <async_mqtt/util/log.hpp>
 
@@ -36,7 +36,7 @@ struct layer_customize<bs::websocket::stream<NextLayer>> {
         stream.set_option(
             bs::websocket::stream_base::decorator(
                 [](bs::websocket::request_type& req) {
-                    req.set("Sec-WebSocket-Protocol", "mqtt");
+                    req.set(bs::http::field::sec_websocket_protocol, "mqtt");
                 }
             )
         );

--- a/tool/broker.cpp
+++ b/tool/broker.cpp
@@ -23,6 +23,7 @@
 
 #if defined(ASYNC_MQTT_USE_WS)
 #include <async_mqtt/asio_bind/predefined_layer/ws.hpp>
+#include <boost/beast/http/field.hpp>
 namespace bs = boost::beast;
 #endif // defined(ASYNC_MQTT_USE_WS)
 
@@ -356,19 +357,25 @@ void run_broker(boost::program_options::variables_map const& vm) {
                                                 << "HTTP upgrade error:" << ec.message();
                                         }
                                         else if (bs::websocket::is_upgrade(*request)) {
-                                            auto it = request->find("Sec-WebSocket-Protocol");
-                                            if (it != request->end()) {
-                                                ws_layer.set_option(
-                                                    bs::websocket::stream_base::decorator(
-                                                        [
-                                                            name = it->name(),  // enum
-                                                            value = it->value() // string_view
-                                                        ]
-                                                        (bs::websocket::response_type& res) {
-                                                            res.set(name, value);
-                                                        }
-                                                    )
-                                                );
+                                            for (
+                                                auto it = request->find(bs::http::field::sec_websocket_protocol);
+                                                it != request->end();
+                                                ++it
+                                            ) {
+                                                if (it->value() == "mqtt") {
+                                                    ws_layer.set_option(
+                                                        bs::websocket::stream_base::decorator(
+                                                            [
+                                                                name = it->name(),  // enum
+                                                                value = it->value() // string_view
+                                                            ]
+                                                            (bs::websocket::response_type& res) {
+                                                                res.set(name, value);
+                                                            }
+                                                        )
+                                                    );
+                                                    break;
+                                                }
                                             }
                                             ws_layer.async_accept(
                                                 *request,
@@ -601,19 +608,25 @@ void run_broker(boost::program_options::variables_map const& vm) {
                                                             << "HTTP upgrade error:" << ec.message();
                                                     }
                                                     else if (bs::websocket::is_upgrade(*request)) {
-                                                        auto it = request->find("Sec-WebSocket-Protocol");
-                                                        if (it != request->end()) {
-                                                            ws_layer.set_option(
-                                                                bs::websocket::stream_base::decorator(
-                                                                    [
-                                                                        name = it->name(),  // enum
-                                                                        value = it->value() // string_view
-                                                                    ]
-                                                                    (bs::websocket::response_type& res) {
-                                                                        res.set(name, value);
-                                                                    }
-                                                                )
-                                                            );
+                                                        for (
+                                                            auto it = request->find(bs::http::field::sec_websocket_protocol);
+                                                            it != request->end();
+                                                            ++it
+                                                        ) {
+                                                            if (it->value() == "mqtt") {
+                                                                ws_layer.set_option(
+                                                                    bs::websocket::stream_base::decorator(
+                                                                        [
+                                                                            name = it->name(),  // enum
+                                                                            value = it->value() // string_view
+                                                                        ]
+                                                                        (bs::websocket::response_type& res) {
+                                                                            res.set(name, value);
+                                                                        }
+                                                                    )
+                                                                );
+                                                                break;
+                                                            }
                                                         }
                                                         ws_layer.async_accept(
                                                             *request,


### PR DESCRIPTION
Used Boost.Beast predefined enum instead of string literal. Checked all "Sec-WebSocket-Protocol" fields, and if "mqtt" exists, add it to the response, and then move into websocket handshake. Otherwise, directly move into websocket handshake.