### PR TITLE
Fixed disconnect status updating timing.

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -3,8 +3,9 @@
 = History
 
 == 10.0.1 (undetermined)
+* Fixed connection status updating timing. #402
 * Refined CI. #401
-* Refined log level. #399
+* Refined log level. #399, #402
 * Refined documentr. Added coding rule to navigation bar.  #396
 * Refined broker. #395, #398
 * Changed the broker auth JSON file comment syntax. #394

--- a/include/async_mqtt/protocol/connection_status.hpp
+++ b/include/async_mqtt/protocol/connection_status.hpp
@@ -22,4 +22,8 @@ enum class connection_status {
 
 } // namespace async_mqtt
 
+#if !defined(ASYNC_MQTT_SEPARATE_COMPILATION)
+#include <async_mqtt/protocol/impl/connection_status_impl.ipp>
+#endif // !defined(ASYNC_MQTT_SEPARATE_COMPILATION)
+
 #endif // ASYNC_MQTT_PROTOCOL_CONNECTION_STATUS_HPP

--- a/include/async_mqtt/protocol/impl/connection_impl.ipp
+++ b/include/async_mqtt/protocol/impl/connection_impl.ipp
@@ -573,7 +573,6 @@ process_recv_packet() {
         auto ep = force_move(rpb_.get());
         rpb_.clear();
         if (ep.ec) {
-            status_ = connection_status::disconnected;
             cancel_timers();
             con_.on_close();
             con_.on_error(ep.ec);
@@ -1375,12 +1374,10 @@ process_recv_packet() {
                     con_.on_receive(p);
                 },
                 [&](v3_1_1::disconnect_packet& p) {
-                    status_ = connection_status::disconnected;
                     cancel_timers();
                     con_.on_receive(p);
                 },
                 [&](v5::disconnect_packet& p) {
-                    status_ = connection_status::disconnected;
                     cancel_timers();
                     con_.on_receive(p);
                 },

--- a/include/async_mqtt/protocol/impl/connection_send.ipp
+++ b/include/async_mqtt/protocol/impl/connection_send.ipp
@@ -604,7 +604,7 @@ process_send_packet(
                 return true;
             }
             else {
-                ASYNC_MQTT_LOG("mqtt_impl", trace)
+                ASYNC_MQTT_LOG("mqtt_impl", error)
                     << "publish message try to send but not connected";
                 con_.on_error(
                     make_error_code(

--- a/include/async_mqtt/protocol/impl/connection_status_impl.ipp
+++ b/include/async_mqtt/protocol/impl/connection_status_impl.ipp
@@ -1,0 +1,37 @@
+// Copyright Takatoshi Kondo 2025
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(ASYNC_MQTT_PROTOCOL_IMPL_CONNECTION_STATUS_IMPL_IPP)
+#define ASYNC_MQTT_PROTOCOL_IMPL_CONNECTION_STATUS_IMPL_IPP
+
+#include <ostream>
+
+#include <async_mqtt/protocol/connection_status.hpp>
+#include <async_mqtt/util/inline.hpp>
+
+namespace async_mqtt {
+
+ASYNC_MQTT_HEADER_ONLY_INLINE
+constexpr
+char const* connection_status_to_string(connection_status v) {
+    switch (v) {
+    case connection_status::connecting:   return "connecting";
+    case connection_status::connected:    return "connected";
+    case connection_status::disconnected: return "disconnected";
+    default:                              return "unknown_connection_status";
+    }
+}
+
+inline
+std::ostream& operator<<(std::ostream& o, connection_status v)
+{
+    o << connection_status_to_string(v);
+    return o;
+}
+
+} // namespace async_mqtt
+
+#endif // ASYNC_MQTT_PROTOCOL_IMPL_CONNECTION_STATUS_IMPL_IPP

--- a/include/async_mqtt/protocol/impl/timer_impl.ipp
+++ b/include/async_mqtt/protocol/impl/timer_impl.ipp
@@ -7,8 +7,11 @@
 #if !defined(ASYNC_MQTT_PROTOCOL_IMPL_TIMER_IMPL_IPP)
 #define ASYNC_MQTT_PROTOCOL_IMPL_TIMER_IMPL_IPP
 
+#include <ostream>
+
 #include <async_mqtt/protocol/timer.hpp>
 #include <async_mqtt/util/inline.hpp>
+
 namespace async_mqtt {
 
 ASYNC_MQTT_HEADER_ONLY_INLINE

--- a/include/async_mqtt/separate/src_connection.hpp
+++ b/include/async_mqtt/separate/src_connection.hpp
@@ -10,6 +10,7 @@
 #include <async_mqtt/protocol/impl/buffer_to_packet_variant.ipp>
 #include <async_mqtt/protocol/impl/connection_impl.ipp>
 #include <async_mqtt/protocol/impl/connection_send.ipp>
+#include <async_mqtt/protocol/impl/connection_status_impl.ipp>
 #include <async_mqtt/protocol/impl/timer_impl.ipp>
 #include <async_mqtt/protocol/packet/impl/packet_variant.ipp>
 #include <async_mqtt/protocol/packet/impl/property.ipp>

--- a/test/common/test_main.hpp
+++ b/test/common/test_main.hpp
@@ -7,7 +7,7 @@
 #if !defined(ASYNC_MQTT_TEST_MAIN_HPP)
 #define ASYNC_MQTT_TEST_MAIN_HPP
 
-#define BOOST_TEST_MODULE mqtt_client_cpp_test
+#define BOOST_TEST_MODULE async_mqtt_test
 #include <boost/test/unit_test.hpp>
 
 #endif // ASYNC_MQTT_TEST_MAIN_HPP

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -21,6 +21,7 @@ list(APPEND check_PROGRAMS
     ut_buffer.cpp
     ut_code.cpp
     ut_connection.cpp
+    ut_connection_status.cpp
     ut_ep_alloc.cpp
     ut_ep_con_discon.cpp
     ut_ep_keep_alive.cpp

--- a/test/unit/ut_connection_status.cpp
+++ b/test/unit/ut_connection_status.cpp
@@ -1,0 +1,40 @@
+// Copyright Takatoshi Kondo 2025
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include "../common/test_main.hpp"
+#include "../common/global_fixture.hpp"
+
+#include <async_mqtt/protocol/connection_status.hpp>
+
+BOOST_AUTO_TEST_SUITE(ut_connection_status)
+
+namespace am = async_mqtt;
+
+
+BOOST_AUTO_TEST_CASE(status) {
+    {
+        std::stringstream ss;
+        ss << am::connection_status::connected;
+        BOOST_TEST(ss.str() == "connected");
+    }
+    {
+        std::stringstream ss;
+        ss << am::connection_status::connecting;
+        BOOST_TEST(ss.str() == "connecting");
+    }
+    {
+        std::stringstream ss;
+        ss << am::connection_status::disconnected;
+        BOOST_TEST(ss.str() == "disconnected");
+    }
+    {
+        std::stringstream ss;
+        ss << static_cast<am::connection_status>(3);
+        BOOST_TEST(ss.str() == "unknown_connection_status");
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tool/include/broker/session_state.hpp
+++ b/tool/include/broker/session_state.hpp
@@ -183,7 +183,7 @@ struct session_state : std::enable_shared_from_this<session_state<Sp>> {
                 << ASYNC_MQTT_ADD_VALUE(address, this)
                 << "session expiry interval timer set";
 
-            tim_session_expiry_ = std::make_shared<as::steady_timer>(exe_, *session_expiry_interval_);
+            tim_session_expiry_->expires_after(*session_expiry_interval_);
             tim_session_expiry_->async_wait(
                 [
                     this,
@@ -745,7 +745,8 @@ private:
     std::string username_;
 
     std::optional<std::chrono::steady_clock::duration> session_expiry_interval_;
-    std::shared_ptr<as::steady_timer> tim_session_expiry_;
+    std::shared_ptr<as::steady_timer> tim_session_expiry_ =
+        std::make_shared<as::steady_timer>(exe_);
 
     mutable mutex mtx_inflight_messages_;
     inflight_messages inflight_messages_;


### PR DESCRIPTION
When DISCONNECT packet is received or invalid packet is received, status_ shouldn't be updated to disconnected.
If send() is called just after that, sent packet is NOT stored even if store is required.
It sometimes happens in the real use case.

So this fix removed status update to disconnect on recv(). After error is reported, the user call notify_closed(), then status is updated to disconnect.