### PR TITLE
Added broker's Client Certificate subjectAltName.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@
 # Build directory
 build/
 node_modules/
+
+# Tool
+.vscode/

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -3,6 +3,7 @@
 = History
 
 == 10.1.1 (undetermined)
+* Added broker's Client Certificate subjectAltName. #416
 * Fixed invalid remaining length parsing problem on disconnect and auth packet. #415
 * Supported Boost.1.88.0 defaulted process v2. #414
 * Fixed PacketIdBytes treatment in MQTT v5 publish response packets. #412


### PR DESCRIPTION
When set the broker option `--verify_filed subjectAltName`, then subjectAltName the first entry of the DNS is used.