### PR TITLE
Adjusted log severity level.

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -3,6 +3,7 @@
 = History
 
 == 10.0.1 (undetermined)
+* Refined log level. #399
 * Refined documentr. Added coding rule to navigation bar.  #396
 * Refined broker. #395, #398
 * Changed the broker auth JSON file comment syntax. #394

--- a/include/async_mqtt/protocol/impl/connection_send.ipp
+++ b/include/async_mqtt/protocol/impl/connection_send.ipp
@@ -604,7 +604,7 @@ process_send_packet(
                 return true;
             }
             else {
-                ASYNC_MQTT_LOG("mqtt_impl", error)
+                ASYNC_MQTT_LOG("mqtt_impl", trace)
                     << "publish message try to send but not connected";
                 con_.on_error(
                     make_error_code(


### PR DESCRIPTION
When a client send DISCONNECT packet or closed(EOF), internal status_ is updated to `connection_state::disconnect`.
Just after this point, send packet could be processed. It sometimes happens. Then output error log (not harmful).
error log is too much, so updated to trace.